### PR TITLE
fix: add missing DevOps params and conditional guard to orchestrator

### DIFF
--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -226,27 +226,31 @@ if ($TenantId) {
 }
 
 # --- DevOps API ---
-Write-Host "`n[8/8] Running DevOps API checks..." -ForegroundColor Yellow
-$devopsParams = @{}
-if ($GitHubRepo)  { $devopsParams['GitHubRepo']  = $GitHubRepo }
-if ($GitHubToken) { $devopsParams['GitHubToken'] = $GitHubToken }
-if ($AdoOrg)      { $devopsParams['AdoOrg']      = $AdoOrg }
-if ($AdoProject)  { $devopsParams['AdoProject']  = $AdoProject }
-if ($AdoToken)    { $devopsParams['AdoToken']     = $AdoToken }
-$devopsResult = Invoke-Wrapper -Script 'Invoke-DevOpsApi.ps1' -Params $devopsParams
-foreach ($f in $devopsResult.Findings) {
-    $allResults.Add([PSCustomObject]@{
-        Id          = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())
-        Source      = 'devops-api'
-        Category    = Get-Prop $f 'Category' 'DevOps'
-        Title       = Get-Prop $f 'Title' 'Unknown'
-        Severity    = Map-Severity (Get-Prop $f 'Severity' 'Medium')
-        Compliant   = $f.Compliant
-        Detail      = Get-Prop $f 'Detail' ''
-        Remediation = Get-Prop $f 'Remediation' ''
-    })
+if ($GitHubRepo -or $AdoOrg) {
+    Write-Host "`n[8/8] Running DevOps API checks..." -ForegroundColor Yellow
+    $devopsParams = @{}
+    if ($GitHubRepo)  { $devopsParams['GitHubRepo']  = $GitHubRepo }
+    if ($GitHubToken) { $devopsParams['GitHubToken'] = $GitHubToken }
+    if ($AdoOrg)      { $devopsParams['AdoOrg']      = $AdoOrg }
+    if ($AdoProject)  { $devopsParams['AdoProject']  = $AdoProject }
+    if ($AdoToken)    { $devopsParams['AdoToken']     = $AdoToken }
+    $devopsResult = Invoke-Wrapper -Script 'Invoke-DevOpsApi.ps1' -Params $devopsParams
+    foreach ($f in $devopsResult.Findings) {
+        $allResults.Add([PSCustomObject]@{
+            Id          = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())
+            Source      = 'devops-api'
+            Category    = Get-Prop $f 'Category' 'DevOps'
+            Title       = Get-Prop $f 'Title' 'Unknown'
+            Severity    = Map-Severity (Get-Prop $f 'Severity' 'Medium')
+            Compliant   = $f.Compliant
+            Detail      = Get-Prop $f 'Detail' ''
+            Remediation = Get-Prop $f 'Remediation' ''
+        })
+    }
+    Write-Host "  DevOps: $($devopsResult.Findings.Count) findings" -ForegroundColor Gray
+} else {
+    Write-Host "`n[8/8] Skipping DevOps API checks (no GitHubRepo or AdoOrg provided)" -ForegroundColor DarkGray
 }
-Write-Host "  DevOps: $($devopsResult.Findings.Count) findings" -ForegroundColor Gray
 # --- Write output ---
 try {
     if (-not (Test-Path $OutputPath)) {


### PR DESCRIPTION
Fixes a runtime crash under Set-StrictMode -Version Latest -- \$GitHubRepo, \$GitHubToken, \$AdoOrg, \$AdoProject, \$AdoToken were referenced but not declared in param(), causing the entire script to abort at step 8/8 and lose all prior results.

Also:
- Adds conditional guard around DevOps step (consistent with all other optional steps)
- Fixes step counter labels [1/5]-[4/5] -> [1/8]-[4/8]