### PR TITLE
docs: append GitHub-first principle and v6 actions policy to copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,3 +44,9 @@ Every PR that changes code, queries, or configuration MUST include a docs update
 - ✅ The auto-label-issues workflow adds `squad` automatically on open — never remove it
 - ✅ Use labels `enhancement`, `bug`, `documentation` alongside `squad` to signal priority and type
 - ✅ Issue titles must follow: `feat:`, `fix:`, `docs:`, `chore:` prefix
+
+## Actions version policy
+- Use actions/checkout@v6 and actions/setup-python@v6 (Node.js 24 compatible)
+
+## GitHub-first principle
+Validate changes in GitHub Actions, not locally. Push, trigger workflow, check logs, iterate.


### PR DESCRIPTION
Adds missing sections to .github/copilot-instructions.md:
- Actions version policy (v6 for Node.js 24 compatibility)
- GitHub-first principle

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>