### PR TITLE
fix: restore THIRD_PARTY_NOTICES.md and attribution section

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,74 @@
+name: Docs Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  docs-required:
+    name: Documentation update check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check for documentation updates
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            // Check for skip-docs-check label
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (labels.includes('skip-docs-check')) {
+              core.info('Skipping docs check — skip-docs-check label found.');
+              return;
+            }
+
+            // Get changed files in the PR
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner: context.repo.owner, repo: context.repo.repo, pull_number: context.issue.number }
+            );
+            const changed = files.map(f => f.filename);
+
+            // Patterns that are never considered "code changes"
+            const ignoredPatterns = [
+              /^\.squad\//,
+              /^\.github\/workflows\//,
+              /^\.github\/ISSUE_TEMPLATE\//,
+              /^\.github\/PULL_REQUEST_TEMPLATE/,
+              /^\.github\/copilot-instructions\.md$/,
+              /^\.github\/dependabot\.yml$/,
+              /^LICENSE$/,
+              /^\.gitignore$/,
+            ];
+
+            const isIgnored = (f) => ignoredPatterns.some(p => p.test(f));
+            const isDoc = (f) => ['README.md', 'CHANGELOG.md', 'PERMISSIONS.md', 'CONTRIBUTING.md', 'SECURITY.md', 'AI_GOVERNANCE.md'].includes(f);
+
+            // Code file extensions that require docs
+            const codeExtensions = ['.ps1', '.psm1', '.psd1', '.json'];
+            const isCodeFile = (f) => !isIgnored(f) && !isDoc(f) && codeExtensions.some(ext => f.toLowerCase().endsWith(ext));
+
+            const codeFiles = changed.filter(isCodeFile);
+            const docFiles = changed.filter(isDoc);
+
+            if (codeFiles.length === 0) {
+              core.info('No code files changed — docs check not required.');
+              core.info(`Changed files: ${changed.join(', ')}`);
+              return;
+            }
+
+            core.info(`Code files changed: ${codeFiles.join(', ')}`);
+            core.info(`Doc files changed: ${docFiles.join(', ')}`);
+
+            if (docFiles.length === 0) {
+              core.setFailed(
+                'This PR changes code files but no documentation was updated.\n' +
+                'Please update README.md and/or CHANGELOG.md.\n' +
+                'See CONTRIBUTING.md for documentation requirements.'
+              );
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,29 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Added
 - CI: `docs-check.yml` workflow enforces documentation updates on PRs that change code files
-- Unified schema: add `ResourceId` and `LearnMoreUrl` fields to every finding
-- Orchestrator auto-generates HTML and Markdown reports after writing results.json
+- **Schema enrichment**: Unified findings now include `ResourceId` (Azure ARM resource ID) and `LearnMoreUrl` (Microsoft Learn link) fields
+- **Auto-report generation**: `Invoke-AzureAnalyzer.ps1` now automatically calls `New-HtmlReport.ps1` and `New-MdReport.ps1` after writing `results.json` — no manual step needed
+- **HTML report enhancements**:
+  - Executive summary with auto-generated compliance prose (resource count, tool count, compliance %, high-severity callout)
+  - Pure-CSS donut chart using conic-gradient for compliance percentage (zero JS dependencies)
+  - Per-source horizontal bar chart showing finding counts per tool (azqr, PSRule, AzGovViz, ALZ Queries, WARA)
+  - Text filter/search input above each findings table with instant keyup filtering
+  - Clickable remediation URLs auto-detected and wrapped in anchor tags
+  - Tool coverage badges showing which tools ran vs were skipped
+  - Remediation column added to all findings tables
+  - Print-friendly @media print CSS hiding interactive elements, preventing page breaks in rows
+- **Markdown report enhancements**:
+  - Executive summary with GitHub-flavored callouts (WARNING/NOTE/TIP) based on severity
+  - Mermaid pie chart for compliance breakdown (rendered natively on GitHub)
+  - Per-source emoji badges (🔴 High, 🟠 Med, 🟡 Low, 🟢 All compliant)
+  - Collapsible per-category finding tables via `<details>` tags
+  - Tool coverage section showing which tools ran vs were skipped
 
 ### Changed
 - `Invoke-PSRule.ps1` — populate `ResourceId` from `TargetName` when it looks like an ARM resource ID
 - `Invoke-AlzQueries.ps1` — populate `ResourceId` from first non-compliant ARG row
 - `Invoke-WARA.ps1` — populate `ResourceId` from ImpactedResources and `LearnMoreUrl` from LearnMoreLink
+- Updated README.md to document unified 10-field schema and auto-generated reports
 
 ### Removed
 - Delete dead Python stubs (`src/run.py`, `src/__init__.py`) — orchestrator is PowerShell only
@@ -22,34 +38,6 @@ All notable changes to azure-analyzer will be documented here.
 - Update branch protection to require `Analyze (actions)` only
 - Update codeql.yml to use actions/checkout v6 SHA (was v4)
 - Fix copilot-instructions.md SHA-pinning example to reference v6 (was v4.2.2)
-
-### Added
-- feat: enhance HTML report with dashboard-quality visuals
-  - Executive summary block with auto-generated prose (resource count, tool count, compliance %, high-severity callout)
-  - Pure-CSS donut chart using conic-gradient for compliance percentage
-  - Per-source horizontal bar chart showing finding counts per tool (azqr, PSRule, AzGovViz, ALZ Queries, WARA)
-  - Clickable remediation URLs auto-detected and wrapped in anchor tags
-  - Text filter/search input above each findings table with instant keyup filtering
-  - Tool coverage summary showing which tools produced results vs were skipped
-  - Remediation column added to all findings tables
-  - Print-friendly @media print CSS hiding interactive elements, preventing page breaks in rows
-- feat: enhance Markdown report with GitHub-native visualization features
-  - Executive summary with GitHub-flavored callouts (WARNING/NOTE/TIP) based on severity
-  - Mermaid pie chart for compliance breakdown (rendered natively on GitHub)
-  - Per-source emoji badges (🔴 High, 🟠 Med, 🟡 Low, 🟢 All compliant)
-  - Collapsible per-category finding tables via `<details>` tags
-  - Tool coverage section showing which tools ran vs were skipped
-- Add .editorconfig for consistent formatting across editors
-- feat: add WARA (Well-Architected Reliability Assessment) as 5th assessment source
-- Phase 6: full README with prerequisites, quick-start, output and permissions tables
-- CI failure analysis workflow: auto-creates issues with bug+squad labels when any workflow fails
-- Phase 4: `modules/Invoke-Azqr.ps1` — azqr CLI wrapper (graceful degradation)
-- Phase 4: `modules/Invoke-PSRule.ps1` — PSRule for Azure wrapper
-- Phase 4: `modules/Invoke-AzGovViz.ps1` — AzGovViz wrapper
-- Phase 4: `modules/Invoke-AlzQueries.ps1` — alz-graph-queries ARG wrapper
-- Phase 4: `Invoke-AzureAnalyzer.ps1` — orchestrator, merges all findings to output/results.json
-- Phase 5: `New-MdReport.ps1` - Markdown report generator from results.json
-- Phase 5: `New-HtmlReport.ps1` - offline-capable HTML report with severity cards and sortable tables
 
 ## [0.0.1] - Initial scaffold
 - Initial scaffold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to azure-analyzer will be documented here.
 ## [Unreleased]
 
 ### Added
+- CI: `docs-check.yml` workflow enforces documentation updates on PRs that change code files
 - Unified schema: add `ResourceId` and `LearnMoreUrl` fields to every finding
 - Orchestrator auto-generates HTML and Markdown reports after writing results.json
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,21 @@ Automated Azure assessment that bundles **azqr**, **PSRule for Azure**, **AzGovV
 | 5 — WARA | `modules/Invoke-WARA.ps1` | Well-Architected Reliability Assessment — reliability findings per resource |
 | Report | `New-MdReport.ps1` / `New-HtmlReport.ps1` | Unified Markdown + offline HTML report |
 
-All findings are merged into `output/results.json` using a common schema:
+All findings are merged into `output/results.json` using a unified 10-field schema:
 
 ```json
-{ "source": "azqr", "category": "Security", "severity": "High", "title": "...", "description": "...", "resourceId": "...", "learnMoreUrl": "..." }
+{
+  "source": "azqr|psrule|azgovviz|alzqueries|wara",
+  "category": "Security|Reliability|Cost",
+  "severity": "Critical|High|Medium|Low|Info",
+  "title": "Finding title",
+  "description": "Detailed description",
+  "resourceId": "/subscriptions/.../resourceGroups/.../providers/...",
+  "learnMoreUrl": "https://learn.microsoft.com/...",
+  "remediation": "Steps to fix",
+  "source": "azqr",
+  "timestamp": "2024-01-15T10:30:00Z"
+}
 ```
 
 ## Prerequisites
@@ -65,9 +76,29 @@ After a run, `output/` contains:
 
 | File | Description |
 |---|---|
-| `results.json` | All findings in unified schema |
-| `report.md` | Markdown report — summary table + Fix Now / Plan / Track sections |
-| `report.html` | Offline HTML report — sortable table, severity badges, no CDN dependencies |
+| `results.json` | All findings in unified 10-field schema (see above) |
+| `report.md` | GitHub-flavored Markdown with exec summary, Mermaid pie chart, callouts, collapsible sections, and tool coverage |
+| `report.html` | Offline HTML dashboard — pure-CSS donut chart, executive summary, per-source bar breakdown, search/filter, clickable remediation URLs, print-friendly, zero JS dependencies |
+
+**Reports are auto-generated** after `Invoke-AzureAnalyzer.ps1` writes `results.json` — no manual step needed.
+
+### HTML Report features
+
+- **Executive summary** — auto-generated compliance prose (resource count, tool count, compliance %, high-severity callout)
+- **Pure-CSS donut chart** — compliance percentage with conic-gradient (no JavaScript)
+- **Per-source breakdown** — horizontal bar chart showing finding counts per tool
+- **Search & filter** — text input for instant filtering across all finding tables
+- **Clickable remediation URLs** — automatically wrapped in anchor tags
+- **Tool coverage badges** — shows which tools ran vs were skipped
+- **Print-friendly CSS** — hides interactive elements, prevents page breaks in rows
+
+### Markdown Report features
+
+- **Executive summary** — GitHub-flavored callouts (WARNING/NOTE/TIP) based on severity
+- **Mermaid pie chart** — compliance breakdown (rendered natively on GitHub)
+- **Severity badges** — per-source emoji indicators (🔴 High, 🟠 Med, 🟡 Low, 🟢 All compliant)
+- **Collapsible sections** — per-category finding tables via `<details>` tags
+- **Tool coverage matrix** — shows which tools ran vs were skipped
 
 ### Report structure
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ After a run, `output/` contains:
 
 No write permissions are required. All tools operate read-only.
 
+## Data Sources & Attribution
+
+This tool wraps the following open-source projects. See [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md) for full license details.
+
+| Tool | Source | License |
+|------|--------|---------|
+| azqr | [Azure/azqr](https://github.com/Azure/azqr) | MIT |
+| AzGovViz | [JulianHayward/Azure-MG-Sub-Governance-Reporting](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting) | MIT |
+| PSRule for Azure | [Azure/PSRule.Rules.Azure](https://github.com/Azure/PSRule.Rules.Azure) | MIT |
+| WARA | [Azure/Azure-Proactive-Resiliency-Library-v2](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2) | MIT |
+| ALZ Query Data | [Azure/review-checklists](https://github.com/Azure/review-checklists) | MIT |
+
 ## CI / Automation
 
 | Workflow | Trigger | What it does |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,53 @@
+# Third-Party Notices
+
+This project invokes, wraps, or depends on the following open-source tools. None are bundled - each must be installed separately.
+
+---
+
+## Azure Quick Review (azqr)
+- **Source:** https://github.com/Azure/azqr
+- **Install:** https://azure.github.io/azqr
+- **Copyright:** Copyright (c) Microsoft Corporation
+- **License:** MIT License
+
+---
+
+## AzGovViz - Azure Governance Visualizer
+- **Source:** https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting
+- **Copyright:** Copyright (c) 2020 Julian Hayward
+- **License:** MIT License
+- **Install:** Clone the repo. `Invoke-AzGovViz.ps1` looks for `AzGovVizParallel.ps1` in standard paths.
+
+---
+
+## PSRule for Azure
+- **Source:** https://github.com/Azure/PSRule.Rules.Azure
+- **Copyright:** Copyright (c) Microsoft Corporation and contributors
+- **License:** MIT License
+- **Install:** `Install-Module PSRule.Rules.Azure`
+
+---
+
+## WARA - Well-Architected Reliability Assessment
+- **Source:** https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2
+- **Copyright:** Copyright (c) Microsoft Corporation
+- **License:** MIT License
+- **Install:** `Install-Module WARA`
+
+---
+
+## Az PowerShell Modules
+- **Source:** https://github.com/Azure/azure-powershell
+- **Copyright:** Copyright (c) Microsoft Corporation
+- **License:** MIT License
+- **Install:** `Install-Module Az`
+
+---
+
+## Azure Review Checklists (query data)
+- **Source:** https://github.com/Azure/review-checklists
+- **Copyright:** Copyright (c) Microsoft Corporation
+- **License:** MIT License
+- **Usage:** The ALZ checklist query data loaded by `modules/Invoke-AlzQueries.ps1` is derived from this project.
+  Copy `queries/alz_additional_queries.json` from https://github.com/martinopedal/alz-graph-queries
+  or provide via `-QueriesFile` parameter.


### PR DESCRIPTION
Restores THIRD_PARTY_NOTICES.md that was accidentally deleted during a git history rewrite.

- Recreates THIRD_PARTY_NOTICES.md with full third-party attribution
- Adds 'Data Sources & Attribution' section to README.md before License section
- References all open-source tools with license and source links