### PR TITLE
feat: Phase 4 - tool wrappers and orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Added
 - CI failure analysis workflow: auto-creates issues with bug+squad labels when any workflow fails
+- Phase 4: `modules/Invoke-Azqr.ps1` — azqr CLI wrapper (graceful degradation)
+- Phase 4: `modules/Invoke-PSRule.ps1` — PSRule for Azure wrapper
+- Phase 4: `modules/Invoke-AzGovViz.ps1` — AzGovViz wrapper
+- Phase 4: `modules/Invoke-AlzQueries.ps1` — alz-graph-queries ARG wrapper
+- Phase 4: `Invoke-AzureAnalyzer.ps1` — orchestrator, merges all findings to output/results.json
 
 ## [0.0.1] - Initial scaffold
 - Initial scaffold

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -1,0 +1,160 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Azure Analyzer — unified Azure assessment orchestrator.
+.DESCRIPTION
+    Calls all four assessment tool wrappers (azqr, PSRule, AzGovViz, alz-queries),
+    merges results into a unified schema, and writes output/results.json.
+    At least one of -SubscriptionId or -ManagementGroupId is required.
+    Tools that are not installed are skipped gracefully.
+.PARAMETER SubscriptionId
+    Azure subscription ID. Used by azqr, PSRule (live), and alz-queries.
+.PARAMETER ManagementGroupId
+    Management group ID. Used by AzGovViz and alz-queries.
+.PARAMETER OutputPath
+    Output directory for results.json. Defaults to .\output.
+.EXAMPLE
+    .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "00000000-0000-0000-0000-000000000000"
+    .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ManagementGroupId "my-mg"
+#>
+[CmdletBinding()]
+param (
+    [string] $SubscriptionId,
+    [string] $ManagementGroupId,
+    [string] $OutputPath = (Join-Path $PSScriptRoot 'output')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $SubscriptionId -and -not $ManagementGroupId) {
+    throw "At least one of -SubscriptionId or -ManagementGroupId is required."
+}
+
+$modulesPath = Join-Path $PSScriptRoot 'modules'
+
+function Invoke-Wrapper {
+    param ([string]$Script, [hashtable]$Params)
+    $scriptPath = Join-Path $modulesPath $Script
+    if (-not (Test-Path $scriptPath)) {
+        Write-Warning "$Script not found at $scriptPath"
+        return [PSCustomObject]@{ Source = $Script; Findings = @() }
+    }
+    try {
+        return & $scriptPath @Params
+    } catch {
+        Write-Warning "$Script threw an unexpected error: $_"
+        return [PSCustomObject]@{ Source = $Script; Findings = @() }
+    }
+}
+
+function Map-Severity {
+    param ([string]$Input)
+    switch -Regex ($Input.ToLower()) {
+        'high|critical' { return 'High' }
+        'medium|moderate' { return 'Medium' }
+        'low' { return 'Low' }
+        default { return 'Info' }
+    }
+}
+
+Write-Host "=== Azure Analyzer ===" -ForegroundColor Cyan
+
+$allResults = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+# --- azqr ---
+if ($SubscriptionId) {
+    Write-Host "`n[1/4] Running azqr..." -ForegroundColor Yellow
+    $azqrResult = Invoke-Wrapper -Script 'Invoke-Azqr.ps1' -Params @{ SubscriptionId = $SubscriptionId }
+    foreach ($f in $azqrResult.Findings) {
+        $allResults.Add([PSCustomObject]@{
+            Id          = [guid]::NewGuid().ToString()
+            Source      = 'azqr'
+            Category    = $f.Category ?? $f.ServiceCategory ?? 'General'
+            Title       = $f.Recommendation ?? $f.Description ?? ($f | ConvertTo-Json -Compress)
+            Severity    = Map-Severity ($f.Severity ?? $f.Risk ?? 'Info')
+            Compliant   = ($f.Result -eq 'OK') -or ($f.Compliant -eq $true)
+            Detail      = $f.Notes ?? $f.Description ?? ''
+            Remediation = $f.Url ?? ''
+        })
+    }
+    Write-Host "  azqr: $($azqrResult.Findings.Count) findings" -ForegroundColor Gray
+}
+
+# --- PSRule ---
+Write-Host "`n[2/4] Running PSRule..." -ForegroundColor Yellow
+$psruleParams = if ($SubscriptionId) { @{ SubscriptionId = $SubscriptionId } } else { @{ Path = '.' } }
+$psruleResult = Invoke-Wrapper -Script 'Invoke-PSRule.ps1' -Params $psruleParams
+foreach ($f in $psruleResult.Findings) {
+    $allResults.Add([PSCustomObject]@{
+        Id          = [guid]::NewGuid().ToString()
+        Source      = 'psrule'
+        Category    = $f.RuleName ?? 'PSRule'
+        Title       = $f.RuleName ?? 'Unknown rule'
+        Severity    = Map-Severity ($f.Outcome ?? 'Info')
+        Compliant   = $f.Outcome -eq 'Pass'
+        Detail      = $f.Message ?? $f.TargetName ?? ''
+        Remediation = ''
+    })
+}
+Write-Host "  PSRule: $($psruleResult.Findings.Count) findings" -ForegroundColor Gray
+
+# --- AzGovViz ---
+if ($ManagementGroupId) {
+    Write-Host "`n[3/4] Running AzGovViz..." -ForegroundColor Yellow
+    $azgovvizResult = Invoke-Wrapper -Script 'Invoke-AzGovViz.ps1' -Params @{ ManagementGroupId = $ManagementGroupId }
+    foreach ($f in $azgovvizResult.Findings) {
+        $allResults.Add([PSCustomObject]@{
+            Id          = [guid]::NewGuid().ToString()
+            Source      = 'azgovviz'
+            Category    = $f.Category ?? 'Governance'
+            Title       = $f.Title ?? $f.Description ?? ($f | ConvertTo-Json -Compress)
+            Severity    = Map-Severity ($f.Severity ?? 'Info')
+            Compliant   = $f.Compliant ?? $true
+            Detail      = $f.Detail ?? ''
+            Remediation = $f.Remediation ?? ''
+        })
+    }
+    Write-Host "  AzGovViz: $($azgovvizResult.Findings.Count) findings" -ForegroundColor Gray
+} else {
+    Write-Host "`n[3/4] Skipping AzGovViz (no ManagementGroupId provided)" -ForegroundColor DarkGray
+}
+
+# --- ALZ Queries ---
+Write-Host "`n[4/4] Running ALZ queries..." -ForegroundColor Yellow
+$alzParams = if ($ManagementGroupId) {
+    @{ ManagementGroupId = $ManagementGroupId }
+} else {
+    @{ SubscriptionId = $SubscriptionId }
+}
+$alzResult = Invoke-Wrapper -Script 'Invoke-AlzQueries.ps1' -Params $alzParams
+foreach ($f in $alzResult.Findings) {
+    $allResults.Add([PSCustomObject]@{
+        Id          = $f.Id ?? [guid]::NewGuid().ToString()
+        Source      = 'alz-queries'
+        Category    = $f.Category ?? 'ALZ'
+        Title       = $f.Title ?? 'Unknown'
+        Severity    = Map-Severity ($f.Severity ?? 'Medium')
+        Compliant   = $f.Compliant
+        Detail      = $f.Detail ?? ''
+        Remediation = ''
+    })
+}
+Write-Host "  ALZ queries: $($alzResult.Findings.Count) findings" -ForegroundColor Gray
+
+# --- Write output ---
+if (-not (Test-Path $OutputPath)) {
+    $null = New-Item -ItemType Directory -Path $OutputPath -Force
+}
+
+$outputFile = Join-Path $OutputPath 'results.json'
+$allResults | ConvertTo-Json -Depth 5 | Set-Content -Path $outputFile -Encoding UTF8
+
+$high = ($allResults | Where-Object { $_.Severity -eq 'High' -and -not $_.Compliant }).Count
+$medium = ($allResults | Where-Object { $_.Severity -eq 'Medium' -and -not $_.Compliant }).Count
+$low = ($allResults | Where-Object { $_.Severity -eq 'Low' -and -not $_.Compliant }).Count
+
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+Write-Host "  Total findings: $($allResults.Count)"
+Write-Host "  Non-compliant — High: $high  Medium: $medium  Low: $low" -ForegroundColor Yellow
+Write-Host "  Output: $outputFile" -ForegroundColor Green

--- a/modules/Invoke-AlzQueries.ps1
+++ b/modules/Invoke-AlzQueries.ps1
@@ -1,0 +1,102 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Wrapper for alz-graph-queries ARG queries.
+.DESCRIPTION
+    Reads alz_additional_queries.json, runs each queryable item via Search-AzGraph,
+    and returns an array of PSObjects with compliance results.
+    Requires the Az.ResourceGraph module.
+    Never throws — skips items that fail individually, warns on module absence.
+.PARAMETER SubscriptionId
+    Scope queries to a specific subscription.
+.PARAMETER ManagementGroupId
+    Scope queries to a management group.
+.PARAMETER QueriesFile
+    Path to alz_additional_queries.json.
+    Defaults to .\queries\alz_additional_queries.json relative to this script.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Subscription')]
+param (
+    [Parameter(Mandatory, ParameterSetName = 'Subscription')]
+    [ValidateNotNullOrEmpty()]
+    [string] $SubscriptionId,
+
+    [Parameter(Mandatory, ParameterSetName = 'ManagementGroup')]
+    [ValidateNotNullOrEmpty()]
+    [string] $ManagementGroupId,
+
+    [string] $QueriesFile = (Join-Path $PSScriptRoot '..' 'queries' 'alz_additional_queries.json')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Get-Module -Name Az.ResourceGraph -ListAvailable -ErrorAction SilentlyContinue)) {
+    Write-Warning "Az.ResourceGraph module not installed. Skipping ALZ queries. Run: Install-Module Az.ResourceGraph"
+    return [PSCustomObject]@{
+        Source   = 'alz-queries'
+        Findings = @()
+    }
+}
+
+Import-Module Az.ResourceGraph -ErrorAction SilentlyContinue
+
+if (-not (Test-Path $QueriesFile)) {
+    Write-Warning "ALZ queries file not found at: $QueriesFile"
+    Write-Warning "Clone https://github.com/martinopedal/alz-graph-queries and run with -QueriesFile path."
+    return [PSCustomObject]@{
+        Source   = 'alz-queries'
+        Findings = @()
+    }
+}
+
+$data = Get-Content $QueriesFile -Raw | ConvertFrom-Json -ErrorAction Stop
+$queryable = $data.queries | Where-Object { $_.queryable -eq $true -and $_.graph }
+
+if ($queryable.Count -eq 0) {
+    Write-Warning "No queryable items found in $QueriesFile"
+    return [PSCustomObject]@{
+        Source   = 'alz-queries'
+        Findings = @()
+    }
+}
+
+$graphParams = @{}
+if ($PSCmdlet.ParameterSetName -eq 'ManagementGroup') {
+    $graphParams['ManagementGroup'] = $ManagementGroupId
+} else {
+    $graphParams['Subscription'] = $SubscriptionId
+}
+
+$findings = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+foreach ($item in $queryable) {
+    try {
+        $rows = Search-AzGraph -Query $item.graph @graphParams -First 1000 -ErrorAction Stop
+        $compliant = $rows.Count -gt 0
+
+        $findings.Add([PSCustomObject]@{
+            Id       = $item.guid
+            Title    = $item.text
+            Category = $item.category
+            Severity = $item.severity
+            Compliant = $compliant
+            Detail   = if ($rows.Count -gt 0) { "Found $($rows.Count) resource(s)" } else { "No resources found" }
+        })
+    } catch {
+        Write-Warning "ALZ query failed for $($item.guid): $_"
+        $findings.Add([PSCustomObject]@{
+            Id       = $item.guid
+            Title    = $item.text
+            Category = $item.category
+            Severity = $item.severity
+            Compliant = $false
+            Detail   = "Query error: $_"
+        })
+    }
+}
+
+return [PSCustomObject]@{
+    Source   = 'alz-queries'
+    Findings = $findings.ToArray()
+}

--- a/modules/Invoke-AzGovViz.ps1
+++ b/modules/Invoke-AzGovViz.ps1
@@ -1,0 +1,83 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Wrapper for AzGovViz (Azure Governance Visualizer).
+.DESCRIPTION
+    Runs AzGovVizParallel.ps1 for a management group and returns a summary PSObject.
+    If AzGovViz is not installed/found, writes a warning and returns empty result.
+    Never throws.
+.PARAMETER ManagementGroupId
+    Management group ID to analyze.
+.PARAMETER OutputPath
+    Directory for AzGovViz output. Defaults to .\output\azgovviz.
+#>
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $ManagementGroupId,
+
+    [string] $OutputPath = (Join-Path (Get-Location) 'output' 'azgovviz')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Find-AzGovViz {
+    $candidates = @(
+        (Join-Path (Get-Location) 'AzGovVizParallel.ps1'),
+        (Join-Path $env:USERPROFILE 'AzGovViz' 'AzGovVizParallel.ps1'),
+        (Join-Path $env:HOME 'AzGovViz' 'AzGovVizParallel.ps1')
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path $c) { return $c }
+    }
+    return $null
+}
+
+$azGovVizScript = Find-AzGovViz
+
+if (-not $azGovVizScript) {
+    Write-Warning "AzGovViz (AzGovVizParallel.ps1) not found. Skipping. Clone from https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting"
+    return [PSCustomObject]@{
+        Source   = 'azgovviz'
+        Findings = @()
+    }
+}
+
+if (-not (Test-Path $OutputPath)) {
+    $null = New-Item -ItemType Directory -Path $OutputPath -Force
+}
+
+try {
+    Write-Verbose "Running AzGovViz for management group: $ManagementGroupId"
+    pwsh -File $azGovVizScript `
+        -ManagementGroupId $ManagementGroupId `
+        -OutputPath $OutputPath `
+        -AzureDevOpsWikiAsCode $false `
+        -HierarchyTreeOnly $false `
+        -ErrorAction Stop
+
+    $summaryFiles = Get-ChildItem -Path $OutputPath -Filter '*Summary*.json' -Recurse -ErrorAction SilentlyContinue
+
+    $findings = @()
+    foreach ($file in $summaryFiles) {
+        try {
+            $data = Get-Content -Raw $file.FullName | ConvertFrom-Json -ErrorAction Stop
+            $findings += $data
+        } catch {
+            Write-Warning "Could not parse AzGovViz output $($file.Name): $_"
+        }
+    }
+
+    return [PSCustomObject]@{
+        Source   = 'azgovviz'
+        Findings = $findings
+    }
+} catch {
+    Write-Warning "AzGovViz run failed: $_"
+    return [PSCustomObject]@{
+        Source   = 'azgovviz'
+        Findings = @()
+    }
+}

--- a/modules/Invoke-Azqr.ps1
+++ b/modules/Invoke-Azqr.ps1
@@ -1,0 +1,72 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Wrapper for Azure Quick Review (azqr) CLI.
+.DESCRIPTION
+    Scans an Azure subscription with azqr and returns findings as a PSObject.
+    If azqr is not installed, writes a warning and returns an empty result.
+    Never throws — designed for graceful degradation in the orchestrator.
+.PARAMETER SubscriptionId
+    The Azure subscription ID to scan.
+.PARAMETER OutputPath
+    Directory where azqr writes its output. Defaults to .\output\azqr.
+#>
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $SubscriptionId,
+
+    [string] $OutputPath = (Join-Path (Get-Location) 'output' 'azqr')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Test-AzqrInstalled {
+    $null -ne (Get-Command azqr -ErrorAction SilentlyContinue)
+}
+
+if (-not (Test-AzqrInstalled)) {
+    Write-Warning "azqr is not installed. Skipping Azqr scan. Install from https://azure.github.io/azqr"
+    return [PSCustomObject]@{
+        Source   = 'azqr'
+        Findings = @()
+    }
+}
+
+if (-not (Test-Path $OutputPath)) {
+    $null = New-Item -ItemType Directory -Path $OutputPath -Force
+}
+
+try {
+    Write-Verbose "Running azqr scan for subscription $SubscriptionId"
+    $null = azqr scan --subscription-id $SubscriptionId --output-dir $OutputPath 2>&1
+
+    $jsonFiles = Get-ChildItem -Path $OutputPath -Filter '*.json' -ErrorAction SilentlyContinue
+    $findings = @()
+
+    foreach ($file in $jsonFiles) {
+        try {
+            $data = Get-Content -Raw $file.FullName | ConvertFrom-Json -ErrorAction Stop
+            if ($data -is [array]) {
+                $findings += $data
+            } elseif ($null -ne $data) {
+                $findings += $data
+            }
+        } catch {
+            Write-Warning "Could not parse azqr output file $($file.Name): $_"
+        }
+    }
+
+    return [PSCustomObject]@{
+        Source   = 'azqr'
+        Findings = $findings
+    }
+} catch {
+    Write-Warning "azqr scan failed: $_"
+    return [PSCustomObject]@{
+        Source   = 'azqr'
+        Findings = @()
+    }
+}

--- a/modules/Invoke-PSRule.ps1
+++ b/modules/Invoke-PSRule.ps1
@@ -1,0 +1,77 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Wrapper for PSRule for Azure.
+.DESCRIPTION
+    Runs PSRule.Rules.Azure against a subscription or IaC path.
+    Returns PSObject array of rule violations.
+    If PSRule is not installed, writes a warning and returns empty result.
+    Never throws.
+.PARAMETER SubscriptionId
+    Azure subscription ID to evaluate. Used for live Azure resource evaluation.
+.PARAMETER Path
+    Path to IaC files (ARM templates, Bicep) for static analysis.
+    Mutually exclusive with SubscriptionId.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Subscription')]
+param (
+    [Parameter(Mandatory, ParameterSetName = 'Subscription')]
+    [ValidateNotNullOrEmpty()]
+    [string] $SubscriptionId,
+
+    [Parameter(Mandatory, ParameterSetName = 'Path')]
+    [ValidateNotNullOrEmpty()]
+    [string] $Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Test-PSRuleInstalled {
+    $null -ne (Get-Module -Name PSRule -ListAvailable -ErrorAction SilentlyContinue) -and
+    $null -ne (Get-Module -Name PSRule.Rules.Azure -ListAvailable -ErrorAction SilentlyContinue)
+}
+
+if (-not (Test-PSRuleInstalled)) {
+    Write-Warning "PSRule.Rules.Azure is not installed. Skipping PSRule scan. Run: Install-Module PSRule.Rules.Azure"
+    return [PSCustomObject]@{
+        Source   = 'psrule'
+        Findings = @()
+    }
+}
+
+try {
+    $invokeParams = @{
+        Module = 'PSRule.Rules.Azure'
+    }
+
+    if ($PSCmdlet.ParameterSetName -eq 'Path') {
+        Write-Verbose "Running PSRule on path: $Path"
+        $invokeParams['InputPath'] = $Path
+    } else {
+        Write-Verbose "Running PSRule for subscription: $SubscriptionId"
+        $invokeParams['Option'] = @{ 'Configuration.AZURE_SUBSCRIPTION_ID' = $SubscriptionId }
+    }
+
+    $results = Invoke-PSRule @invokeParams -ErrorAction Stop
+
+    $findings = $results | ForEach-Object {
+        [PSCustomObject]@{
+            RuleName  = $_.RuleName
+            Outcome   = $_.Outcome
+            TargetName = $_.TargetName
+            Message   = $_.Detail.Reason -join '; '
+        }
+    }
+
+    return [PSCustomObject]@{
+        Source   = 'psrule'
+        Findings = @($findings)
+    }
+} catch {
+    Write-Warning "PSRule scan failed: $_"
+    return [PSCustomObject]@{
+        Source   = 'psrule'
+        Findings = @()
+    }
+}


### PR DESCRIPTION
## What
Adds all four assessment tool wrappers and the orchestrator:

### New files
- \modules/Invoke-Azqr.ps1\: Azure Quick Review (azqr) wrapper
- \modules/Invoke-PSRule.ps1\: PSRule for Azure wrapper
- \modules/Invoke-AzGovViz.ps1\: AzGovViz wrapper
- \modules/Invoke-AlzQueries.ps1\: ALZ Graph Query wrapper (reads alz_additional_queries.json)
- \Invoke-AzureAnalyzer.ps1\: Orchestrator that calls all 4 wrappers and writes output/results.json

### Design
- All wrappers: reader-only, no write operations
- Graceful degradation: if tool not installed, warn and return empty (never crash)
- No hardcoded credentials or subscription IDs
- Unified output schema: Id, Source, Category, Title, Severity, Compliant, Detail, Remediation

## Docs updated
- CHANGELOG.md: Phase 4 entries

## AI Assistance Disclosure
- [x] AI-assisted
- [x] Reviewed for accuracy