### PR TITLE
fix: remove python from CodeQL matrix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,12 +12,12 @@ Bundle multiple Azure assessment tools into a single, portable runner. Output un
 - Signed commits NOT required (breaks Dependabot and GitHub API commits)
 - 0 required reviewers (solo-maintained)
 - enforce_admins = true, linear history, no force push
-- Required status checks: CodeQL Analyze (actions), CodeQL Analyze (python), Validate Queries
+- ✅ Required status checks: `Analyze (actions)` only (Python removed — repo is PowerShell)
 
 ## CodeQL policy
-- This repo has Python + GitHub Actions workflows — both are scanned
-- Actions scanning covers workflow injection risks
-- Python scanning covers the tool wrappers and orchestrator
+- This repo scans GitHub Actions workflows only — `language: [actions]`
+- PowerShell is NOT scanned by CodeQL (no supported CodeQL extractor for PS)
+- Actions scanning covers workflow injection risks (expression injection, untrusted input)
 
 ## SHA-pinning
 - All GitHub Actions MUST use SHA-pinned versions, not tags

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [python, actions]
+        language: [actions]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: github/codeql-action/init@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+- Remove `python` from CodeQL language matrix; repo is PowerShell-only, no Python extractor needed
+- Update branch protection to require `Analyze (actions)` only
+
 ### Added
 - Phase 6: full README with prerequisites, quick-start, output and permissions tables
 - CI failure analysis workflow: auto-creates issues with bug+squad labels when any workflow fails


### PR DESCRIPTION
## Why
The repo is PowerShell-only. There are no Python source files. The \python\ language entry in the CodeQL matrix caused a warning on every push.

## Changes
- \.github/workflows/codeql.yml\: \language: [python, actions]\ → \[actions]\
- Branch protection: removed \Analyze (python)\ required check (done via API before this PR)
- \.github/copilot-instructions.md\: updated CodeQL policy section
- \CHANGELOG.md\: added fix entry