### PR TITLE
fix: upgrade codeql-action to v4.35.1, pin checkout to v4 SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         language: [python, actions]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: github/codeql-action/init@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
-      - uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+      - uses: github/codeql-action/autobuild@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
+      - uses: github/codeql-action/analyze@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## What
- Upgrades codeql-action from v3.35.1 SHA to v4.35.1 SHA (\