### PR TITLE
feat: add WARA as 5th assessment source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to azure-analyzer will be documented here.
 - Update branch protection to require `Analyze (actions)` only
 
 ### Added
+- feat: add WARA (Well-Architected Reliability Assessment) as 5th assessment source
 - Phase 6: full README with prerequisites, quick-start, output and permissions tables
 - CI failure analysis workflow: auto-creates issues with bug+squad labels when any workflow fails
 - Phase 4: `modules/Invoke-Azqr.ps1` — azqr CLI wrapper (graceful degradation)

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -3,24 +3,28 @@
 .SYNOPSIS
     Azure Analyzer — unified Azure assessment orchestrator.
 .DESCRIPTION
-    Calls all four assessment tool wrappers (azqr, PSRule, AzGovViz, alz-queries),
+    Calls all five assessment tool wrappers (azqr, PSRule, AzGovViz, alz-queries, WARA),
     merges results into a unified schema, and writes output/results.json.
     At least one of -SubscriptionId or -ManagementGroupId is required.
     Tools that are not installed are skipped gracefully.
 .PARAMETER SubscriptionId
-    Azure subscription ID. Used by azqr, PSRule (live), and alz-queries.
+    Azure subscription ID. Used by azqr, PSRule (live), alz-queries, and WARA.
 .PARAMETER ManagementGroupId
     Management group ID. Used by AzGovViz and alz-queries.
+.PARAMETER TenantId
+    Azure tenant ID. Used by WARA collector. Defaults to current Az context tenant.
 .PARAMETER OutputPath
     Output directory for results.json. Defaults to .\output.
 .EXAMPLE
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "00000000-0000-0000-0000-000000000000"
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ManagementGroupId "my-mg"
+    .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -TenantId "..."
 #>
 [CmdletBinding()]
 param (
     [string] $SubscriptionId,
     [string] $ManagementGroupId,
+    [string] $TenantId,
     [string] $OutputPath = (Join-Path $PSScriptRoot 'output')
 )
 
@@ -64,7 +68,7 @@ $allResults = [System.Collections.Generic.List[PSCustomObject]]::new()
 
 # --- azqr ---
 if ($SubscriptionId) {
-    Write-Host "`n[1/4] Running azqr..." -ForegroundColor Yellow
+    Write-Host "`n[1/5] Running azqr..." -ForegroundColor Yellow
     $azqrResult = Invoke-Wrapper -Script 'Invoke-Azqr.ps1' -Params @{ SubscriptionId = $SubscriptionId }
     foreach ($f in $azqrResult.Findings) {
         $allResults.Add([PSCustomObject]@{
@@ -82,7 +86,7 @@ if ($SubscriptionId) {
 }
 
 # --- PSRule ---
-Write-Host "`n[2/4] Running PSRule..." -ForegroundColor Yellow
+Write-Host "`n[2/5] Running PSRule..." -ForegroundColor Yellow
 $psruleParams = if ($SubscriptionId) { @{ SubscriptionId = $SubscriptionId } } else { @{ Path = '.' } }
 $psruleResult = Invoke-Wrapper -Script 'Invoke-PSRule.ps1' -Params $psruleParams
 foreach ($f in $psruleResult.Findings) {
@@ -101,7 +105,7 @@ Write-Host "  PSRule: $($psruleResult.Findings.Count) findings" -ForegroundColor
 
 # --- AzGovViz ---
 if ($ManagementGroupId) {
-    Write-Host "`n[3/4] Running AzGovViz..." -ForegroundColor Yellow
+    Write-Host "`n[3/5] Running AzGovViz..." -ForegroundColor Yellow
     $azgovvizResult = Invoke-Wrapper -Script 'Invoke-AzGovViz.ps1' -Params @{ ManagementGroupId = $ManagementGroupId }
     foreach ($f in $azgovvizResult.Findings) {
         $allResults.Add([PSCustomObject]@{
@@ -117,11 +121,11 @@ if ($ManagementGroupId) {
     }
     Write-Host "  AzGovViz: $($azgovvizResult.Findings.Count) findings" -ForegroundColor Gray
 } else {
-    Write-Host "`n[3/4] Skipping AzGovViz (no ManagementGroupId provided)" -ForegroundColor DarkGray
+    Write-Host "`n[3/5] Skipping AzGovViz (no ManagementGroupId provided)" -ForegroundColor DarkGray
 }
 
 # --- ALZ Queries ---
-Write-Host "`n[4/4] Running ALZ queries..." -ForegroundColor Yellow
+Write-Host "`n[4/5] Running ALZ queries..." -ForegroundColor Yellow
 $alzParams = if ($ManagementGroupId) {
     @{ ManagementGroupId = $ManagementGroupId }
 } else {
@@ -141,6 +145,29 @@ foreach ($f in $alzResult.Findings) {
     })
 }
 Write-Host "  ALZ queries: $($alzResult.Findings.Count) findings" -ForegroundColor Gray
+
+# --- WARA ---
+if ($SubscriptionId) {
+    Write-Host "`n[5/5] Running WARA..." -ForegroundColor Yellow
+    $waraParams = @{ SubscriptionId = $SubscriptionId; OutputPath = (Join-Path $OutputPath 'wara') }
+    if ($TenantId) { $waraParams['TenantId'] = $TenantId }
+    $waraResult = Invoke-Wrapper -Script 'Invoke-WARA.ps1' -Params $waraParams
+    foreach ($f in $waraResult.Findings) {
+        $allResults.Add([PSCustomObject]@{
+            Id          = $f.Id ?? [guid]::NewGuid().ToString()
+            Source      = 'wara'
+            Category    = $f.Category ?? 'Reliability'
+            Title       = $f.Title ?? 'Unknown'
+            Severity    = Map-Severity ($f.Severity ?? 'Medium')
+            Compliant   = $f.Compliant
+            Detail      = $f.Detail ?? ''
+            Remediation = $f.Remediation ?? ''
+        })
+    }
+    Write-Host "  WARA: $($waraResult.Findings.Count) findings" -ForegroundColor Gray
+} else {
+    Write-Host "`n[5/5] Skipping WARA (no SubscriptionId provided)" -ForegroundColor DarkGray
+}
 
 # --- Write output ---
 if (-not (Test-Path $OutputPath)) {

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -11,6 +11,7 @@ All tools run with the minimum permissions required. No write permissions anywhe
 | PSRule for Azure | Subscription | Reader | Reads ARM/Bicep resources for rule evaluation |
 | AzGovViz | Management Group | Reader + Directory.Read.All | Enumerates hierarchy, policies, RBAC assignments |
 | ALZ Resource Graph queries | Subscription/Tenant | Reader | ARG queries are read-only |
+| WARA (Start-WARACollector) | Subscription | Reader | Reads resources via ARG for reliability assessment |
 
 ## GitHub permissions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # azure-analyzer
 
-Automated Azure assessment that bundles **azqr**, **PSRule for Azure**, **AzGovViz**, and the **ALZ Resource Graph queries** from [alz-graph-queries](https://github.com/martinopedal/alz-graph-queries) into a single orchestrated run with unified Markdown and HTML reports.
+Automated Azure assessment that bundles **azqr**, **PSRule for Azure**, **AzGovViz**, the **ALZ Resource Graph queries** from [alz-graph-queries](https://github.com/martinopedal/alz-graph-queries), and **WARA** into a single orchestrated run with unified Markdown and HTML reports.
 
 ## What it does
 
@@ -10,6 +10,7 @@ Automated Azure assessment that bundles **azqr**, **PSRule for Azure**, **AzGovV
 | 2 — PSRule | `modules/Invoke-PSRule.ps1` | PSRule for Azure — rule-based policy validation |
 | 3 — AzGovViz | `modules/Invoke-AzGovViz.ps1` | Azure Governance Visualizer — tenant/MG/subscription hierarchy |
 | 4 — ALZ queries | `modules/Invoke-AlzQueries.ps1` | 132 custom ARG queries from alz-graph-queries |
+| 5 — WARA | `modules/Invoke-WARA.ps1` | Well-Architected Reliability Assessment — reliability findings per resource |
 | Report | `New-MdReport.ps1` / `New-HtmlReport.ps1` | Unified Markdown + offline HTML report |
 
 All findings are merged into `output/results.json` using a common schema:
@@ -28,7 +29,8 @@ All findings are merged into `output/results.json` using a common schema:
 | azqr | latest | `winget install azure-quick-review.azqr` |
 | PSRule for Azure | latest | `Install-Module PSRule.Rules.Azure` |
 | AzGovViz | latest | [Download](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting) to `tools/AzGovViz/` |
-| Reader | subscription | All four tools need at minimum `Reader` on subscriptions in scope |
+| WARA | latest | `Install-Module WARA` (auto-installed if missing) |
+| Reader | subscription | All five tools need at minimum `Reader` on subscriptions in scope |
 
 ## Quick Start
 

--- a/modules/Invoke-WARA.ps1
+++ b/modules/Invoke-WARA.ps1
@@ -1,0 +1,107 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Wrapper for the Well-Architected Reliability Assessment (WARA) collector.
+.DESCRIPTION
+    Installs/imports the WARA module if needed, runs Start-WARACollector for the
+    given subscription, parses the output JSON, and returns findings as PSObjects.
+    Gracefully degrades if WARA is not available or collector fails.
+.PARAMETER SubscriptionId
+    Azure subscription ID (without /subscriptions/ prefix).
+.PARAMETER TenantId
+    Azure tenant ID. Defaults to current Az context tenant if not specified.
+.PARAMETER OutputPath
+    Directory to write WARA collector JSON. Defaults to .\output\wara.
+.EXAMPLE
+    .\Invoke-WARA.ps1 -SubscriptionId "00000000-0000-0000-0000-000000000000"
+#>
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [string] $SubscriptionId,
+    [string] $TenantId,
+    [string] $OutputPath = (Join-Path $PSScriptRoot '..\output\wara')
+)
+
+Set-StrictMode -Version Latest
+
+# Ensure WARA module is available
+if (-not (Get-Module -ListAvailable -Name WARA)) {
+    try {
+        Write-Warning "WARA module not found. Installing from PSGallery..."
+        Install-Module -Name WARA -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
+    } catch {
+        Write-Warning "Could not install WARA module: $_. Returning empty result."
+        return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+    }
+}
+
+Import-Module WARA -ErrorAction SilentlyContinue
+if (-not (Get-Command Start-WARACollector -ErrorAction SilentlyContinue)) {
+    Write-Warning "WARA module loaded but Start-WARACollector not found. Returning empty result."
+    return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+}
+
+# Resolve tenant
+if (-not $TenantId) {
+    $ctx = Get-AzContext -ErrorAction SilentlyContinue
+    $TenantId = $ctx?.Tenant?.Id
+    if (-not $TenantId) {
+        Write-Warning "No TenantId provided and no Az context found. Returning empty result."
+        return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+    }
+}
+
+# Ensure output dir
+if (-not (Test-Path $OutputPath)) {
+    $null = New-Item -ItemType Directory -Path $OutputPath -Force
+}
+
+# Run collector
+$subArg = "/subscriptions/$SubscriptionId"
+try {
+    Push-Location $OutputPath
+    Start-WARACollector -TenantID $TenantId -SubscriptionIds $subArg -ErrorAction Stop
+    Pop-Location
+} catch {
+    Pop-Location
+    Write-Warning "WARA collector failed: $_. Returning empty result."
+    return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+}
+
+# Find the newest JSON output file
+$jsonFile = Get-ChildItem -Path $OutputPath -Filter "WARA_File_*.json" |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+
+if (-not $jsonFile) {
+    Write-Warning "WARA collector ran but no output JSON found in $OutputPath."
+    return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+}
+
+# Parse findings
+try {
+    $raw = Get-Content $jsonFile.FullName -Raw | ConvertFrom-Json -ErrorAction Stop
+} catch {
+    Write-Warning "Could not parse WARA JSON: $_"
+    return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+}
+
+# Map to flat finding objects — WARA JSON has a 'ImpactedResources' or 'Recommendations' array
+# Handle both known WARA output shapes gracefully
+$findings = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+$recommendations = $raw.Recommendations ?? ($raw.PSObject.Properties.Value | Where-Object { $_ -is [array] } | Select-Object -First 1)
+foreach ($rec in $recommendations) {
+    $findings.Add([PSCustomObject]@{
+        Id          = $rec.GUID ?? [guid]::NewGuid().ToString()
+        Category    = $rec.Category ?? $rec.Service ?? 'Reliability'
+        Title       = $rec.Recommendation ?? $rec.Title ?? 'Unknown'
+        Severity    = $rec.Impact ?? $rec.Severity ?? 'Medium'
+        Compliant   = $false  # WARA only emits non-compliant findings
+        Detail      = $rec.Description ?? $rec.LongDescription ?? ''
+        Remediation = $rec.LearnMoreLink ?? $rec.Link ?? ''
+    })
+}
+
+return [PSCustomObject]@{ Source = 'wara'; Findings = $findings }


### PR DESCRIPTION
## What
Adds [Well-Architected Reliability Assessment](https://github.com/Azure/Well-Architected-Reliability-Assessment) as a 5th tool wrapper in azure-analyzer.

## How it works
- \modules/Invoke-WARA.ps1\ — installs WARA module if missing, runs \Start-WARACollector\, parses JSON output
- Orchestrator calls it as \[5/5]\ when \-SubscriptionId\ is provided
- Findings mapped to unified schema with \Source='wara'\
- Graceful degradation if WARA unavailable

## New parameter
- \-TenantId\ added to orchestrator (used by WARA collector; falls back to current Az context)

## Permissions
Reader on subscription — same as other tools. No write operations.

## Docs updated
- README.md — tool bundle table, prerequisites
- PERMISSIONS.md — WARA row added
- CHANGELOG.md — entry added

## AI Assistance Disclosure
- [x] AI-assisted
- [x] Reviewed for accuracy