### PR TITLE
fix: correct Az PowerShell license from MIT to Apache 2.0

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -39,7 +39,7 @@ This project invokes, wraps, or depends on the following open-source tools. None
 ## Az PowerShell Modules
 - **Source:** https://github.com/Azure/azure-powershell
 - **Copyright:** Copyright (c) Microsoft Corporation
-- **License:** MIT License
+- **License:** Apache License 2.0
 - **Install:** `Install-Module Az`
 
 ---


### PR DESCRIPTION
License audit found Az PowerShell modules use Apache License 2.0, not MIT. THIRD_PARTY_NOTICES.md was incorrect.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>