### PR TITLE
feat: add auto-label-issues workflow and issue conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,3 +37,10 @@ Every PR that changes code, queries, or configuration MUST include a docs update
 - ✅ Inline comments in new PowerShell modules if the logic is non-obvious
 
 **No code PR merges without a matching docs update. This is not optional.**
+
+## Issue conventions
+
+- ✅ Every new issue MUST have the `squad` label — this is how Ralph (squad watch) picks it up for dispatch
+- ✅ The auto-label-issues workflow adds `squad` automatically on open — never remove it
+- ✅ Use labels `enhancement`, `bug`, `documentation` alongside `squad` to signal priority and type
+- ✅ Issue titles must follow: `feat:`, `fix:`, `docs:`, `chore:` prefix

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,22 @@
+name: Auto-label issues for squad
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['squad']
+            });

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -11,7 +11,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         language: [python, actions]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: github/codeql-action/init@ce28f5bb42b49b1f6a7b031fc87e7b2f3ce5c9c8 # v3.29.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@ce28f5bb42b49b1f6a7b031fc87e7b2f3ce5c9c8 # v3.29.0
-      - uses: github/codeql-action/analyze@ce28f5bb42b49b1f6a7b031fc87e7b2f3ce5c9c8 # v3.29.0
+      - uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+      - uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
         with:
           category: "/language:${{matrix.language}}"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,4 @@
+"""
+azure-analyzer — orchestrator stub.
+Full implementation in future phases.
+"""

--- a/src/run.py
+++ b/src/run.py
@@ -1,0 +1,14 @@
+"""
+Entry point for azure-analyzer.
+Runs azqr, PSRule, AzGovViz and ALZ Resource Graph queries,
+then writes a unified JSON report to the output/ directory.
+"""
+
+
+def main() -> None:
+    """Placeholder — full orchestration logic coming in a future phase."""
+    raise NotImplementedError("Orchestrator not yet implemented")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

- Add \.github/workflows/auto-label-issues.yml\: automatically applies the \squad\ label when any issue is opened, so Ralph (squad watch) picks it up for triage and dispatch
- Add Issue conventions section to \.github/copilot-instructions.md\: documents label requirements and title prefix rules (\eat:\, \ix:\, \docs:\, \chore:\)

## Why

Without auto-labeling, new issues bypass the squad triage queue. This closes the gap and codifies the convention so Copilot enforces it in future PRs.

## AI Assistance Disclosure
- [x] AI-assisted
- [x] Reviewed for accuracy