### PR TITLE
feat(hybrid): on-premises/hybrid network ARG queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Added
+- feat(hybrid): `queries/hybrid_network_queries.json` -- 6 ARG queries for on-premises/hybrid network health (HN-001 through HN-006): ExpressRoute circuit state and SKU, VPN gateway active-active and SKU, VPN connection BGP and status
+- feat(hybrid): `Invoke-AlzQueries.ps1` now auto-discovers all `*.json` files in `queries/` -- add any file to extend checks without code changes
+- feat(hybrid): `Invoke-AlzQueries.ps1` supports both `query` (azure-analyzer format) and `graph` (alz-graph-queries format) KQL field names
+
+
 ### Fixed
 - Remove `python` from CodeQL language matrix; repo is PowerShell-only, no Python extractor needed
 - Update branch protection to require `Analyze (actions)` only

--- a/README.md
+++ b/README.md
@@ -76,6 +76,45 @@ After a run, `output/` contains:
 - **Track** — Low + Info severity
 - Per-category breakdown with finding counts
 
+
+## Hybrid Network Queries
+
+`queries/hybrid_network_queries.json` contains 6 ARG queries for on-premises/hybrid connectivity health assessment:
+
+| ID | Check | Severity |
+|---|---|---|
+| HN-001 | ExpressRoute circuit provisioning state (Enabled + Provisioned) | High |
+| HN-002 | ExpressRoute circuit SKU (not Basic) | Medium |
+| HN-003 | VPN gateway active-active configuration | Medium |
+| HN-004 | VPN gateway SKU (not Basic) | Medium |
+| HN-005 | VPN connection BGP enablement | Low |
+| HN-006 | VPN connection status (Connected) | High |
+
+**Empty-result semantics**: if no hybrid resources exist in scope (e.g., no VPN gateways), the query returns zero rows and is treated as not applicable -- not non-compliant.
+
+### Extending with custom queries
+
+All `*.json` files in the `queries/` directory are auto-loaded by `Invoke-AlzQueries.ps1`. Add your own file using the azure-analyzer schema:
+
+```json
+{
+  "metadata": { "version": "1.0", "description": "My custom queries" },
+  "queries": [
+    {
+      "guid": "MY-001",
+      "category": "Security",
+      "subcategory": "...",
+      "severity": "High",
+      "text": "Human readable check description",
+      "query": "resources | where ... | extend compliant = (...) | project id, name, resourceGroup, compliant",
+      "not_queryable_reason": null
+    }
+  ]
+}
+```
+
+Every query **must** return a `compliant` boolean column. The `query` field (azure-analyzer format) and `graph` field (alz-graph-queries format) are both supported.
+
 ## Required Azure permissions
 
 | Scope | Role |

--- a/modules/Invoke-AlzQueries.ps1
+++ b/modules/Invoke-AlzQueries.ps1
@@ -1,10 +1,12 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-    Wrapper for alz-graph-queries ARG queries.
+    Wrapper for alz-graph-queries ARG queries and local azure-analyzer queries.
 .DESCRIPTION
     Reads alz_additional_queries.json, runs each queryable item via Search-AzGraph,
     and returns an array of PSObjects with compliance results.
+    Also auto-discovers and runs all *.json files in the queries/ directory
+    (supporting the azure-analyzer query schema with a 'query' field).
     Requires the Az.ResourceGraph module.
     Never throws — skips items that fail individually, warns on module absence.
 .PARAMETER SubscriptionId
@@ -51,7 +53,25 @@ if (-not (Test-Path $QueriesFile)) {
 }
 
 $data = Get-Content $QueriesFile -Raw | ConvertFrom-Json -ErrorAction Stop
-$queryable = $data.queries | Where-Object { $_.queryable -eq $true -and $_.graph }
+$queryable = @($data.queries | Where-Object { $_.queryable -eq $true -and $_.graph })
+
+# Also read local azure-analyzer queries from queries/ directory.
+# These use the 'query' field (not 'graph') and wrap items in { "queries": [...] }.
+# Empty results for a query mean no resources in scope -- not non-compliant.
+$localQueriesDir = Join-Path $PSScriptRoot '..' 'queries'
+if (Test-Path $localQueriesDir) {
+    $localQueryFiles = Get-ChildItem -Path $localQueriesDir -Filter '*.json' -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne 'alz_additional_queries.json' }
+    foreach ($qf in $localQueryFiles) {
+        try {
+            $localData = Get-Content $qf.FullName -Raw | ConvertFrom-Json -ErrorAction Stop
+            $localItems = if ($localData.PSObject.Properties['queries']) { $localData.queries } else { $localData }
+            $queryable += @($localItems | Where-Object { $_.PSObject.Properties['query'] -and $_.query -and -not $_.not_queryable_reason })
+        } catch {
+            Write-Warning "Failed to parse $($qf.Name): $_"
+        }
+    }
+}
 
 if ($queryable.Count -eq 0) {
     Write-Warning "No queryable items found in $QueriesFile"
@@ -72,7 +92,13 @@ $findings = [System.Collections.Generic.List[PSCustomObject]]::new()
 
 foreach ($item in $queryable) {
     try {
-        $rows = Search-AzGraph -Query $item.graph @graphParams -First 1000 -ErrorAction Stop
+        # Support both 'graph' (alz-graph-queries format) and 'query' (azure-analyzer format)
+        $kql = if ($item.PSObject.Properties['graph'] -and $item.graph) { $item.graph }
+               elseif ($item.PSObject.Properties['query'] -and $item.query) { $item.query }
+               else { $null }
+        if (-not $kql) { continue }
+
+        $rows = Search-AzGraph -Query $kql @graphParams -First 1000 -ErrorAction Stop
         # Queries return a 'compliant' boolean column.
         # No rows means no resources in scope — treat as compliant.
         if ($rows.Count -eq 0) {

--- a/queries/hybrid_network_queries.json
+++ b/queries/hybrid_network_queries.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "version": "1.0",
+    "description": "Hybrid connectivity ARG queries for azure-analyzer"
+  },
+  "queries": [
+    {
+      "guid": "HN-001",
+      "category": "Network",
+      "subcategory": "Hybrid Connectivity",
+      "severity": "High",
+      "text": "ExpressRoute circuits should be in a healthy provisioning state",
+      "query": "resources | where type =~ 'microsoft.network/expressroutecircuits' | extend compliant = (properties.circuitProvisioningState =~ 'Enabled' and properties.serviceProviderProvisioningState =~ 'Provisioned') | project id, name, resourceGroup, location, compliant, sku = properties.sku.tier, state = properties.circuitProvisioningState",
+      "not_queryable_reason": null
+    },
+    {
+      "guid": "HN-002",
+      "category": "Network",
+      "subcategory": "Hybrid Connectivity",
+      "severity": "Medium",
+      "text": "ExpressRoute circuits should use Standard or Premium SKU, not Basic",
+      "query": "resources | where type =~ 'microsoft.network/expressroutecircuits' | extend compliant = (properties.sku.tier !~ 'Basic') | project id, name, resourceGroup, compliant, tier = properties.sku.tier",
+      "not_queryable_reason": null
+    },
+    {
+      "guid": "HN-003",
+      "category": "Network",
+      "subcategory": "Hybrid Connectivity",
+      "severity": "Medium",
+      "text": "VPN gateways should be configured in active-active mode for high availability",
+      "query": "resources | where type =~ 'microsoft.network/virtualnetworkgateways' and properties.gatewayType =~ 'Vpn' | extend compliant = (properties.activeActive == true) | project id, name, resourceGroup, location, compliant, sku = properties.sku.name",
+      "not_queryable_reason": null
+    },
+    {
+      "guid": "HN-004",
+      "category": "Network",
+      "subcategory": "Hybrid Connectivity",
+      "severity": "Medium",
+      "text": "VPN gateways should not use the Basic SKU",
+      "query": "resources | where type =~ 'microsoft.network/virtualnetworkgateways' and properties.gatewayType =~ 'Vpn' | extend compliant = (properties.sku.name !~ 'Basic') | project id, name, resourceGroup, compliant, sku = properties.sku.name",
+      "not_queryable_reason": null
+    },
+    {
+      "guid": "HN-005",
+      "category": "Network",
+      "subcategory": "Hybrid Connectivity",
+      "severity": "Low",
+      "text": "VPN connections should have BGP enabled for dynamic routing",
+      "query": "resources | where type =~ 'microsoft.network/connections' and properties.connectionType =~ 'IPsec' | extend compliant = (properties.enableBgp == true) | project id, name, resourceGroup, compliant, connectionType = properties.connectionType",
+      "not_queryable_reason": null
+    },
+    {
+      "guid": "HN-006",
+      "category": "Network",
+      "subcategory": "Hybrid Connectivity",
+      "severity": "High",
+      "text": "VPN connections should be in the Connected state",
+      "query": "resources | where type =~ 'microsoft.network/connections' | extend compliant = (properties.connectionStatus =~ 'Connected') | project id, name, resourceGroup, compliant, connectionStatus = properties.connectionStatus",
+      "not_queryable_reason": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds ARG queries for on-premises/hybrid network resource health assessment.

### Queries added (queries/hybrid_network_queries.json)
- HN-001: ExpressRoute circuit provisioning state health
- HN-002: ExpressRoute circuit SKU (not Basic)
- HN-003: VPN gateway active-active configuration
- HN-004: VPN gateway SKU (not Basic)
- HN-005: VPN connection BGP enablement
- HN-006: VPN connection status (Connected)

### Module changes (modules/Invoke-AlzQueries.ps1)
- Now reads ALL *.json files from queries/ (auto-discovery)
- Supports both query (azure-analyzer format) and graph (alz-graph-queries format) KQL field

### Empty-result semantics
Resources absent = not applicable. Documented inline.

Closes #5

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>