### PR TITLE
fix: null safety, compliance logic, and empty-result handling

### DIFF
--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -53,13 +53,22 @@ function Invoke-Wrapper {
 }
 
 function Map-Severity {
-    param ([string]$Input)
-    switch -Regex ($Input.ToLower()) {
-        'high|critical' { return 'High' }
+    param ([string]$Raw)
+    if ([string]::IsNullOrEmpty($Raw)) { return 'Info' }
+    switch -Regex ($Raw.ToLowerInvariant()) {
+        'high|critical'   { return 'High' }
         'medium|moderate' { return 'Medium' }
-        'low' { return 'Low' }
-        default { return 'Info' }
+        'low'             { return 'Low' }
+        default           { return 'Info' }
     }
+}
+
+function Get-Prop {
+    param ($Obj, [string]$Name, $Default = '')
+    if ($null -eq $Obj) { return $Default }
+    $p = $Obj.PSObject.Properties[$Name]
+    if ($null -eq $p -or $null -eq $p.Value) { return $Default }
+    return $p.Value
 }
 
 Write-Host "=== Azure Analyzer ===" -ForegroundColor Cyan
@@ -74,12 +83,12 @@ if ($SubscriptionId) {
         $allResults.Add([PSCustomObject]@{
             Id          = [guid]::NewGuid().ToString()
             Source      = 'azqr'
-            Category    = $f.Category ?? $f.ServiceCategory ?? 'General'
-            Title       = $f.Recommendation ?? $f.Description ?? ($f | ConvertTo-Json -Compress)
-            Severity    = Map-Severity ($f.Severity ?? $f.Risk ?? 'Info')
-            Compliant   = ($f.Result -eq 'OK') -or ($f.Compliant -eq $true)
-            Detail      = $f.Notes ?? $f.Description ?? ''
-            Remediation = $f.Url ?? ''
+            Category    = Get-Prop $f 'Category' (Get-Prop $f 'ServiceCategory' 'General')
+            Title       = Get-Prop $f 'Recommendation' (Get-Prop $f 'Description' ($f | ConvertTo-Json -Compress -ErrorAction SilentlyContinue))
+            Severity    = Map-Severity (Get-Prop $f 'Severity' (Get-Prop $f 'Risk' 'Info'))
+            Compliant   = ((Get-Prop $f 'Result') -eq 'OK') -or ((Get-Prop $f 'Compliant') -eq $true)
+            Detail      = Get-Prop $f 'Notes' (Get-Prop $f 'Description' '')
+            Remediation = Get-Prop $f 'Url' ''
         })
     }
     Write-Host "  azqr: $($azqrResult.Findings.Count) findings" -ForegroundColor Gray
@@ -93,11 +102,11 @@ foreach ($f in $psruleResult.Findings) {
     $allResults.Add([PSCustomObject]@{
         Id          = [guid]::NewGuid().ToString()
         Source      = 'psrule'
-        Category    = $f.RuleName ?? 'PSRule'
-        Title       = $f.RuleName ?? 'Unknown rule'
-        Severity    = Map-Severity ($f.Outcome ?? 'Info')
-        Compliant   = $f.Outcome -eq 'Pass'
-        Detail      = $f.Message ?? $f.TargetName ?? ''
+        Category    = Get-Prop $f 'RuleName' 'PSRule'
+        Title       = Get-Prop $f 'RuleName' 'Unknown rule'
+        Severity    = Map-Severity (Get-Prop $f 'Outcome' 'Info')
+        Compliant   = (Get-Prop $f 'Outcome') -eq 'Pass'
+        Detail      = Get-Prop $f 'Message' (Get-Prop $f 'TargetName' '')
         Remediation = ''
     })
 }
@@ -111,12 +120,12 @@ if ($ManagementGroupId) {
         $allResults.Add([PSCustomObject]@{
             Id          = [guid]::NewGuid().ToString()
             Source      = 'azgovviz'
-            Category    = $f.Category ?? 'Governance'
-            Title       = $f.Title ?? $f.Description ?? ($f | ConvertTo-Json -Compress)
-            Severity    = Map-Severity ($f.Severity ?? 'Info')
-            Compliant   = $f.Compliant ?? $true
-            Detail      = $f.Detail ?? ''
-            Remediation = $f.Remediation ?? ''
+            Category    = Get-Prop $f 'Category' 'Governance'
+            Title       = Get-Prop $f 'Title' (Get-Prop $f 'Description' ($f | ConvertTo-Json -Compress -ErrorAction SilentlyContinue))
+            Severity    = Map-Severity (Get-Prop $f 'Severity' 'Info')
+            Compliant   = if ($null -eq $f.PSObject.Properties['Compliant']) { $true } else { (Get-Prop $f 'Compliant') -ne $false }
+            Detail      = Get-Prop $f 'Detail' ''
+            Remediation = Get-Prop $f 'Remediation' ''
         })
     }
     Write-Host "  AzGovViz: $($azgovvizResult.Findings.Count) findings" -ForegroundColor Gray
@@ -134,13 +143,13 @@ $alzParams = if ($ManagementGroupId) {
 $alzResult = Invoke-Wrapper -Script 'Invoke-AlzQueries.ps1' -Params $alzParams
 foreach ($f in $alzResult.Findings) {
     $allResults.Add([PSCustomObject]@{
-        Id          = $f.Id ?? [guid]::NewGuid().ToString()
+        Id          = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())
         Source      = 'alz-queries'
-        Category    = $f.Category ?? 'ALZ'
-        Title       = $f.Title ?? 'Unknown'
-        Severity    = Map-Severity ($f.Severity ?? 'Medium')
+        Category    = Get-Prop $f 'Category' 'ALZ'
+        Title       = Get-Prop $f 'Title' 'Unknown'
+        Severity    = Map-Severity (Get-Prop $f 'Severity' 'Medium')
         Compliant   = $f.Compliant
-        Detail      = $f.Detail ?? ''
+        Detail      = Get-Prop $f 'Detail' ''
         Remediation = ''
     })
 }
@@ -170,12 +179,16 @@ if ($SubscriptionId) {
 }
 
 # --- Write output ---
-if (-not (Test-Path $OutputPath)) {
-    $null = New-Item -ItemType Directory -Path $OutputPath -Force
+try {
+    if (-not (Test-Path $OutputPath)) {
+        $null = New-Item -ItemType Directory -Path $OutputPath -Force
+    }
+    $outputFile = Join-Path $OutputPath 'results.json'
+    $allResults | ConvertTo-Json -Depth 5 | Set-Content -Path $outputFile -Encoding UTF8
+} catch {
+    Write-Error "Failed to write output to ${OutputPath}: $_"
+    return
 }
-
-$outputFile = Join-Path $OutputPath 'results.json'
-$allResults | ConvertTo-Json -Depth 5 | Set-Content -Path $outputFile -Encoding UTF8
 
 $high = ($allResults | Where-Object { $_.Severity -eq 'High' -and -not $_.Compliant }).Count
 $medium = ($allResults | Where-Object { $_.Severity -eq 'Medium' -and -not $_.Compliant }).Count

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -23,7 +23,7 @@ if (-not (Test-Path $InputPath)) {
     throw "Results file not found: $InputPath. Run Invoke-AzureAnalyzer.ps1 first."
 }
 
-$findings = Get-Content $InputPath -Raw | ConvertFrom-Json -ErrorAction Stop
+$findings = @(Get-Content $InputPath -Raw | ConvertFrom-Json -ErrorAction Stop)
 
 $date = Get-Date -Format 'yyyy-MM-dd HH:mm UTC'
 $total = $findings.Count
@@ -166,10 +166,14 @@ function sortTable(th) {
 </html>
 "@
 
-$outputDir = Split-Path $OutputPath -Parent
-if (-not (Test-Path $outputDir)) {
-    $null = New-Item -ItemType Directory -Path $outputDir -Force
+try {
+    $outputDir = Split-Path $OutputPath -Parent
+    if (-not (Test-Path $outputDir)) {
+        $null = New-Item -ItemType Directory -Path $outputDir -Force
+    }
+    $html | Set-Content -Path $OutputPath -Encoding UTF8
+} catch {
+    Write-Error "Failed to write HTML report to ${OutputPath}: $_"
+    return
 }
-
-$html | Set-Content -Path $OutputPath -Encoding UTF8
 Write-Host "HTML report written to: $OutputPath" -ForegroundColor Green

--- a/New-MdReport.ps1
+++ b/New-MdReport.ps1
@@ -24,7 +24,7 @@ if (-not (Test-Path $InputPath)) {
     throw "Results file not found: $InputPath. Run Invoke-AzureAnalyzer.ps1 first."
 }
 
-$findings = Get-Content $InputPath -Raw | ConvertFrom-Json -ErrorAction Stop
+$findings = @(Get-Content $InputPath -Raw | ConvertFrom-Json -ErrorAction Stop)
 
 $date = Get-Date -Format 'yyyy-MM-dd HH:mm UTC'
 $total = $findings.Count
@@ -133,10 +133,14 @@ if ($track.Count -eq 0) {
 }
 $lines.Add('')
 
-$outputDir = Split-Path $OutputPath -Parent
-if (-not (Test-Path $outputDir)) {
-    $null = New-Item -ItemType Directory -Path $outputDir -Force
+try {
+    $outputDir = Split-Path $OutputPath -Parent
+    if (-not (Test-Path $outputDir)) {
+        $null = New-Item -ItemType Directory -Path $outputDir -Force
+    }
+    $lines -join "`n" | Set-Content -Path $OutputPath -Encoding UTF8 -NoNewline
+} catch {
+    Write-Error "Failed to write Markdown report to ${OutputPath}: $_"
+    return
 }
-
-$lines -join "`n" | Set-Content -Path $OutputPath -Encoding UTF8 -NoNewline
 Write-Host "Markdown report written to: $OutputPath" -ForegroundColor Green

--- a/modules/Invoke-AlzQueries.ps1
+++ b/modules/Invoke-AlzQueries.ps1
@@ -73,7 +73,17 @@ $findings = [System.Collections.Generic.List[PSCustomObject]]::new()
 foreach ($item in $queryable) {
     try {
         $rows = Search-AzGraph -Query $item.graph @graphParams -First 1000 -ErrorAction Stop
-        $compliant = $rows.Count -gt 0
+        # Queries return a 'compliant' boolean column.
+        # No rows means no resources in scope — treat as compliant.
+        if ($rows.Count -eq 0) {
+            $compliant = $true
+        } else {
+            $nonCompliantRows = @($rows | Where-Object {
+                $p = $_.PSObject.Properties['compliant']
+                $p -and ($p.Value -eq $false -or $p.Value -eq 0)
+            })
+            $compliant = $nonCompliantRows.Count -eq 0
+        }
 
         $findings.Add([PSCustomObject]@{
             Id       = $item.guid
@@ -81,7 +91,11 @@ foreach ($item in $queryable) {
             Category = $item.category
             Severity = $item.severity
             Compliant = $compliant
-            Detail   = if ($rows.Count -gt 0) { "Found $($rows.Count) resource(s)" } else { "No resources found" }
+            Detail   = if ($compliant) {
+                           if ($rows.Count -eq 0) { 'No resources in scope' } else { "All $($rows.Count) resource(s) compliant" }
+                       } else {
+                           "$($nonCompliantRows.Count) of $($rows.Count) resource(s) non-compliant"
+                       }
         })
     } catch {
         Write-Warning "ALZ query failed for $($item.guid): $_"


### PR DESCRIPTION
## What
Fixes three blocking runtime issues found in a code review.

### 1. StrictMode null safety
\Map-Severity\ crashed on null input. All property accesses via \??\ threw PropertyNotFoundException before the fallback was evaluated. Replaced with a \Get-Prop\ helper and a null guard on \Map-Severity\.

### 2. ALZ compliance logic
Compliance was set from \ows.Count -gt 0\ — incorrect. Queries return a \compliant\ boolean column (integer 0/1 confirmed in \queries/alz_additional_queries.json\). Fixed to read that column and count non-compliant rows. Zero rows = no resources in scope = compliant.

### 3. Empty results.json
\ConvertFrom-Json\ on \[]\ returns null; \@()\ wrapping ensures the reports don't crash when all tools return zero findings.

### 4. File write error handling
Directory creation and file writes wrapped in try/catch for clear error messages instead of hard termination.