### PR TITLE
fix: normalize spaces to dashes in squad member name matching

### DIFF
--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -58,7 +58,8 @@ jobs:
                 }
                 if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
                   const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && cells[0].toLowerCase() === memberName) {
+                  const cellName = cells[0].toLowerCase().replace(/\s+/g, '-');
+                  if (cells.length >= 2 && cellName === memberName) {
                     assignedMember = { name: cells[0], role: cells[1] };
                     break;
                   }


### PR DESCRIPTION
Ensures names like 'Pipeline Dev' in team.md match 'squad:pipeline-dev' label by normalizing spaces to dashes in the comparison.