### PR TITLE
Squad: auto-dispatch Copilot for all squad:member labels

### DIFF
--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -115,10 +115,10 @@ jobs:
 
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
-        if: github.event.label.name == 'squad:copilot'
+        if: startsWith(github.event.label.name, 'squad:')
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          github-token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
Updates squad-issue-assign.yml:
- Broadens trigger from only `squad:copilot` to any `squad:*` label
- Updates token secret name to `COPILOT_GITHUB_TOKEN`