### PR TITLE
fix: exclude squad infrastructure from downloads and clarify CI docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,12 @@
 .squad/agents/*/history.md merge=union
 .squad/log/** merge=union
 .squad/orchestration-log/** merge=union
+
+# Exclude squad infrastructure from archive downloads (zip/tar)
+.squad/ export-ignore
+.squad/** export-ignore
+.github/workflows/squad-*.yml export-ignore
+.github/workflows/sync-squad-labels.yml export-ignore
+.github/workflows/ci-failure-analysis.yml export-ignore
+.github/workflows/auto-label-issues.yml export-ignore
+.github/agents/ export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Changed
+- README: Rewrite CI/Automation section — separate user-facing CI from maintainer-only squad workflows behind a collapsed `<details>` block
+- README: Add "For Contributors" section explaining that `.squad/` is maintainer infrastructure, not part of the tool
+- `.gitattributes`: Add `export-ignore` rules so squad files (`.squad/`, squad workflows, `.github/agents/`) are excluded from archive downloads
+
 ### Added
 - CI: `docs-check.yml` workflow enforces documentation updates on PRs that change code files
 - **Schema enrichment**: Unified findings now include `ResourceId` (Azure ARM resource ID) and `LearnMoreUrl` (Microsoft Learn link) fields

--- a/README.md
+++ b/README.md
@@ -128,13 +128,32 @@ This tool wraps the following open-source projects. See [THIRD_PARTY_NOTICES.md]
 | WARA | [Azure/Azure-Proactive-Resiliency-Library-v2](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2) | MIT |
 | ALZ Query Data | [Azure/review-checklists](https://github.com/Azure/review-checklists) | MIT |
 
-## CI / Automation
+## CI / Quality
 
-| Workflow | Trigger | What it does |
+| Workflow | Trigger | Purpose |
 |---|---|---|
-| `codeql.yml` | Push / PR / weekly | Static analysis (CodeQL v4, SHA-pinned) |
-| `ci-failure-analysis.yml` | Any workflow failure | Auto-creates `bug`+`squad` issue with log excerpt |
-| `squad-heartbeat.yml` | PR open/sync + schedule | Squad CI gate |
+| `codeql.yml` | Push / PR / weekly | Static analysis for security vulnerabilities (CodeQL, SHA-pinned) |
+| `docs-check.yml` | PR | Ensures documentation is updated with code changes |
+
+<details>
+<summary>Maintainer workflows (squad infrastructure)</summary>
+
+These workflows support the AI development team and are excluded from archive downloads.
+
+| Workflow | Purpose |
+|---|---|
+| `squad-heartbeat.yml` | Automated triage and CI gate via Ralph |
+| `squad-triage.yml` | Issue routing to squad members |
+| `squad-issue-assign.yml` | Auto-assignment of issues to squad agents |
+| `sync-squad-labels.yml` | Syncs squad labels across the repo |
+| `ci-failure-analysis.yml` | Auto-creates bug issues with log excerpts on workflow failures |
+| `auto-label-issues.yml` | Adds the `squad` label to new issues |
+
+</details>
+
+## For Contributors
+
+The `.squad/` directory contains AI team infrastructure used by the maintainer for automated issue triage and development workflows. It is **not** part of the azure-analyzer tool itself and is excluded from archive downloads (`Download ZIP`, release tarballs). If you clone the repo as a contributor you will see these files, but they do not affect tool functionality.
 
 ## License
 


### PR DESCRIPTION
## Changes

**Problem 1 — Squad files leak to end users:**
- Users who download azure-analyzer via \Download ZIP\ or release archives shouldn't get \.squad/\ or squad workflow files — those are maintainer-only infrastructure.
- **Fix:** Added \xport-ignore\ rules in \.gitattributes\ for \.squad/\, squad workflows, and \.github/agents/\. Clone still works for contributors; archives are clean.

**Problem 2 — CI docs mix user and maintainer workflows:**
- The README CI table listed squad-heartbeat and ci-failure-analysis alongside CodeQL, confusing users.
- **Fix:** Split into a clean **CI / Quality** table (CodeQL + docs-check) and a collapsed \<details>\ block for maintainer-only squad workflows.

**Also added:**
- A \For Contributors\ section in README explaining \.squad/\ purpose
- CHANGELOG entries for all changes

## Files changed
- \.gitattributes\ — export-ignore rules
- \README.md\ — CI section rewrite + contributor note
- \CHANGELOG.md\ — documented changes