### PR TITLE
fix: wire ResourceId/LearnMoreUrl columns into report outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to azure-analyzer will be documented here.
 - `.gitattributes`: Add `export-ignore` rules so squad files (`.squad/`, squad workflows, `.github/agents/`) are excluded from archive downloads
 - README & THIRD_PARTY_NOTICES.md: Update ALZ queries attribution to reflect derivation chain (alz-graph-queries ← Azure/review-checklists)
 
+### Fixed
+- **Report field rendering**: HTML and Markdown reports now render `ResourceId` and `LearnMoreUrl` columns in all findings tables (previously only stored in JSON but not displayed)
+
 ### Added
 - CI: `docs-check.yml` workflow enforces documentation updates on PRs that change code files
 - **Schema enrichment**: Unified findings now include `ResourceId` (Azure ARM resource ID) and `LearnMoreUrl` (Microsoft Learn link) fields

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -76,7 +76,9 @@ $rowsJson = $findings | ForEach-Object {
   severity: `"$(HE $_.Severity)`",
   compliant: $($_.Compliant.ToString().ToLower()),
   detail: `"$(HE $_.Detail)`",
-  remediation: `"$(HE $_.Remediation)`"
+  remediation: `"$(HE $_.Remediation)`",
+  resourceId: `"$(HE $_.ResourceId)`",
+  learnMoreUrl: `"$(HE $_.LearnMoreUrl)`"
 }
 "@
 } -join ','
@@ -92,7 +94,9 @@ $categoryHtml = foreach ($cat in $byCategory) {
         $sevClass = SeverityClass $f.Severity
         $compliantStr = if ($f.Compliant) { '<span class="badge badge-ok">Yes</span>' } else { '<span class="badge badge-fail">No</span>' }
         $remediationHtml = Linkify $f.Remediation
-        "<tr><td>$(HE $f.Title)</td><td><span class='badge $sevClass'>$(HE $f.Severity)</span></td><td>$(HE $f.Source)</td><td>$compliantStr</td><td>$(HE $f.Detail)</td><td>$remediationHtml</td></tr>"
+        $resourceIdHtml = HE $f.ResourceId
+        $learnMoreHtml = if ([string]::IsNullOrWhiteSpace($f.LearnMoreUrl)) { '' } else { "<a href=`"$(HE $f.LearnMoreUrl)`" target=`"_blank`" rel=`"noopener noreferrer`">Learn more</a>" }
+        "<tr><td>$(HE $f.Title)</td><td><span class='badge $sevClass'>$(HE $f.Severity)</span></td><td>$(HE $f.Source)</td><td>$compliantStr</td><td>$(HE $f.Detail)</td><td>$remediationHtml</td><td class=`"resource-id`">$resourceIdHtml</td><td>$learnMoreHtml</td></tr>"
     }
     @"
 <details id="cat-$catId">
@@ -107,6 +111,8 @@ $categoryHtml = foreach ($cat in $byCategory) {
         <th onclick="sortTable(this)">Compliant</th>
         <th>Detail</th>
         <th>Remediation</th>
+        <th onclick="sortTable(this)">Resource ID</th>
+        <th>Learn More</th>
       </tr>
     </thead>
     <tbody>
@@ -209,6 +215,7 @@ $html = @"
   .findings-table th:hover { background: #e0e0e0; }
   .findings-table td { padding: 7px 10px; border-top: 1px solid #f0f0f0; vertical-align: top; }
   .findings-table td a { color: #1565c0; word-break: break-all; }
+  .findings-table td.resource-id { font-size: 11px; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .findings-table tr:hover td { background: #fafafa; }
   .badge { display: inline-block; padding: 2px 7px; border-radius: 3px; font-size: 11px; font-weight: 600; }
   .sev-high { background: #fde8e8; color: #c62828; }

--- a/New-MdReport.ps1
+++ b/New-MdReport.ps1
@@ -69,13 +69,15 @@ $byCategory = $findings | Group-Object -Property Category | Sort-Object Name
 foreach ($cat in $byCategory) {
     $lines.Add("### $($cat.Name)")
     $lines.Add('')
-    $lines.Add('| Title | Severity | Source | Compliant | Detail |')
-    $lines.Add('|---|---|---|---|---|')
+    $lines.Add('| Title | Severity | Source | Compliant | Detail | Resource ID | Learn More |')
+    $lines.Add('|---|---|---|---|---|---|---|')
     foreach ($f in ($cat.Group | Sort-Object Severity, Title)) {
         $compliantStr = if ($f.Compliant) { 'Yes' } else { 'No' }
         $detail = ($f.Detail -replace '\|', '\\|' -replace "`n|`r", ' ')
         $title = ($f.Title -replace '\|', '\\|' -replace "`n|`r", ' ')
-        $lines.Add("| $title | $($f.Severity) | $($f.Source) | $compliantStr | $detail |")
+        $resId = ($f.ResourceId -replace '\|', '\\|')
+        $learnMore = if ([string]::IsNullOrWhiteSpace($f.LearnMoreUrl)) { '' } else { "[$($f.LearnMoreUrl)]($($f.LearnMoreUrl))" }
+        $lines.Add("| $title | $($f.Severity) | $($f.Source) | $compliantStr | $detail | $resId | $learnMore |")
     }
     $lines.Add('')
 }
@@ -92,13 +94,15 @@ $lines.Add('')
 if ($fixNow.Count -eq 0) {
     $lines.Add('No high-severity non-compliant findings.')
 } else {
-    $lines.Add('| Title | Source | Detail | Remediation |')
-    $lines.Add('|---|---|---|---|')
+    $lines.Add('| Title | Source | Detail | Remediation | Resource ID | Learn More |')
+    $lines.Add('|---|---|---|---|---|---|')
     foreach ($f in $fixNow) {
         $title = ($f.Title -replace '\|', '\\|')
         $detail = ($f.Detail -replace '\|', '\\|' -replace "`n|`r", ' ')
         $rem = ($f.Remediation -replace '\|', '\\|')
-        $lines.Add("| $title | $($f.Source) | $detail | $rem |")
+        $resId = ($f.ResourceId -replace '\|', '\\|')
+        $learnMore = if ([string]::IsNullOrWhiteSpace($f.LearnMoreUrl)) { '' } else { "[$($f.LearnMoreUrl)]($($f.LearnMoreUrl))" }
+        $lines.Add("| $title | $($f.Source) | $detail | $rem | $resId | $learnMore |")
     }
 }
 $lines.Add('')
@@ -108,12 +112,14 @@ $lines.Add('')
 if ($planFix.Count -eq 0) {
     $lines.Add('No medium-severity non-compliant findings.')
 } else {
-    $lines.Add('| Title | Source | Detail |')
-    $lines.Add('|---|---|---|')
+    $lines.Add('| Title | Source | Detail | Resource ID | Learn More |')
+    $lines.Add('|---|---|---|---|---|')
     foreach ($f in $planFix) {
         $title = ($f.Title -replace '\|', '\\|')
         $detail = ($f.Detail -replace '\|', '\\|' -replace "`n|`r", ' ')
-        $lines.Add("| $title | $($f.Source) | $detail |")
+        $resId = ($f.ResourceId -replace '\|', '\\|')
+        $learnMore = if ([string]::IsNullOrWhiteSpace($f.LearnMoreUrl)) { '' } else { "[$($f.LearnMoreUrl)]($($f.LearnMoreUrl))" }
+        $lines.Add("| $title | $($f.Source) | $detail | $resId | $learnMore |")
     }
 }
 $lines.Add('')
@@ -123,12 +129,14 @@ $lines.Add('')
 if ($track.Count -eq 0) {
     $lines.Add('No low/info non-compliant findings.')
 } else {
-    $lines.Add('| Title | Severity | Source | Detail |')
-    $lines.Add('|---|---|---|---|')
+    $lines.Add('| Title | Severity | Source | Detail | Resource ID | Learn More |')
+    $lines.Add('|---|---|---|---|---|---|')
     foreach ($f in $track) {
         $title = ($f.Title -replace '\|', '\\|')
         $detail = ($f.Detail -replace '\|', '\\|' -replace "`n|`r", ' ')
-        $lines.Add("| $title | $($f.Severity) | $($f.Source) | $detail |")
+        $resId = ($f.ResourceId -replace '\|', '\\|')
+        $learnMore = if ([string]::IsNullOrWhiteSpace($f.LearnMoreUrl)) { '' } else { "[$($f.LearnMoreUrl)]($($f.LearnMoreUrl))" }
+        $lines.Add("| $title | $($f.Severity) | $($f.Source) | $detail | $resId | $learnMore |")
     }
 }
 $lines.Add('')


### PR DESCRIPTION
## Summary
Forge verified the full e2e pipeline and found that both HTML and Markdown reports stored ResourceId/LearnMoreUrl in JSON but never rendered them. This commit adds those columns to all report tables.

### Changes
- **HTML report**: Two new table columns (Resource ID, Learn More with clickable links) + CSS for overflow
- **Markdown report**: Resource ID and Learn More columns in all 4 table sections
- **CHANGELOG**: Entry documenting the fix

### Verification
- All 5 tool wrappers populate the 10-field unified schema ✅
- AlzQueries default path confirmed correct ✅
- Reports now surface all enriched fields ✅