### PR TITLE
feat: add Maester and OpenSSF Scorecard assessment tools

### DIFF
--- a/AzureAnalyzer.psd1
+++ b/AzureAnalyzer.psd1
@@ -1,0 +1,78 @@
+@{
+    RootModule            = 'AzureAnalyzer.psm1'
+    ModuleVersion         = '2.0.0'
+    GUID                  = '0e0f0e0f-0f0e-0f0e-0f0e-0f0e0f0e0f0e'
+    Author                = 'Martin Opedal'
+    CompanyName           = 'Azure Community'
+    Description           = 'Unified Azure assessment tool bundling azqr, PSRule for Azure, AzGovViz, ALZ Resource Graph queries, WARA, Maester, and OpenSSF Scorecard into a single orchestrated run with unified JSON, HTML, and Markdown reports.'
+    
+    PowerShellVersion     = '7.0'
+    
+    RequiredModules       = @(
+        @{ ModuleName = 'Az.Accounts'; ModuleVersion = '2.13.0'; },
+        @{ ModuleName = 'Az.ResourceGraph'; ModuleVersion = '0.13.0'; }
+    )
+    
+    FunctionsToExport     = @(
+        'Invoke-AzureAnalyzer',
+        'New-HtmlReport',
+        'New-MdReport'
+    )
+    
+    CmdletsToExport       = @()
+    VariablesToExport     = @()
+    AliasesToExport       = @()
+    
+    PrivateData           = @{
+        PSData = @{
+            Tags                     = @('Azure', 'Assessment', 'Compliance', 'Security', 'Governance', 'PSRule', 'WARA', 'AzGovViz')
+            LicenseUri               = 'https://github.com/martinopedal/azure-analyzer/blob/main/LICENSE'
+            ProjectUri               = 'https://github.com/martinopedal/azure-analyzer'
+            IconUri                  = ''
+            ReleaseNotes             = @'
+# v2.0.0 Release Notes
+
+## Major Features
+- Unified module packaging for PSGallery distribution
+- All seven assessment tools now available via single Install-Module command
+- Integrated report generation (HTML, Markdown, JSON)
+- AI-assisted triage for prioritized findings
+
+## Tools Included
+1. **azqr** - Azure Quick Review
+2. **PSRule for Azure** - Policy validation
+3. **AzGovViz** - Governance hierarchy
+4. **ALZ Queries** - Azure Resource Graph queries
+5. **WARA** - Well-Architected Review
+6. **Maester** - Entra ID security
+7. **OpenSSF Scorecard** - Repository security
+
+## Breaking Changes
+- Module now uses unified schema for all findings
+- New parameter contract for Invoke-AzureAnalyzer
+
+See https://github.com/martinopedal/azure-analyzer/blob/main/CHANGELOG.md for full details.
+'@
+            Prerelease               = ''
+        }
+    }
+    
+    FileList              = @(
+        'AzureAnalyzer.psd1',
+        'AzureAnalyzer.psm1',
+        'Invoke-AzureAnalyzer.ps1',
+        'New-HtmlReport.ps1',
+        'New-MdReport.ps1',
+        'modules/Invoke-Azqr.ps1',
+        'modules/Invoke-PSRule.ps1',
+        'modules/Invoke-AzGovViz.ps1',
+        'modules/Invoke-AlzQueries.ps1',
+        'modules/Invoke-WARA.ps1',
+        'modules/Invoke-Maester.ps1',
+        'modules/Invoke-CopilotTriage.ps1',
+        'modules/Invoke-CopilotTriage.py',
+        'queries/',
+        'samples/',
+        'docs/'
+    )
+}

--- a/AzureAnalyzer.psd1
+++ b/AzureAnalyzer.psd1
@@ -1,17 +1,14 @@
 @{
     RootModule            = 'AzureAnalyzer.psm1'
-    ModuleVersion         = '2.0.0'
+    ModuleVersion         = '1.0.0'
     GUID                  = '0e0f0e0f-0f0e-0f0e-0f0e-0f0e0f0e0f0e'
     Author                = 'Martin Opedal'
     CompanyName           = 'Azure Community'
-    Description           = 'Unified Azure assessment tool bundling azqr, PSRule for Azure, AzGovViz, ALZ Resource Graph queries, WARA, Maester, and OpenSSF Scorecard into a single orchestrated run with unified JSON, HTML, and Markdown reports.'
+    Description           = 'Unified Azure assessment tool bundling azqr, PSRule for Azure, AzGovViz, ALZ Resource Graph queries, WARA, Maester, and OpenSSF Scorecard. Local module for on-demand assessment runs.'
     
     PowerShellVersion     = '7.0'
     
-    RequiredModules       = @(
-        @{ ModuleName = 'Az.Accounts'; ModuleVersion = '2.13.0'; },
-        @{ ModuleName = 'Az.ResourceGraph'; ModuleVersion = '0.13.0'; }
-    )
+    RequiredModules       = @()
     
     FunctionsToExport     = @(
         'Invoke-AzureAnalyzer',
@@ -22,57 +19,4 @@
     CmdletsToExport       = @()
     VariablesToExport     = @()
     AliasesToExport       = @()
-    
-    PrivateData           = @{
-        PSData = @{
-            Tags                     = @('Azure', 'Assessment', 'Compliance', 'Security', 'Governance', 'PSRule', 'WARA', 'AzGovViz')
-            LicenseUri               = 'https://github.com/martinopedal/azure-analyzer/blob/main/LICENSE'
-            ProjectUri               = 'https://github.com/martinopedal/azure-analyzer'
-            IconUri                  = ''
-            ReleaseNotes             = @'
-# v2.0.0 Release Notes
-
-## Major Features
-- Unified module packaging for PSGallery distribution
-- All seven assessment tools now available via single Install-Module command
-- Integrated report generation (HTML, Markdown, JSON)
-- AI-assisted triage for prioritized findings
-
-## Tools Included
-1. **azqr** - Azure Quick Review
-2. **PSRule for Azure** - Policy validation
-3. **AzGovViz** - Governance hierarchy
-4. **ALZ Queries** - Azure Resource Graph queries
-5. **WARA** - Well-Architected Review
-6. **Maester** - Entra ID security
-7. **OpenSSF Scorecard** - Repository security
-
-## Breaking Changes
-- Module now uses unified schema for all findings
-- New parameter contract for Invoke-AzureAnalyzer
-
-See https://github.com/martinopedal/azure-analyzer/blob/main/CHANGELOG.md for full details.
-'@
-            Prerelease               = ''
-        }
-    }
-    
-    FileList              = @(
-        'AzureAnalyzer.psd1',
-        'AzureAnalyzer.psm1',
-        'Invoke-AzureAnalyzer.ps1',
-        'New-HtmlReport.ps1',
-        'New-MdReport.ps1',
-        'modules/Invoke-Azqr.ps1',
-        'modules/Invoke-PSRule.ps1',
-        'modules/Invoke-AzGovViz.ps1',
-        'modules/Invoke-AlzQueries.ps1',
-        'modules/Invoke-WARA.ps1',
-        'modules/Invoke-Maester.ps1',
-        'modules/Invoke-CopilotTriage.ps1',
-        'modules/Invoke-CopilotTriage.py',
-        'queries/',
-        'samples/',
-        'docs/'
-    )
 }

--- a/AzureAnalyzer.psm1
+++ b/AzureAnalyzer.psm1
@@ -5,7 +5,9 @@
 .DESCRIPTION
     Loads all public functions from the modules/ directory and the root-level
     scripts (Invoke-AzureAnalyzer.ps1, New-HtmlReport.ps1, New-MdReport.ps1).
-    Private helper scripts are dot-sourced but not exported.
+    
+    This is a local module for convenience—use after Import-Module ./AzureAnalyzer.psd1
+    in the cloned repository.
 #>
 
 Set-StrictMode -Version Latest
@@ -34,18 +36,14 @@ foreach ($funcName in $publicFunctions) {
     }
 }
 
-# Ensure required modules are available
-$requiredModules = @('Az.Accounts', 'Az.ResourceGraph')
-foreach ($moduleName in $requiredModules) {
-    if (-not (Get-Module -Name $moduleName -ErrorAction SilentlyContinue)) {
-        try {
-            Import-Module -Name $moduleName -ErrorAction Stop | Out-Null
-        }
-        catch {
-            Write-Warning "Required module '$moduleName' not found. Install with: Install-Module $moduleName"
-        }
+# Warn if core required modules are missing
+$coreRequired = @('Az.Accounts', 'Az.ResourceGraph')
+foreach ($moduleName in $coreRequired) {
+    if (-not (Get-Module -Name $moduleName -ListAvailable -ErrorAction SilentlyContinue)) {
+        Write-Warning "Core module '$moduleName' not found. Install with: Install-Module $moduleName -Scope CurrentUser"
     }
 }
 
 # Export public functions
 Export-ModuleMember -Function $publicFunctions
+

--- a/AzureAnalyzer.psm1
+++ b/AzureAnalyzer.psm1
@@ -1,0 +1,51 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Azure Analyzer PowerShell Module — Root module script.
+.DESCRIPTION
+    Loads all public functions from the modules/ directory and the root-level
+    scripts (Invoke-AzureAnalyzer.ps1, New-HtmlReport.ps1, New-MdReport.ps1).
+    Private helper scripts are dot-sourced but not exported.
+#>
+
+Set-StrictMode -Version Latest
+
+# Get the module root path
+$ModuleRoot = Split-Path -Parent $PSScriptRoot
+
+# Dot-source all tool wrapper modules from modules/ directory
+# These are internal helpers and should not be exported directly
+Get-ChildItem -Path (Join-Path $ModuleRoot 'modules') -Filter '*.ps1' -ErrorAction SilentlyContinue | ForEach-Object {
+    . $_.FullName
+}
+
+# Import public functions from root level
+# These are exported in the manifest as FunctionsToExport
+$publicFunctions = @(
+    'Invoke-AzureAnalyzer',
+    'New-HtmlReport',
+    'New-MdReport'
+)
+
+foreach ($funcName in $publicFunctions) {
+    $funcPath = Join-Path $ModuleRoot "$($funcName).ps1"
+    if (Test-Path $funcPath) {
+        . $funcPath
+    }
+}
+
+# Ensure required modules are available
+$requiredModules = @('Az.Accounts', 'Az.ResourceGraph')
+foreach ($moduleName in $requiredModules) {
+    if (-not (Get-Module -Name $moduleName -ErrorAction SilentlyContinue)) {
+        try {
+            Import-Module -Name $moduleName -ErrorAction Stop | Out-Null
+        }
+        catch {
+            Write-Warning "Required module '$moduleName' not found. Install with: Install-Module $moduleName"
+        }
+    }
+}
+
+# Export public functions
+Export-ModuleMember -Function $publicFunctions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 All notable changes to azure-analyzer will be documented here.
 
-## [2.0.0] - 2025-01-15
+## [1.0.0] - 2025-01-15
 
 ### Added
-- **PSGallery module distribution**: Azure Analyzer is now available as a PowerShell module via PSGallery. Install with `Install-Module AzureAnalyzer -Scope CurrentUser`. Includes module manifest (`AzureAnalyzer.psd1`) and module root script (`AzureAnalyzer.psm1`) for simplified adoption and updates via `Update-Module`.
-- **Public module API**: Exported functions `Invoke-AzureAnalyzer`, `New-HtmlReport`, and `New-MdReport` are now formally published as module member functions. All tool wrappers remain internal.
-- **Module metadata**: PSGallery tags, LicenseUri, ProjectUri, and release notes for discoverability and governance tracking.
-- **README PSGallery instructions**: Quick Start now leads with "Install from PSGallery" as the recommended option, with "Clone and run from source" as Option 2.
+- **Local module packaging**: Created `AzureAnalyzer.psd1` manifest and `AzureAnalyzer.psm1` loader. Users can now `Import-Module ./AzureAnalyzer.psd1` after cloning. Simplifies local invocation and development.
+- **Public module API**: Three exported functions: `Invoke-AzureAnalyzer`, `New-HtmlReport`, `New-MdReport`. All tool wrappers remain internal.
+- **Module auto-loading**: Root script dot-sources all tool wrappers from `modules/` directory and public functions from root scripts.
+- **README module instructions**: Quick Start updated to show `Import-Module` workflow after clone.
 
 ### Changed
-- README: Reordered Quick Start to prioritize PSGallery installation over source clone (PSGallery is now the recommended entry point)
+- README: Updated Quick Start to include `Import-Module ./AzureAnalyzer.psd1` step.
+- ModuleVersion: 1.0.0 (local module only, no PSGallery).
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Added
 - **Management group recursion**: When `-ManagementGroupId` is provided, the orchestrator auto-discovers all child subscriptions via ARG query and runs subscription-scoped tools (azqr, PSRule, WARA) across each one. MG-scoped tools (AzGovViz, ALZ queries) and tenant-wide tools (Maester) are unaffected. Use `-Recurse:$false` to disable.
-- **AI triage (optional)**: `-EnableAiTriage` switch enriches non-compliant findings via GitHub Copilot SDK with priority ranking, risk context, remediation steps, and root cause grouping. See `docs/ai-triage.md`.
+- **AI triage (optional, requires GitHub Copilot license)**: `-EnableAiTriage` switch enriches non-compliant findings via GitHub Copilot SDK with priority ranking, risk context, remediation steps, and root cause grouping. Zero footprint when disabled. See `docs/ai-triage.md`.
 - **AI triage in reports**: HTML/Markdown reports include AI Triage Summary when `triage.json` exists.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,47 +8,12 @@ All notable changes to azure-analyzer will be documented here.
 - **Management group recursion**: When `-ManagementGroupId` is provided, the orchestrator auto-discovers all child subscriptions via ARG query and runs subscription-scoped tools (azqr, PSRule, WARA) across each one. MG-scoped tools (AzGovViz, ALZ queries) and tenant-wide tools (Maester) are unaffected. Use `-Recurse:$false` to disable.
 - **AI triage (optional, requires GitHub Copilot license)**: `-EnableAiTriage` switch enriches non-compliant findings via GitHub Copilot SDK with priority ranking, risk context, remediation steps, and root cause grouping. Zero footprint when disabled. See `docs/ai-triage.md`.
 - **AI triage in reports**: HTML/Markdown reports include AI Triage Summary when `triage.json` exists.
-
-### Fixed
-- **Maester API mapping**: Fix `.Tests` → `.Result` to match Pester `TestResultContainer` returned by `Invoke-Maester -PassThru`. Handle `NotRun` status alongside `Passed`/`Skipped`.
-- **Graph scopes hint**: Warning message now shows `Connect-MgGraph -Scopes (Get-MtGraphScope)` with correct scope helper.
-- **Prereq behavior**: `Install-Prerequisites` now advise-only by default — lists missing modules with install commands. Add `-InstallMissingModules` switch to opt-in to auto-install. Prevents unexpected writes in shared/CI environments.
-
-## [1.0.0] - 2025-01-15
-
-### Added
-- **Auto-install prerequisites**: `Install-Prerequisites` auto-installs missing PSGallery modules (Az.ResourceGraph, PSRule, PSRule.Rules.Azure, WARA, Maester) on first run. CLI tools (azqr, scorecard) print install instructions. Respects `-IncludeTools` to only install what's needed. Use `-SkipPrereqCheck` to bypass in CI.
-- **Local module packaging**: Created `AzureAnalyzer.psd1` manifest and `AzureAnalyzer.psm1` loader. Users can now `Import-Module ./AzureAnalyzer.psd1` after cloning. Simplifies local invocation and development.
-- **Public module API**: Three exported functions: `Invoke-AzureAnalyzer`, `New-HtmlReport`, `New-MdReport`. All tool wrappers remain internal.
-- **Module auto-loading**: Root script dot-sources all tool wrappers from `modules/` directory and public functions from root scripts.
-- **README module instructions**: Quick Start updated to show `Import-Module` workflow after clone.
-
-### Changed
-- README: Updated Quick Start to include `Import-Module ./AzureAnalyzer.psd1` step.
-- ModuleVersion: 1.0.0 (local module only, no PSGallery).
-
-## [Unreleased]
-
-### Added
 - **Wrapper status contract**: All tool wrappers now return `Status` ('Success', 'Skipped', 'Failed') and `Message` fields alongside `Source` and `Findings`.
 - **Tool status summary**: Orchestrator tracks which tools succeeded, were skipped, or failed.
-- **Maester integration**: Added `modules/Invoke-Maester.ps1` wrapper for Entra ID / identity security posture assessment (tool #6). Auto-installs from PSGallery, checks Graph connection, maps Pester test results to unified schema. Runs unconditionally (tenant-scoped, not subscription-gated).
+- **Maester integration**: Added `modules/Invoke-Maester.ps1` wrapper for Entra ID / identity security posture assessment (tool #6). Checks Graph connection, maps Pester test results to unified schema. Runs unconditionally (tenant-scoped, not subscription-gated).
 - **OpenSSF Scorecard integration**: Added `modules/Invoke-Scorecard.ps1` wrapper for repository supply chain security assessment (tool #7). Evaluates branch protection, dependency pinning, CI/CD configuration, and other security practices. Requires repository context via new `-Repository` parameter.
 - **Sample reports and visual previews in README**: Added `samples/` directory with mock findings data and pre-generated HTML + Markdown reports so users can see output before running the tool. README now includes collapsed preview sections for both report formats.
 - **Bundled ALZ queries**: ALZ Resource Graph queries are now automatically bundled from [alz-graph-queries](https://github.com/martinopedal/alz-graph-queries) — no manual copy-step required. Queries originate from [Azure/review-checklists](https://github.com/Azure/review-checklists).
-
-### Changed
-- README: Restructure as consumer-first (Quick Start → What you get → Prerequisites → Usage → Schema → Permissions) with contributor/CI sections below a separator
-- README: Rewrite CI/Automation section — separate user-facing CI from maintainer-only squad workflows behind a collapsed `<details>` block
-- README: Add "For Contributors" section explaining that `.squad/` is maintainer infrastructure, not part of the tool
-- `.gitattributes`: Add `export-ignore` rules so squad files (`.squad/`, squad workflows, `.github/agents/`) are excluded from archive downloads
-- README & THIRD_PARTY_NOTICES.md: Update ALZ queries attribution to reflect derivation chain (alz-graph-queries ← Azure/review-checklists)
-
-### Fixed
-- **Report field rendering**: HTML and Markdown reports now render `ResourceId` and `LearnMoreUrl` columns in all findings tables (previously only stored in JSON but not displayed)
-- **PS 7.6 compatibility**: Fix `New-HtmlReport.ps1` `-join` operator parsing error on PowerShell 7.6 (wrap `ForEach-Object` pipeline in parentheses)
-
-### Added
 - CI: `docs-check.yml` workflow enforces documentation updates on PRs that change code files
 - **Schema enrichment**: Unified findings now include `ResourceId` (Azure ARM resource ID) and `LearnMoreUrl` (Microsoft Learn link) fields
 - **Auto-report generation**: `Invoke-AzureAnalyzer.ps1` now automatically calls `New-HtmlReport.ps1` and `New-MdReport.ps1` after writing `results.json` — no manual step needed
@@ -69,6 +34,11 @@ All notable changes to azure-analyzer will be documented here.
   - Tool coverage section showing which tools ran vs were skipped
 
 ### Changed
+- README: Restructure as consumer-first (Quick Start → What you get → Prerequisites → Usage → Schema → Permissions) with contributor/CI sections below a separator
+- README: Rewrite CI/Automation section — separate user-facing CI from maintainer-only squad workflows behind a collapsed `<details>` block
+- README: Add "For Contributors" section explaining that `.squad/` is maintainer infrastructure, not part of the tool
+- `.gitattributes`: Add `export-ignore` rules so squad files (`.squad/`, squad workflows, `.github/agents/`) are excluded from archive downloads
+- README & THIRD_PARTY_NOTICES.md: Update ALZ queries attribution to reflect derivation chain (alz-graph-queries ← Azure/review-checklists)
 - `Invoke-PSRule.ps1` — populate `ResourceId` from `TargetName` when it looks like an ARM resource ID
 - `Invoke-AlzQueries.ps1` — populate `ResourceId` from first non-compliant ARG row
 - `Invoke-WARA.ps1` — populate `ResourceId` from ImpactedResources and `LearnMoreUrl` from LearnMoreLink
@@ -78,10 +48,28 @@ All notable changes to azure-analyzer will be documented here.
 - Delete dead Python stubs (`src/run.py`, `src/__init__.py`) — orchestrator is PowerShell only
 
 ### Fixed
+- **Maester API mapping**: Fix `.Tests` → `.Result` to match Pester `TestResultContainer` returned by `Invoke-Maester -PassThru`. Handle `NotRun` status alongside `Passed`/`Skipped`.
+- **Graph scopes hint**: Warning message now shows `Connect-MgGraph -Scopes (Get-MtGraphScope)` with correct scope helper.
+- **Prereq behavior**: `Install-Prerequisites` now advise-only by default — lists missing modules with install commands. Add `-InstallMissingModules` switch to opt-in to auto-install. Prevents unexpected writes in shared/CI environments.
+- **Report field rendering**: HTML and Markdown reports now render `ResourceId` and `LearnMoreUrl` columns in all findings tables (previously only stored in JSON but not displayed)
+- **PS 7.6 compatibility**: Fix `New-HtmlReport.ps1` `-join` operator parsing error on PowerShell 7.6 (wrap `ForEach-Object` pipeline in parentheses)
 - Remove `python` from CodeQL language matrix; repo is PowerShell-only, no Python extractor needed
 - Update branch protection to require `Analyze (actions)` only
 - Update codeql.yml to use actions/checkout v6 SHA (was v4)
 - Fix copilot-instructions.md SHA-pinning example to reference v6 (was v4.2.2)
+
+## [1.0.0] - 2025-01-15
+
+### Added
+- **Auto-install prerequisites**: `Install-Prerequisites` auto-installs missing PSGallery modules (Az.ResourceGraph, PSRule, PSRule.Rules.Azure, WARA, Maester) on first run. CLI tools (azqr, scorecard) print install instructions. Respects `-IncludeTools` to only install what's needed. Use `-SkipPrereqCheck` to bypass in CI.
+- **Local module packaging**: Created `AzureAnalyzer.psd1` manifest and `AzureAnalyzer.psm1` loader. Users can now `Import-Module ./AzureAnalyzer.psd1` after cloning. Simplifies local invocation and development.
+- **Public module API**: Three exported functions: `Invoke-AzureAnalyzer`, `New-HtmlReport`, `New-MdReport`. All tool wrappers remain internal.
+- **Module auto-loading**: Root script dot-sources all tool wrappers from `modules/` directory and public functions from root scripts.
+- **README module instructions**: Quick Start updated to show `Import-Module` workflow after clone.
+
+### Changed
+- README: Updated Quick Start to include `Import-Module ./AzureAnalyzer.psd1` step.
+- ModuleVersion: 1.0.0 (local module only, no PSGallery).
 
 ## [0.0.1] - Initial scaffold
 - Initial scaffold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to azure-analyzer will be documented here.
 ## [Unreleased]
 
 ### Added
+- **Management group recursion**: When `-ManagementGroupId` is provided, the orchestrator auto-discovers all child subscriptions via ARG query and runs subscription-scoped tools (azqr, PSRule, WARA) across each one. MG-scoped tools (AzGovViz, ALZ queries) and tenant-wide tools (Maester) are unaffected. Use `-Recurse:$false` to disable.
 - **AI triage (optional)**: `-EnableAiTriage` switch enriches non-compliant findings via GitHub Copilot SDK with priority ranking, risk context, remediation steps, and root cause grouping. See `docs/ai-triage.md`.
 - **AI triage in reports**: HTML/Markdown reports include AI Triage Summary when `triage.json` exists.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to azure-analyzer will be documented here.
 ## [Unreleased]
 
 ### Added
+- **Maester integration**: Added `modules/Invoke-Maester.ps1` wrapper for Entra ID / identity security posture assessment (tool #6). Auto-installs from PSGallery, checks Graph connection, maps Pester test results to unified schema. Runs unconditionally (tenant-scoped, not subscription-gated).
+- **OpenSSF Scorecard integration**: Added `modules/Invoke-Scorecard.ps1` wrapper for repository supply chain security assessment (tool #7). Evaluates branch protection, dependency pinning, CI/CD configuration, and other security practices. Requires repository context via new `-Repository` parameter.
 - **Sample reports and visual previews in README**: Added `samples/` directory with mock findings data and pre-generated HTML + Markdown reports so users can see output before running the tool. README now includes collapsed preview sections for both report formats.
 - **Bundled ALZ queries**: ALZ Resource Graph queries are now automatically bundled from [alz-graph-queries](https://github.com/martinopedal/alz-graph-queries) — no manual copy-step required. Queries originate from [Azure/review-checklists](https://github.com/Azure/review-checklists).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to azure-analyzer will be documented here.
 ## [Unreleased]
 
 ### Added
+- **Wrapper status contract**: All tool wrappers now return `Status` ('Success', 'Skipped', 'Failed') and `Message` fields alongside `Source` and `Findings`.
+- **Tool status summary**: Orchestrator tracks which tools succeeded, were skipped, or failed.
 - **Maester integration**: Added `modules/Invoke-Maester.ps1` wrapper for Entra ID / identity security posture assessment (tool #6). Auto-installs from PSGallery, checks Graph connection, maps Pester test results to unified schema. Runs unconditionally (tenant-scoped, not subscription-gated).
 - **OpenSSF Scorecard integration**: Added `modules/Invoke-Scorecard.ps1` wrapper for repository supply chain security assessment (tool #7). Evaluates branch protection, dependency pinning, CI/CD configuration, and other security practices. Requires repository context via new `-Repository` parameter.
 - **Sample reports and visual previews in README**: Added `samples/` directory with mock findings data and pre-generated HTML + Markdown reports so users can see output before running the tool. README now includes collapsed preview sections for both report formats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to azure-analyzer will be documented here.
 - **AI triage (optional)**: `-EnableAiTriage` switch enriches non-compliant findings via GitHub Copilot SDK with priority ranking, risk context, remediation steps, and root cause grouping. See `docs/ai-triage.md`.
 - **AI triage in reports**: HTML/Markdown reports include AI Triage Summary when `triage.json` exists.
 
+### Fixed
+- **Maester API mapping**: Fix `.Tests` → `.Result` to match Pester `TestResultContainer` returned by `Invoke-Maester -PassThru`. Handle `NotRun` status alongside `Passed`/`Skipped`.
+- **Graph scopes hint**: Warning message now shows `Connect-MgGraph -Scopes (Get-MtGraphScope)` with correct scope helper.
+- **Prereq behavior**: `Install-Prerequisites` now advise-only by default — lists missing modules with install commands. Add `-InstallMissingModules` switch to opt-in to auto-install. Prevents unexpected writes in shared/CI environments.
+
 ## [1.0.0] - 2025-01-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to azure-analyzer will be documented here.
 
+## [2.0.0] - 2025-01-15
+
+### Added
+- **PSGallery module distribution**: Azure Analyzer is now available as a PowerShell module via PSGallery. Install with `Install-Module AzureAnalyzer -Scope CurrentUser`. Includes module manifest (`AzureAnalyzer.psd1`) and module root script (`AzureAnalyzer.psm1`) for simplified adoption and updates via `Update-Module`.
+- **Public module API**: Exported functions `Invoke-AzureAnalyzer`, `New-HtmlReport`, and `New-MdReport` are now formally published as module member functions. All tool wrappers remain internal.
+- **Module metadata**: PSGallery tags, LicenseUri, ProjectUri, and release notes for discoverability and governance tracking.
+- **README PSGallery instructions**: Quick Start now leads with "Install from PSGallery" as the recommended option, with "Clone and run from source" as Option 2.
+
+### Changed
+- README: Reordered Quick Start to prioritize PSGallery installation over source clone (PSGallery is now the recommended entry point)
+
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 All notable changes to azure-analyzer will be documented here.
 
+## [Unreleased]
+
+### Added
+- **AI triage (optional)**: `-EnableAiTriage` switch enriches non-compliant findings via GitHub Copilot SDK with priority ranking, risk context, remediation steps, and root cause grouping. See `docs/ai-triage.md`.
+- **AI triage in reports**: HTML/Markdown reports include AI Triage Summary when `triage.json` exists.
+
 ## [1.0.0] - 2025-01-15
 
 ### Added
+- **Auto-install prerequisites**: `Install-Prerequisites` auto-installs missing PSGallery modules (Az.ResourceGraph, PSRule, PSRule.Rules.Azure, WARA, Maester) on first run. CLI tools (azqr, scorecard) print install instructions. Respects `-IncludeTools` to only install what's needed. Use `-SkipPrereqCheck` to bypass in CI.
 - **Local module packaging**: Created `AzureAnalyzer.psd1` manifest and `AzureAnalyzer.psm1` loader. Users can now `Import-Module ./AzureAnalyzer.psd1` after cloning. Simplifies local invocation and development.
 - **Public module API**: Three exported functions: `Invoke-AzureAnalyzer`, `New-HtmlReport`, `New-MdReport`. All tool wrappers remain internal.
 - **Module auto-loading**: Root script dot-sources all tool wrappers from `modules/` directory and public functions from root scripts.

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -57,19 +57,31 @@ if ($needsAzureScope -and -not $SubscriptionId -and -not $ManagementGroupId) {
 }
 
 $modulesPath = Join-Path $PSScriptRoot 'modules'
+$toolErrors = [System.Collections.Generic.List[PSCustomObject]]::new()
 
 function Invoke-Wrapper {
-    param ([string]$Script, [hashtable]$Params)
+    param ([string]$Script, [hashtable]$Params, [int]$MaxRetries = 2, [int]$RetryDelaySec = 5)
     $scriptPath = Join-Path $modulesPath $Script
     if (-not (Test-Path $scriptPath)) {
         Write-Warning "$Script not found at $scriptPath"
         return [PSCustomObject]@{ Source = $Script; Findings = @() }
     }
-    try {
-        return & $scriptPath @Params
-    } catch {
-        Write-Warning "$Script threw an unexpected error: $_"
-        return [PSCustomObject]@{ Source = $Script; Findings = @() }
+    for ($attempt = 1; $attempt -le ($MaxRetries + 1); $attempt++) {
+        try {
+            $result = & $scriptPath @Params
+            if ($result.Findings.Count -gt 0 -or $attempt -gt $MaxRetries) { return $result }
+            Write-Warning "$Script returned 0 findings (attempt $attempt/$($MaxRetries+1)), retrying..."
+            Start-Sleep -Seconds $RetryDelaySec
+        } catch {
+            if ($attempt -le $MaxRetries) {
+                Write-Warning "$Script failed (attempt $attempt/$($MaxRetries+1)): $_ — retrying in ${RetryDelaySec}s..."
+                Start-Sleep -Seconds $RetryDelaySec
+            } else {
+                Write-Warning "$Script failed after $($MaxRetries+1) attempts: $_"
+                $toolErrors.Add([PSCustomObject]@{ Tool = $Script; Error = $_.Exception.Message; Timestamp = Get-Date })
+                return [PSCustomObject]@{ Source = $Script; Findings = @() }
+            }
+        }
     }
 }
 
@@ -90,6 +102,27 @@ function Get-Prop {
     $p = $Obj.PSObject.Properties[$Name]
     if ($null -eq $p -or $null -eq $p.Value) { return $Default }
     return $p.Value
+}
+
+function Get-SeverityRank ([string]$Sev) {
+    switch ($Sev) { 'High' { 3 } 'Medium' { 2 } 'Low' { 1 } default { 0 } }
+}
+
+function Remove-DuplicateFindings {
+    param ([System.Collections.Generic.List[PSCustomObject]]$Findings)
+    $deduped = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $groups = $Findings | Group-Object { "$($_.ResourceId)`t$($_.Title)".ToLowerInvariant() }
+    foreach ($g in $groups) {
+        if ($g.Count -eq 1) { $deduped.Add($g.Group[0]); continue }
+        $best = $g.Group | Sort-Object { Get-SeverityRank $_.Severity } -Descending | Select-Object -First 1
+        $mergedSource = ($g.Group | Select-Object -ExpandProperty Source -Unique | Sort-Object) -join ', '
+        $longestDetail = ($g.Group | Sort-Object { ($_.Detail ?? '').Length } -Descending | Select-Object -First 1).Detail
+        $merged = $best.PSObject.Copy()
+        $merged.Source = $mergedSource
+        $merged.Detail = $longestDetail
+        $deduped.Add($merged)
+    }
+    return $deduped
 }
 
 Write-Host "=== Azure Analyzer ===" -ForegroundColor Cyan
@@ -252,6 +285,15 @@ Write-Host "  Maester: $($maesterResult.Findings.Count) findings" -ForegroundCol
     Write-Host "`n[6/7] Skipping maester (excluded)" -ForegroundColor DarkGray
 }
 
+
+# --- Deduplicate cross-tool findings ---
+$preDedup = $allResults.Count
+$allResults = Remove-DuplicateFindings $allResults
+$dedupRemoved = $preDedup - $allResults.Count
+if ($dedupRemoved -gt 0) {
+    Write-Host "  Deduplication: removed $dedupRemoved duplicate(s) ($preDedup -> $($allResults.Count))" -ForegroundColor Gray
+}
+
 # --- Write output ---
 try {
     if (-not (Test-Path $OutputPath)) {
@@ -288,3 +330,17 @@ Write-Host "`n=== Summary ===" -ForegroundColor Cyan
 Write-Host "  Total findings: $($allResults.Count)"
 Write-Host "  Non-compliant ÔÇö High: $high  Medium: $medium  Low: $low" -ForegroundColor Yellow
 Write-Host "  Output: $outputFile" -ForegroundColor Green
+
+# --- Error summary ---
+if ($toolErrors.Count -gt 0) {
+    $errorsFile = Join-Path $OutputPath 'errors.json'
+    try {
+        $toolErrors | ConvertTo-Json -Depth 3 | Set-Content -Path $errorsFile -Encoding UTF8
+    } catch {
+        Write-Warning "Failed to write errors.json: $_"
+    }
+    Write-Host "`n⚠️ $($toolErrors.Count) tool(s) encountered errors:" -ForegroundColor Red
+    foreach ($te in $toolErrors) {
+        Write-Host "  - $($te.Tool): $($te.Error)" -ForegroundColor Red
+    }
+}

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-    Azure Analyzer — unified Azure assessment orchestrator.
+    Azure Analyzer ÔÇö unified Azure assessment orchestrator.
 .DESCRIPTION
     Calls all seven assessment tool wrappers (azqr, PSRule, AzGovViz, alz-queries,
     WARA, Maester, Scorecard), merges results into a unified schema, and writes
@@ -14,27 +14,18 @@
     Management group ID. Used by AzGovViz and alz-queries.
 .PARAMETER TenantId
     Azure tenant ID. Used by WARA collector. Defaults to current Az context tenant.
-.PARAMETER Repository
-    GitHub repository to scan with OpenSSF Scorecard (e.g., "github.com/org/repo").
-    If not provided, Scorecard is skipped.
-.PARAMETER ScorecardThreshold
-    Minimum score (0-10) to mark a Scorecard check as compliant. Default is 7.
 .PARAMETER OutputPath
     Output directory for results.json. Defaults to .\output.
 .EXAMPLE
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "00000000-0000-0000-0000-000000000000"
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ManagementGroupId "my-mg"
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -TenantId "..."
-    .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -Repository "github.com/org/repo"
 #>
 [CmdletBinding()]
 param (
     [string] $SubscriptionId,
     [string] $ManagementGroupId,
     [string] $TenantId,
-    [string] $Repository,
-    [ValidateRange(0, 10)]
-    [int] $ScorecardThreshold = 7,
     [string] $OutputPath = (Join-Path $PSScriptRoot 'output'),
     [string[]] $IncludeTools,
     [string[]] $ExcludeTools
@@ -43,28 +34,23 @@ param (
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# --- Tool selection validation ---
+# --- Tool selection ---
 $validTools = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara', 'maester', 'scorecard')
 $azureScopedTools = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara')
 
 if ($IncludeTools -and $ExcludeTools) {
     throw "Cannot use both -IncludeTools and -ExcludeTools. Use one or the other."
 }
-
 foreach ($t in @($IncludeTools) + @($ExcludeTools) | Where-Object { $_ }) {
-    if ($t -notin $validTools) {
-        throw "Unknown tool '$t'. Valid tools: $($validTools -join ', ')"
-    }
+    if ($t -notin $validTools) { throw "Unknown tool '$t'. Valid: $($validTools -join ', ')" }
 }
 
-function ShouldRunTool {
-    param ([string]$ToolName)
+function ShouldRunTool { param ([string]$ToolName)
     if ($IncludeTools) { return $ToolName -in $IncludeTools }
     if ($ExcludeTools) { return $ToolName -notin $ExcludeTools }
     return $true
 }
 
-# Only require Azure scope if at least one Azure-scoped tool will run
 $needsAzureScope = $azureScopedTools | Where-Object { ShouldRunTool $_ }
 if ($needsAzureScope -and -not $SubscriptionId -and -not $ManagementGroupId) {
     throw "At least one of -SubscriptionId or -ManagementGroupId is required for: $($needsAzureScope -join ', ')."
@@ -111,6 +97,7 @@ Write-Host "=== Azure Analyzer ===" -ForegroundColor Cyan
 $allResults = [System.Collections.Generic.List[PSCustomObject]]::new()
 
 # --- azqr ---
+if (ShouldRunTool 'azqr') {
 if ($SubscriptionId) {
     Write-Host "`n[1/7] Running azqr..." -ForegroundColor Yellow
     $azqrResult = Invoke-Wrapper -Script 'Invoke-Azqr.ps1' -Params @{ SubscriptionId = $SubscriptionId }
@@ -130,8 +117,12 @@ if ($SubscriptionId) {
     }
     Write-Host "  azqr: $($azqrResult.Findings.Count) findings" -ForegroundColor Gray
 }
+} else {
+    Write-Host "`n[1/7] Skipping azqr (excluded)" -ForegroundColor DarkGray
+}
 
 # --- PSRule ---
+if (ShouldRunTool 'psrule') {
 Write-Host "`n[2/7] Running PSRule..." -ForegroundColor Yellow
 $psruleParams = if ($SubscriptionId) { @{ SubscriptionId = $SubscriptionId } } else { @{ Path = '.' } }
 $psruleResult = Invoke-Wrapper -Script 'Invoke-PSRule.ps1' -Params $psruleParams
@@ -150,8 +141,12 @@ foreach ($f in $psruleResult.Findings) {
     })
 }
 Write-Host "  PSRule: $($psruleResult.Findings.Count) findings" -ForegroundColor Gray
+} else {
+    Write-Host "`n[2/7] Skipping psrule (excluded)" -ForegroundColor DarkGray
+}
 
 # --- AzGovViz ---
+if (ShouldRunTool 'azgovviz') {
 if ($ManagementGroupId) {
     Write-Host "`n[3/7] Running AzGovViz..." -ForegroundColor Yellow
     $azgovvizResult = Invoke-Wrapper -Script 'Invoke-AzGovViz.ps1' -Params @{ ManagementGroupId = $ManagementGroupId }
@@ -173,8 +168,12 @@ if ($ManagementGroupId) {
 } else {
     Write-Host "`n[3/7] Skipping AzGovViz (no ManagementGroupId provided)" -ForegroundColor DarkGray
 }
+} else {
+    Write-Host "`n[3/7] Skipping azgovviz (excluded)" -ForegroundColor DarkGray
+}
 
 # --- ALZ Queries ---
+if (ShouldRunTool 'alz-queries') {
 Write-Host "`n[4/7] Running ALZ queries..." -ForegroundColor Yellow
 $alzParams = if ($ManagementGroupId) {
     @{ ManagementGroupId = $ManagementGroupId }
@@ -197,8 +196,12 @@ foreach ($f in $alzResult.Findings) {
     })
 }
 Write-Host "  ALZ queries: $($alzResult.Findings.Count) findings" -ForegroundColor Gray
+} else {
+    Write-Host "`n[4/7] Skipping alz-queries (excluded)" -ForegroundColor DarkGray
+}
 
 # --- WARA ---
+if (ShouldRunTool 'wara') {
 if ($SubscriptionId) {
     Write-Host "`n[5/7] Running WARA..." -ForegroundColor Yellow
     $waraParams = @{ SubscriptionId = $SubscriptionId; OutputPath = (Join-Path $OutputPath 'wara') }
@@ -222,8 +225,12 @@ if ($SubscriptionId) {
 } else {
     Write-Host "`n[5/7] Skipping WARA (no SubscriptionId provided)" -ForegroundColor DarkGray
 }
+} else {
+    Write-Host "`n[5/7] Skipping wara (excluded)" -ForegroundColor DarkGray
+}
 
 # --- Maester ---
+if (ShouldRunTool 'maester') {
 Write-Host "`n[6/7] Running Maester..." -ForegroundColor Yellow
 $maesterResult = Invoke-Wrapper -Script 'Invoke-Maester.ps1' -Params @{}
 foreach ($f in $maesterResult.Findings) {
@@ -241,30 +248,10 @@ foreach ($f in $maesterResult.Findings) {
     })
 }
 Write-Host "  Maester: $($maesterResult.Findings.Count) findings" -ForegroundColor Gray
-
-
-# --- Scorecard ---
-if ($Repository) {
-    Write-Host "`n[7/7] Running Scorecard..." -ForegroundColor Yellow
-    $scorecardResult = Invoke-Wrapper -Script 'Invoke-Scorecard.ps1' -Params @{ Repository = $Repository; Threshold = $ScorecardThreshold }
-    foreach ($f in $scorecardResult.Findings) {
-        $allResults.Add([PSCustomObject]@{
-            Id           = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())
-            Source       = 'scorecard'
-            Category     = Get-Prop $f 'Category' 'Supply Chain'
-            Title        = Get-Prop $f 'Title' 'Unknown'
-            Severity     = Map-Severity (Get-Prop $f 'Severity' 'Medium')
-            Compliant    = $f.Compliant
-            Detail       = Get-Prop $f 'Detail' ''
-            Remediation  = Get-Prop $f 'Remediation' ''
-            ResourceId   = Get-Prop $f 'ResourceId' ''
-            LearnMoreUrl = Get-Prop $f 'LearnMoreUrl' ''
-        })
-    }
-    Write-Host "  Scorecard: $($scorecardResult.Findings.Count) findings" -ForegroundColor Gray
 } else {
-    Write-Host "`n[7/7] Skipping Scorecard (no -Repository provided)" -ForegroundColor DarkGray
+    Write-Host "`n[6/7] Skipping maester (excluded)" -ForegroundColor DarkGray
 }
+
 # --- Write output ---
 try {
     if (-not (Test-Path $OutputPath)) {
@@ -299,5 +286,5 @@ $low = ($allResults | Where-Object { $_.Severity -eq 'Low' -and -not $_.Complian
 
 Write-Host "`n=== Summary ===" -ForegroundColor Cyan
 Write-Host "  Total findings: $($allResults.Count)"
-Write-Host "  Non-compliant — High: $high  Medium: $medium  Low: $low" -ForegroundColor Yellow
+Write-Host "  Non-compliant ÔÇö High: $high  Medium: $medium  Low: $low" -ForegroundColor Yellow
 Write-Host "  Output: $outputFile" -ForegroundColor Green

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -17,6 +17,8 @@
 .PARAMETER Repository
     GitHub repository to scan with OpenSSF Scorecard (e.g., "github.com/org/repo").
     If not provided, Scorecard is skipped.
+.PARAMETER ScorecardThreshold
+    Minimum score (0-10) to mark a Scorecard check as compliant. Default is 7.
 .PARAMETER OutputPath
     Output directory for results.json. Defaults to .\output.
 .EXAMPLE
@@ -31,6 +33,8 @@ param (
     [string] $ManagementGroupId,
     [string] $TenantId,
     [string] $Repository,
+    [ValidateRange(0, 10)]
+    [int] $ScorecardThreshold = 7,
     [string] $OutputPath = (Join-Path $PSScriptRoot 'output')
 )
 
@@ -217,7 +221,7 @@ Write-Host "  Maester: $($maesterResult.Findings.Count) findings" -ForegroundCol
 # --- Scorecard ---
 if ($Repository) {
     Write-Host "`n[7/7] Running Scorecard..." -ForegroundColor Yellow
-    $scorecardResult = Invoke-Wrapper -Script 'Invoke-Scorecard.ps1' -Params @{ Repository = $Repository }
+    $scorecardResult = Invoke-Wrapper -Script 'Invoke-Scorecard.ps1' -Params @{ Repository = $Repository; Threshold = $ScorecardThreshold }
     foreach ($f in $scorecardResult.Findings) {
         $allResults.Add([PSCustomObject]@{
             Id           = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -14,12 +14,16 @@
     Management group ID. Used by AzGovViz and alz-queries.
 .PARAMETER TenantId
     Azure tenant ID. Used by WARA collector. Defaults to current Az context tenant.
+.PARAMETER Repository
+    GitHub repository to scan with OpenSSF Scorecard (e.g., "github.com/org/repo").
+    If not provided, Scorecard is skipped.
 .PARAMETER OutputPath
     Output directory for results.json. Defaults to .\output.
 .EXAMPLE
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "00000000-0000-0000-0000-000000000000"
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ManagementGroupId "my-mg"
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -TenantId "..."
+    .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -Repository "github.com/org/repo"
 #>
 [CmdletBinding()]
 param (
@@ -209,6 +213,29 @@ foreach ($f in $maesterResult.Findings) {
 }
 Write-Host "  Maester: $($maesterResult.Findings.Count) findings" -ForegroundColor Gray
 
+
+# --- Scorecard ---
+if ($Repository) {
+    Write-Host "`n[7/7] Running Scorecard..." -ForegroundColor Yellow
+    $scorecardResult = Invoke-Wrapper -Script 'Invoke-Scorecard.ps1' -Params @{ Repository = $Repository }
+    foreach ($f in $scorecardResult.Findings) {
+        $allResults.Add([PSCustomObject]@{
+            Id           = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())
+            Source       = 'scorecard'
+            Category     = Get-Prop $f 'Category' 'Supply Chain'
+            Title        = Get-Prop $f 'Title' 'Unknown'
+            Severity     = Map-Severity (Get-Prop $f 'Severity' 'Medium')
+            Compliant    = $f.Compliant
+            Detail       = Get-Prop $f 'Detail' ''
+            Remediation  = Get-Prop $f 'Remediation' ''
+            ResourceId   = Get-Prop $f 'ResourceId' ''
+            LearnMoreUrl = Get-Prop $f 'LearnMoreUrl' ''
+        })
+    }
+    Write-Host "  Scorecard: $($scorecardResult.Findings.Count) findings" -ForegroundColor Gray
+} else {
+    Write-Host "`n[7/7] Skipping Scorecard (no -Repository provided)" -ForegroundColor DarkGray
+}
 # --- Write output ---
 try {
     if (-not (Test-Path $OutputPath)) {

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -16,10 +16,16 @@
     Azure tenant ID. Used by WARA collector. Defaults to current Az context tenant.
 .PARAMETER OutputPath
     Output directory for results.json. Defaults to .\output.
+.PARAMETER Repository
+    GitHub repository to scan with OpenSSF Scorecard (e.g. "github.com/org/repo").
+    Required for Scorecard tool; ignored by Azure-scoped tools.
+.PARAMETER EnableAiTriage
+    When set, enriches non-compliant findings via GitHub Copilot SDK with priority
+    ranking, risk context, and remediation steps. Requires a GitHub Copilot license.
 .EXAMPLE
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "00000000-0000-0000-0000-000000000000"
     .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ManagementGroupId "my-mg"
-    .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -TenantId "..."
+    .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -Repository "github.com/org/repo"
 #>
 [CmdletBinding()]
 param (
@@ -31,7 +37,9 @@ param (
     [string[]] $ExcludeTools,
     [switch] $SkipPrereqCheck,
     [switch] $InstallMissingModules,
-    [switch] $Recurse
+    [switch] $Recurse,
+    [string] $Repository,
+    [switch] $EnableAiTriage
 )
 
 Set-StrictMode -Version Latest
@@ -57,6 +65,7 @@ function ShouldRunTool { param ([string]$ToolName)
 $needsAzureScope = $azureScopedTools | Where-Object { ShouldRunTool $_ }
 if ($needsAzureScope -and -not $SubscriptionId -and -not $ManagementGroupId) {
     throw "At least one of -SubscriptionId or -ManagementGroupId is required for: $($needsAzureScope -join ', ')."
+}
 
 # --- Management group subscription discovery ---
 function Get-ChildSubscriptions {
@@ -85,7 +94,6 @@ if ($shouldRecurse) {
     Write-Host "Discovered $($subscriptionsToScan.Count) subscription(s) under management group '$ManagementGroupId'" -ForegroundColor Cyan
 } elseif ($ManagementGroupId -and -not $shouldRecurse) {
     Write-Host "Management group '$ManagementGroupId' provided without -Recurse; subscription-scoped tools will only scan explicitly provided subscriptions" -ForegroundColor DarkGray
-}
 }
 
 # --- Prerequisite check ---
@@ -147,8 +155,11 @@ function Invoke-Wrapper {
     for ($attempt = 1; $attempt -le ($MaxRetries + 1); $attempt++) {
         try {
             $result = & $scriptPath @Params
-            if ($result.Findings.Count -gt 0 -or $attempt -gt $MaxRetries) { return $result }
-            Write-Warning "$Script returned 0 findings (attempt $attempt/$($MaxRetries+1)), retrying..."
+            # Return immediately on Success or Skipped — only retry on Failed status
+            $status = if ($result.PSObject.Properties['Status']) { $result.Status } else { $null }
+            if ($status -in @('Success', 'Skipped')) { return $result }
+            if ($attempt -gt $MaxRetries) { return $result }
+            Write-Warning "$Script returned status '$status' (attempt $attempt/$($MaxRetries+1)), retrying..."
             Start-Sleep -Seconds $RetryDelaySec
         } catch {
             if ($attempt -le $MaxRetries) {
@@ -377,6 +388,32 @@ Write-Host "  Maester: $($maesterResult.Findings.Count) findings" -ForegroundCol
     Write-Host "`n[6/7] Skipping maester (excluded)" -ForegroundColor DarkGray
 }
 
+# --- Scorecard ---
+if (ShouldRunTool 'scorecard') {
+    if ($Repository) {
+        Write-Host "`n[7/7] Running Scorecard..." -ForegroundColor Yellow
+        $scorecardResult = Invoke-Wrapper -Script 'Invoke-Scorecard.ps1' -Params @{ Repository = $Repository }
+        foreach ($f in $scorecardResult.Findings) {
+            $allResults.Add([PSCustomObject]@{
+                Id           = $f.Id ?? [guid]::NewGuid().ToString()
+                Source       = 'scorecard'
+                Category     = $f.Category ?? 'Supply Chain'
+                Title        = $f.Title ?? 'Unknown'
+                Severity     = Map-Severity ($f.Severity ?? 'Medium')
+                Compliant    = $f.Compliant
+                Detail       = $f.Detail ?? ''
+                Remediation  = $f.Remediation ?? ''
+                ResourceId   = $f.ResourceId ?? ''
+                LearnMoreUrl = $f.LearnMoreUrl ?? ''
+            })
+        }
+        Write-Host "  Scorecard: $($scorecardResult.Findings.Count) findings" -ForegroundColor Gray
+    } else {
+        Write-Host "`n[7/7] Skipping Scorecard (no -Repository provided)" -ForegroundColor DarkGray
+    }
+} else {
+    Write-Host "`n[7/7] Skipping Scorecard (excluded)" -ForegroundColor DarkGray
+}
 
 # --- Deduplicate cross-tool findings ---
 $preDedup = $allResults.Count

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -30,7 +30,8 @@ param (
     [string[]] $IncludeTools,
     [string[]] $ExcludeTools,
     [switch] $SkipPrereqCheck,
-    [switch] $InstallMissingModules
+    [switch] $InstallMissingModules,
+    [switch] $Recurse
 )
 
 Set-StrictMode -Version Latest
@@ -56,6 +57,35 @@ function ShouldRunTool { param ([string]$ToolName)
 $needsAzureScope = $azureScopedTools | Where-Object { ShouldRunTool $_ }
 if ($needsAzureScope -and -not $SubscriptionId -and -not $ManagementGroupId) {
     throw "At least one of -SubscriptionId or -ManagementGroupId is required for: $($needsAzureScope -join ', ')."
+
+# --- Management group subscription discovery ---
+function Get-ChildSubscriptions {
+    param ([string]$ManagementGroupId)
+    $query = "resourcecontainers | where type == 'microsoft.resources/subscriptions'"
+    try {
+        $subs = Search-AzGraph -Query $query -ManagementGroup $ManagementGroupId -First 1000 -ErrorAction Stop
+        return @($subs | Select-Object -ExpandProperty subscriptionId -Unique)
+    } catch {
+        Write-Warning "Failed to enumerate subscriptions under $ManagementGroupId : $_"
+        return @()
+    }
+}
+
+# Build list of subscriptions to scan
+$subscriptionsToScan = [System.Collections.Generic.List[string]]::new()
+if ($SubscriptionId) { $subscriptionsToScan.Add($SubscriptionId) }
+
+# Recurse into MG by default when ManagementGroupId is provided
+$shouldRecurse = $ManagementGroupId -and (-not $PSBoundParameters.ContainsKey('Recurse') -or $Recurse)
+if ($shouldRecurse) {
+    $childSubs = Get-ChildSubscriptions -ManagementGroupId $ManagementGroupId
+    foreach ($cs in $childSubs) {
+        if ($cs -notin $subscriptionsToScan) { $subscriptionsToScan.Add($cs) }
+    }
+    Write-Host "Discovered $($subscriptionsToScan.Count) subscription(s) under management group '$ManagementGroupId'" -ForegroundColor Cyan
+} elseif ($ManagementGroupId -and -not $shouldRecurse) {
+    Write-Host "Management group '$ManagementGroupId' provided without -Recurse; subscription-scoped tools will only scan explicitly provided subscriptions" -ForegroundColor DarkGray
+}
 }
 
 # --- Prerequisite check ---
@@ -177,55 +207,65 @@ Write-Host "=== Azure Analyzer ===" -ForegroundColor Cyan
 
 $allResults = [System.Collections.Generic.List[PSCustomObject]]::new()
 
+
 # --- azqr ---
 if (ShouldRunTool 'azqr') {
-if ($SubscriptionId) {
-    Write-Host "`n[1/7] Running azqr..." -ForegroundColor Yellow
-    $azqrResult = Invoke-Wrapper -Script 'Invoke-Azqr.ps1' -Params @{ SubscriptionId = $SubscriptionId }
-    foreach ($f in $azqrResult.Findings) {
-        $allResults.Add([PSCustomObject]@{
-            Id           = [guid]::NewGuid().ToString()
-            Source       = 'azqr'
-            Category     = Get-Prop $f 'Category' (Get-Prop $f 'ServiceCategory' 'General')
-            Title        = Get-Prop $f 'Recommendation' (Get-Prop $f 'Description' ($f | ConvertTo-Json -Compress -ErrorAction SilentlyContinue))
-            Severity     = Map-Severity (Get-Prop $f 'Severity' (Get-Prop $f 'Risk' 'Info'))
-            Compliant    = ((Get-Prop $f 'Result') -eq 'OK') -or ((Get-Prop $f 'Compliant') -eq $true)
-            Detail       = Get-Prop $f 'Notes' (Get-Prop $f 'Description' '')
-            Remediation  = Get-Prop $f 'Url' ''
-            ResourceId   = Get-Prop $f 'ResourceId' (Get-Prop $f 'Id' '')
-            LearnMoreUrl = Get-Prop $f 'LearnMoreLink' (Get-Prop $f 'Url' '')
-        })
+    if ($subscriptionsToScan.Count -gt 0) {
+        Write-Host "`n[1/7] Running azqr..." -ForegroundColor Yellow
+        foreach ($subId in $subscriptionsToScan) {
+            if ($subscriptionsToScan.Count -gt 1) { Write-Host "  Scanning subscription: $subId" -ForegroundColor Gray }
+            $azqrResult = Invoke-Wrapper -Script 'Invoke-Azqr.ps1' -Params @{ SubscriptionId = $subId }
+            foreach ($f in $azqrResult.Findings) {
+                $allResults.Add([PSCustomObject]@{
+                    Id           = [guid]::NewGuid().ToString()
+                    Source       = 'azqr'
+                    Category     = Get-Prop $f 'Category' (Get-Prop $f 'ServiceCategory' 'General')
+                    Title        = Get-Prop $f 'Recommendation' (Get-Prop $f 'Description' ($f | ConvertTo-Json -Compress -ErrorAction SilentlyContinue))
+                    Severity     = Map-Severity (Get-Prop $f 'Severity' (Get-Prop $f 'Risk' 'Info'))
+                    Compliant    = ((Get-Prop $f 'Result') -eq 'OK') -or ((Get-Prop $f 'Compliant') -eq $true)
+                    Detail       = Get-Prop $f 'Notes' (Get-Prop $f 'Description' '')
+                    Remediation  = Get-Prop $f 'Url' ''
+                    ResourceId   = Get-Prop $f 'ResourceId' (Get-Prop $f 'Id' '')
+                    LearnMoreUrl = Get-Prop $f 'LearnMoreLink' (Get-Prop $f 'Url' '')
+                })
+            }
+        }
+        $azqrTotal = ($allResults | Where-Object { $_.Source -eq 'azqr' }).Count
+        Write-Host "  azqr: $azqrTotal findings" -ForegroundColor Gray
+    } else {
+        Write-Host "`n[1/7] Skipping azqr (no subscriptions to scan)" -ForegroundColor DarkGray
     }
-    Write-Host "  azqr: $($azqrResult.Findings.Count) findings" -ForegroundColor Gray
-}
 } else {
     Write-Host "`n[1/7] Skipping azqr (excluded)" -ForegroundColor DarkGray
 }
 
 # --- PSRule ---
 if (ShouldRunTool 'psrule') {
-Write-Host "`n[2/7] Running PSRule..." -ForegroundColor Yellow
-$psruleParams = if ($SubscriptionId) { @{ SubscriptionId = $SubscriptionId } } else { @{ Path = '.' } }
-$psruleResult = Invoke-Wrapper -Script 'Invoke-PSRule.ps1' -Params $psruleParams
-foreach ($f in $psruleResult.Findings) {
-    $allResults.Add([PSCustomObject]@{
-        Id           = [guid]::NewGuid().ToString()
-        Source       = 'psrule'
-        Category     = Get-Prop $f 'RuleName' 'PSRule'
-        Title        = Get-Prop $f 'RuleName' 'Unknown rule'
-        Severity     = Map-Severity (Get-Prop $f 'Outcome' 'Info')
-        Compliant    = (Get-Prop $f 'Outcome') -eq 'Pass'
-        Detail       = Get-Prop $f 'Message' (Get-Prop $f 'TargetName' '')
-        Remediation  = ''
-        ResourceId   = Get-Prop $f 'ResourceId' ''
-        LearnMoreUrl = Get-Prop $f 'LearnMoreUrl' ''
-    })
-}
-Write-Host "  PSRule: $($psruleResult.Findings.Count) findings" -ForegroundColor Gray
+    Write-Host "`n[2/7] Running PSRule..." -ForegroundColor Yellow
+    foreach ($subId in ($subscriptionsToScan.Count -gt 0 ? $subscriptionsToScan : @($null))) {
+        $psruleParams = if ($subId) { @{ SubscriptionId = $subId } } else { @{ Path = '.' } }
+        if ($subId -and $subscriptionsToScan.Count -gt 1) { Write-Host "  Scanning subscription: $subId" -ForegroundColor Gray }
+        $psruleResult = Invoke-Wrapper -Script 'Invoke-PSRule.ps1' -Params $psruleParams
+        foreach ($f in $psruleResult.Findings) {
+            $allResults.Add([PSCustomObject]@{
+                Id           = [guid]::NewGuid().ToString()
+                Source       = 'psrule'
+                Category     = Get-Prop $f 'RuleName' 'PSRule'
+                Title        = Get-Prop $f 'RuleName' 'Unknown rule'
+                Severity     = Map-Severity (Get-Prop $f 'Outcome' 'Info')
+                Compliant    = (Get-Prop $f 'Outcome') -eq 'Pass'
+                Detail       = Get-Prop $f 'Message' (Get-Prop $f 'TargetName' '')
+                Remediation  = ''
+                ResourceId   = Get-Prop $f 'ResourceId' ''
+                LearnMoreUrl = Get-Prop $f 'LearnMoreUrl' ''
+            })
+        }
+    }
+    $psruleTotal = ($allResults | Where-Object { $_.Source -eq 'psrule' }).Count
+    Write-Host "  PSRule: $psruleTotal findings" -ForegroundColor Gray
 } else {
     Write-Host "`n[2/7] Skipping psrule (excluded)" -ForegroundColor DarkGray
 }
-
 # --- AzGovViz ---
 if (ShouldRunTool 'azgovviz') {
 if ($ManagementGroupId) {
@@ -281,35 +321,39 @@ Write-Host "  ALZ queries: $($alzResult.Findings.Count) findings" -ForegroundCol
     Write-Host "`n[4/7] Skipping alz-queries (excluded)" -ForegroundColor DarkGray
 }
 
+
 # --- WARA ---
 if (ShouldRunTool 'wara') {
-if ($SubscriptionId) {
-    Write-Host "`n[5/7] Running WARA..." -ForegroundColor Yellow
-    $waraParams = @{ SubscriptionId = $SubscriptionId; OutputPath = (Join-Path $OutputPath 'wara') }
-    if ($TenantId) { $waraParams['TenantId'] = $TenantId }
-    $waraResult = Invoke-Wrapper -Script 'Invoke-WARA.ps1' -Params $waraParams
-    foreach ($f in $waraResult.Findings) {
-        $allResults.Add([PSCustomObject]@{
-            Id           = $f.Id ?? [guid]::NewGuid().ToString()
-            Source       = 'wara'
-            Category     = $f.Category ?? 'Reliability'
-            Title        = $f.Title ?? 'Unknown'
-            Severity     = Map-Severity ($f.Severity ?? 'Medium')
-            Compliant    = $f.Compliant
-            Detail       = $f.Detail ?? ''
-            Remediation  = $f.Remediation ?? ''
-            ResourceId   = $f.ResourceId ?? ''
-            LearnMoreUrl = $f.LearnMoreUrl ?? ''
-        })
+    if ($subscriptionsToScan.Count -gt 0) {
+        Write-Host "`n[5/7] Running WARA..." -ForegroundColor Yellow
+        foreach ($subId in $subscriptionsToScan) {
+            if ($subscriptionsToScan.Count -gt 1) { Write-Host "  Scanning subscription: $subId" -ForegroundColor Gray }
+            $waraParams = @{ SubscriptionId = $subId; OutputPath = (Join-Path $OutputPath 'wara') }
+            if ($TenantId) { $waraParams['TenantId'] = $TenantId }
+            $waraResult = Invoke-Wrapper -Script 'Invoke-WARA.ps1' -Params $waraParams
+            foreach ($f in $waraResult.Findings) {
+                $allResults.Add([PSCustomObject]@{
+                    Id           = $f.Id ?? [guid]::NewGuid().ToString()
+                    Source       = 'wara'
+                    Category     = $f.Category ?? 'Reliability'
+                    Title        = $f.Title ?? 'Unknown'
+                    Severity     = Map-Severity ($f.Severity ?? 'Medium')
+                    Compliant    = $f.Compliant
+                    Detail       = $f.Detail ?? ''
+                    Remediation  = $f.Remediation ?? ''
+                    ResourceId   = $f.ResourceId ?? ''
+                    LearnMoreUrl = $f.LearnMoreUrl ?? ''
+                })
+            }
+        }
+        $waraTotal = ($allResults | Where-Object { $_.Source -eq 'wara' }).Count
+        Write-Host "  WARA: $waraTotal findings" -ForegroundColor Gray
+    } else {
+        Write-Host "`n[5/7] Skipping WARA (no subscriptions to scan)" -ForegroundColor DarkGray
     }
-    Write-Host "  WARA: $($waraResult.Findings.Count) findings" -ForegroundColor Gray
-} else {
-    Write-Host "`n[5/7] Skipping WARA (no SubscriptionId provided)" -ForegroundColor DarkGray
-}
 } else {
     Write-Host "`n[5/7] Skipping wara (excluded)" -ForegroundColor DarkGray
 }
-
 # --- Maester ---
 if (ShouldRunTool 'maester') {
 Write-Host "`n[6/7] Running Maester..." -ForegroundColor Yellow

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -3,8 +3,9 @@
 .SYNOPSIS
     Azure Analyzer — unified Azure assessment orchestrator.
 .DESCRIPTION
-    Calls all five assessment tool wrappers (azqr, PSRule, AzGovViz, alz-queries, WARA),
-    merges results into a unified schema, and writes output/results.json.
+    Calls all seven assessment tool wrappers (azqr, PSRule, AzGovViz, alz-queries,
+    WARA, Maester, Scorecard), merges results into a unified schema, and writes
+    output/results.json.
     At least one of -SubscriptionId or -ManagementGroupId is required.
     Tools that are not installed are skipped gracefully.
 .PARAMETER SubscriptionId
@@ -78,7 +79,7 @@ $allResults = [System.Collections.Generic.List[PSCustomObject]]::new()
 
 # --- azqr ---
 if ($SubscriptionId) {
-    Write-Host "`n[1/5] Running azqr..." -ForegroundColor Yellow
+    Write-Host "`n[1/7] Running azqr..." -ForegroundColor Yellow
     $azqrResult = Invoke-Wrapper -Script 'Invoke-Azqr.ps1' -Params @{ SubscriptionId = $SubscriptionId }
     foreach ($f in $azqrResult.Findings) {
         $allResults.Add([PSCustomObject]@{
@@ -98,7 +99,7 @@ if ($SubscriptionId) {
 }
 
 # --- PSRule ---
-Write-Host "`n[2/5] Running PSRule..." -ForegroundColor Yellow
+Write-Host "`n[2/7] Running PSRule..." -ForegroundColor Yellow
 $psruleParams = if ($SubscriptionId) { @{ SubscriptionId = $SubscriptionId } } else { @{ Path = '.' } }
 $psruleResult = Invoke-Wrapper -Script 'Invoke-PSRule.ps1' -Params $psruleParams
 foreach ($f in $psruleResult.Findings) {
@@ -119,7 +120,7 @@ Write-Host "  PSRule: $($psruleResult.Findings.Count) findings" -ForegroundColor
 
 # --- AzGovViz ---
 if ($ManagementGroupId) {
-    Write-Host "`n[3/5] Running AzGovViz..." -ForegroundColor Yellow
+    Write-Host "`n[3/7] Running AzGovViz..." -ForegroundColor Yellow
     $azgovvizResult = Invoke-Wrapper -Script 'Invoke-AzGovViz.ps1' -Params @{ ManagementGroupId = $ManagementGroupId }
     foreach ($f in $azgovvizResult.Findings) {
         $allResults.Add([PSCustomObject]@{
@@ -137,75 +138,44 @@ if ($ManagementGroupId) {
     }
     Write-Host "  AzGovViz: $($azgovvizResult.Findings.Count) findings" -ForegroundColor Gray
 } else {
-    Write-Host "`n[3/5] Skipping AzGovViz (no ManagementGroupId provided)" -ForegroundColor DarkGray
+    Write-Host "`n[3/7] Skipping AzGovViz (no ManagementGroupId provided)" -ForegroundColor DarkGray
 }
 
 # --- ALZ Queries ---
-if (ShouldRunTool 'alz-queries') {
-    Write-Host "`n[4/7] Running ALZ queries..." -ForegroundColor Yellow
-    $alzParams = if ($ManagementGroupId) {
-        @{ ManagementGroupId = $ManagementGroupId }
-    } else {
-        @{ SubscriptionId = $SubscriptionId }
-    }
-    $alzResult = Invoke-Wrapper -Script 'Invoke-AlzQueries.ps1' -Params $alzParams
-    foreach ($f in $alzResult.Findings) {
-        $allResults.Add([PSCustomObject]@{
-            Id           = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())
-            Source       = 'alz-queries'
-            Category     = Get-Prop $f 'Category' 'ALZ'
-            Title        = Get-Prop $f 'Title' 'Unknown'
-            Severity     = Map-Severity (Get-Prop $f 'Severity' 'Medium')
-            Compliant    = $f.Compliant
-            Detail       = Get-Prop $f 'Detail' ''
-            Remediation  = ''
-            ResourceId   = Get-Prop $f 'ResourceId' ''
-            LearnMoreUrl = Get-Prop $f 'LearnMoreUrl' ''
-        })
-    }
-    Write-Host "  ALZ queries: $($alzResult.Findings.Count) findings" -ForegroundColor Gray
+Write-Host "`n[4/7] Running ALZ queries..." -ForegroundColor Yellow
+$alzParams = if ($ManagementGroupId) {
+    @{ ManagementGroupId = $ManagementGroupId }
 } else {
-    Write-Host "`n[4/7] Skipping ALZ queries (excluded)" -ForegroundColor DarkGray
+    @{ SubscriptionId = $SubscriptionId }
 }
+$alzResult = Invoke-Wrapper -Script 'Invoke-AlzQueries.ps1' -Params $alzParams
+foreach ($f in $alzResult.Findings) {
+    $allResults.Add([PSCustomObject]@{
+        Id           = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())
+        Source       = 'alz-queries'
+        Category     = Get-Prop $f 'Category' 'ALZ'
+        Title        = Get-Prop $f 'Title' 'Unknown'
+        Severity     = Map-Severity (Get-Prop $f 'Severity' 'Medium')
+        Compliant    = $f.Compliant
+        Detail       = Get-Prop $f 'Detail' ''
+        Remediation  = ''
+        ResourceId   = Get-Prop $f 'ResourceId' ''
+        LearnMoreUrl = Get-Prop $f 'LearnMoreUrl' ''
+    })
+}
+Write-Host "  ALZ queries: $($alzResult.Findings.Count) findings" -ForegroundColor Gray
 
 # --- WARA ---
-if (ShouldRunTool 'wara') {
-    if ($SubscriptionId) {
-        Write-Host "`n[5/7] Running WARA..." -ForegroundColor Yellow
-        $waraParams = @{ SubscriptionId = $SubscriptionId; OutputPath = (Join-Path $OutputPath 'wara') }
-        if ($TenantId) { $waraParams['TenantId'] = $TenantId }
-        $waraResult = Invoke-Wrapper -Script 'Invoke-WARA.ps1' -Params $waraParams
-        foreach ($f in $waraResult.Findings) {
-            $allResults.Add([PSCustomObject]@{
-                Id           = $f.Id ?? [guid]::NewGuid().ToString()
-                Source       = 'wara'
-                Category     = $f.Category ?? 'Reliability'
-                Title        = $f.Title ?? 'Unknown'
-                Severity     = Map-Severity ($f.Severity ?? 'Medium')
-                Compliant    = $f.Compliant
-                Detail       = $f.Detail ?? ''
-                Remediation  = $f.Remediation ?? ''
-                ResourceId   = $f.ResourceId ?? ''
-                LearnMoreUrl = $f.LearnMoreUrl ?? ''
-            })
-        }
-        Write-Host "  WARA: $($waraResult.Findings.Count) findings" -ForegroundColor Gray
-    } else {
-        Write-Host "`n[5/7] Skipping WARA (no SubscriptionId provided)" -ForegroundColor DarkGray
-    }
-} else {
-    Write-Host "`n[5/7] Skipping WARA (excluded)" -ForegroundColor DarkGray
-}
-
-# --- Maester ---
-if (ShouldRunTool 'maester') {
-    Write-Host "`n[6/7] Running Maester..." -ForegroundColor Yellow
-    $maesterResult = Invoke-Wrapper -Script 'Invoke-Maester.ps1' -Params @{}
-    foreach ($f in $maesterResult.Findings) {
+if ($SubscriptionId) {
+    Write-Host "`n[5/7] Running WARA..." -ForegroundColor Yellow
+    $waraParams = @{ SubscriptionId = $SubscriptionId; OutputPath = (Join-Path $OutputPath 'wara') }
+    if ($TenantId) { $waraParams['TenantId'] = $TenantId }
+    $waraResult = Invoke-Wrapper -Script 'Invoke-WARA.ps1' -Params $waraParams
+    foreach ($f in $waraResult.Findings) {
         $allResults.Add([PSCustomObject]@{
             Id           = $f.Id ?? [guid]::NewGuid().ToString()
-            Source       = 'maester'
-            Category     = $f.Category ?? 'Identity'
+            Source       = 'wara'
+            Category     = $f.Category ?? 'Reliability'
             Title        = $f.Title ?? 'Unknown'
             Severity     = Map-Severity ($f.Severity ?? 'Medium')
             Compliant    = $f.Compliant
@@ -215,10 +185,29 @@ if (ShouldRunTool 'maester') {
             LearnMoreUrl = $f.LearnMoreUrl ?? ''
         })
     }
-    Write-Host "  Maester: $($maesterResult.Findings.Count) findings" -ForegroundColor Gray
+    Write-Host "  WARA: $($waraResult.Findings.Count) findings" -ForegroundColor Gray
 } else {
-    Write-Host "`n[6/7] Skipping Maester (excluded)" -ForegroundColor DarkGray
+    Write-Host "`n[5/7] Skipping WARA (no SubscriptionId provided)" -ForegroundColor DarkGray
 }
+
+# --- Maester ---
+Write-Host "`n[6/7] Running Maester..." -ForegroundColor Yellow
+$maesterResult = Invoke-Wrapper -Script 'Invoke-Maester.ps1' -Params @{}
+foreach ($f in $maesterResult.Findings) {
+    $allResults.Add([PSCustomObject]@{
+        Id           = $f.Id ?? [guid]::NewGuid().ToString()
+        Source       = 'maester'
+        Category     = $f.Category ?? 'Identity'
+        Title        = $f.Title ?? 'Unknown'
+        Severity     = Map-Severity ($f.Severity ?? 'Medium')
+        Compliant    = $f.Compliant
+        Detail       = $f.Detail ?? ''
+        Remediation  = $f.Remediation ?? ''
+        ResourceId   = $f.ResourceId ?? ''
+        LearnMoreUrl = $f.LearnMoreUrl ?? ''
+    })
+}
+Write-Host "  Maester: $($maesterResult.Findings.Count) findings" -ForegroundColor Gray
 
 # --- Write output ---
 try {

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -155,12 +155,14 @@ function Invoke-Wrapper {
     for ($attempt = 1; $attempt -le ($MaxRetries + 1); $attempt++) {
         try {
             $result = & $scriptPath @Params
-            # Return immediately on Success or Skipped — only retry on Failed status
             $status = if ($result.PSObject.Properties['Status']) { $result.Status } else { $null }
-            if ($status -in @('Success', 'Skipped')) { return $result }
-            if ($attempt -gt $MaxRetries) { return $result }
-            Write-Warning "$Script returned status '$status' (attempt $attempt/$($MaxRetries+1)), retrying..."
-            Start-Sleep -Seconds $RetryDelaySec
+            # Only retry on explicit 'Failed' status; everything else returns as-is
+            if ($status -eq 'Failed' -and $attempt -le $MaxRetries) {
+                Write-Warning "$Script returned status 'Failed' (attempt $attempt/$($MaxRetries+1)), retrying..."
+                Start-Sleep -Seconds $RetryDelaySec
+                continue
+            }
+            return $result
         } catch {
             if ($attempt -le $MaxRetries) {
                 Write-Warning "$Script failed (attempt $attempt/$($MaxRetries+1)): $_ — retrying in ${RetryDelaySec}s..."
@@ -395,16 +397,16 @@ if (ShouldRunTool 'scorecard') {
         $scorecardResult = Invoke-Wrapper -Script 'Invoke-Scorecard.ps1' -Params @{ Repository = $Repository }
         foreach ($f in $scorecardResult.Findings) {
             $allResults.Add([PSCustomObject]@{
-                Id           = $f.Id ?? [guid]::NewGuid().ToString()
+                Id           = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())
                 Source       = 'scorecard'
-                Category     = $f.Category ?? 'Supply Chain'
-                Title        = $f.Title ?? 'Unknown'
-                Severity     = Map-Severity ($f.Severity ?? 'Medium')
-                Compliant    = $f.Compliant
-                Detail       = $f.Detail ?? ''
-                Remediation  = $f.Remediation ?? ''
-                ResourceId   = $f.ResourceId ?? ''
-                LearnMoreUrl = $f.LearnMoreUrl ?? ''
+                Category     = Get-Prop $f 'Category' 'Supply Chain'
+                Title        = Get-Prop $f 'Title' 'Unknown'
+                Severity     = Map-Severity (Get-Prop $f 'Severity' 'Medium')
+                Compliant    = (Get-Prop $f 'Compliant') -eq $true
+                Detail       = Get-Prop $f 'Detail' ''
+                Remediation  = Get-Prop $f 'Remediation' ''
+                ResourceId   = Get-Prop $f 'ResourceId' ''
+                LearnMoreUrl = Get-Prop $f 'LearnMoreUrl' ''
             })
         }
         Write-Host "  Scorecard: $($scorecardResult.Findings.Count) findings" -ForegroundColor Gray

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -35,14 +35,39 @@ param (
     [string] $Repository,
     [ValidateRange(0, 10)]
     [int] $ScorecardThreshold = 7,
-    [string] $OutputPath = (Join-Path $PSScriptRoot 'output')
+    [string] $OutputPath = (Join-Path $PSScriptRoot 'output'),
+    [string[]] $IncludeTools,
+    [string[]] $ExcludeTools
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not $SubscriptionId -and -not $ManagementGroupId) {
-    throw "At least one of -SubscriptionId or -ManagementGroupId is required."
+# --- Tool selection validation ---
+$validTools = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara', 'maester', 'scorecard')
+$azureScopedTools = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara')
+
+if ($IncludeTools -and $ExcludeTools) {
+    throw "Cannot use both -IncludeTools and -ExcludeTools. Use one or the other."
+}
+
+foreach ($t in @($IncludeTools) + @($ExcludeTools) | Where-Object { $_ }) {
+    if ($t -notin $validTools) {
+        throw "Unknown tool '$t'. Valid tools: $($validTools -join ', ')"
+    }
+}
+
+function ShouldRunTool {
+    param ([string]$ToolName)
+    if ($IncludeTools) { return $ToolName -in $IncludeTools }
+    if ($ExcludeTools) { return $ToolName -notin $ExcludeTools }
+    return $true
+}
+
+# Only require Azure scope if at least one Azure-scoped tool will run
+$needsAzureScope = $azureScopedTools | Where-Object { ShouldRunTool $_ }
+if ($needsAzureScope -and -not $SubscriptionId -and -not $ManagementGroupId) {
+    throw "At least one of -SubscriptionId or -ManagementGroupId is required for: $($needsAzureScope -join ', ')."
 }
 
 $modulesPath = Join-Path $PSScriptRoot 'modules'

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -29,7 +29,8 @@ param (
     [string] $OutputPath = (Join-Path $PSScriptRoot 'output'),
     [string[]] $IncludeTools,
     [string[]] $ExcludeTools,
-    [switch] $SkipPrereqCheck
+    [switch] $SkipPrereqCheck,
+    [switch] $InstallMissingModules
 )
 
 Set-StrictMode -Version Latest
@@ -57,7 +58,7 @@ if ($needsAzureScope -and -not $SubscriptionId -and -not $ManagementGroupId) {
     throw "At least one of -SubscriptionId or -ManagementGroupId is required for: $($needsAzureScope -join ', ')."
 }
 
-# --- Prerequisite auto-install ---
+# --- Prerequisite check ---
 function Install-Prerequisites {
     Write-Host "`n[0/7] Checking prerequisites..." -ForegroundColor Yellow
     $psModules = @(
@@ -67,15 +68,21 @@ function Install-Prerequisites {
         @{ Name = 'WARA'; Tool = 'wara' },
         @{ Name = 'Maester'; Tool = 'maester' }
     )
+    $missing = [System.Collections.Generic.List[string]]::new()
     foreach ($mod in $psModules) {
         if (-not (ShouldRunTool $mod.Tool)) { continue }
         if (-not (Get-Module -ListAvailable -Name $mod.Name -ErrorAction SilentlyContinue)) {
-            Write-Host "  Installing $($mod.Name)..." -ForegroundColor Yellow
-            try {
-                Install-Module $mod.Name -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
-                Write-Host "  ✓ $($mod.Name) installed" -ForegroundColor Green
-            } catch {
-                Write-Warning "Could not install $($mod.Name): $_. $($mod.Tool) may be skipped."
+            if ($InstallMissingModules) {
+                Write-Host "  Installing $($mod.Name)..." -ForegroundColor Yellow
+                try {
+                    Install-Module $mod.Name -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
+                    Write-Host "  ✓ $($mod.Name) installed" -ForegroundColor Green
+                } catch {
+                    Write-Warning "Could not install $($mod.Name): $_. $($mod.Tool) may be skipped."
+                }
+            } else {
+                $missing.Add($mod.Name)
+                Write-Host "  ⚠ $($mod.Name) not found. Install: Install-Module $($mod.Name) -Scope CurrentUser" -ForegroundColor DarkYellow
             }
         }
     }
@@ -88,6 +95,9 @@ function Install-Prerequisites {
         if (-not (Get-Command $cli.Cmd -ErrorAction SilentlyContinue)) {
             Write-Host "  ⚠ $($cli.Name) not found. Install: $($cli.Install)" -ForegroundColor DarkYellow
         }
+    }
+    if ($missing.Count -gt 0 -and -not $InstallMissingModules) {
+        Write-Host "  Tip: Re-run with -InstallMissingModules to auto-install $($missing.Count) missing module(s)" -ForegroundColor DarkGray
     }
 }
 

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -28,7 +28,8 @@ param (
     [string] $TenantId,
     [string] $OutputPath = (Join-Path $PSScriptRoot 'output'),
     [string[]] $IncludeTools,
-    [string[]] $ExcludeTools
+    [string[]] $ExcludeTools,
+    [switch] $SkipPrereqCheck
 )
 
 Set-StrictMode -Version Latest
@@ -55,6 +56,43 @@ $needsAzureScope = $azureScopedTools | Where-Object { ShouldRunTool $_ }
 if ($needsAzureScope -and -not $SubscriptionId -and -not $ManagementGroupId) {
     throw "At least one of -SubscriptionId or -ManagementGroupId is required for: $($needsAzureScope -join ', ')."
 }
+
+# --- Prerequisite auto-install ---
+function Install-Prerequisites {
+    Write-Host "`n[0/7] Checking prerequisites..." -ForegroundColor Yellow
+    $psModules = @(
+        @{ Name = 'Az.ResourceGraph'; Tool = 'alz-queries' },
+        @{ Name = 'PSRule'; Tool = 'psrule' },
+        @{ Name = 'PSRule.Rules.Azure'; Tool = 'psrule' },
+        @{ Name = 'WARA'; Tool = 'wara' },
+        @{ Name = 'Maester'; Tool = 'maester' }
+    )
+    foreach ($mod in $psModules) {
+        if (-not (ShouldRunTool $mod.Tool)) { continue }
+        if (-not (Get-Module -ListAvailable -Name $mod.Name -ErrorAction SilentlyContinue)) {
+            Write-Host "  Installing $($mod.Name)..." -ForegroundColor Yellow
+            try {
+                Install-Module $mod.Name -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
+                Write-Host "  ✓ $($mod.Name) installed" -ForegroundColor Green
+            } catch {
+                Write-Warning "Could not install $($mod.Name): $_. $($mod.Tool) may be skipped."
+            }
+        }
+    }
+    $cliTools = @(
+        @{ Cmd = 'azqr'; Tool = 'azqr'; Name = 'Azure Quick Review'; Install = 'winget install azure-quick-review.azqr' },
+        @{ Cmd = 'scorecard'; Tool = 'scorecard'; Name = 'OpenSSF Scorecard'; Install = 'Download from https://github.com/ossf/scorecard/releases' }
+    )
+    foreach ($cli in $cliTools) {
+        if (-not (ShouldRunTool $cli.Tool)) { continue }
+        if (-not (Get-Command $cli.Cmd -ErrorAction SilentlyContinue)) {
+            Write-Host "  ⚠ $($cli.Name) not found. Install: $($cli.Install)" -ForegroundColor DarkYellow
+        }
+    }
+}
+
+if (-not $SkipPrereqCheck) { Install-Prerequisites }
+
 
 $modulesPath = Join-Path $PSScriptRoot 'modules'
 $toolErrors = [System.Collections.Generic.List[PSCustomObject]]::new()
@@ -306,18 +344,32 @@ try {
     return
 }
 
+# --- AI triage (optional) ---
+$triageFile = Join-Path $OutputPath 'triage.json'
+if ($EnableAiTriage) {
+    Write-Host "`n[AI] Running Copilot triage..." -ForegroundColor Magenta
+    try {
+        $triageResult = & (Join-Path $modulesPath 'Invoke-CopilotTriage.ps1') `
+            -InputPath $outputFile -OutputPath $triageFile
+        if ($null -eq $triageResult) { Write-Warning "AI triage did not produce results." }
+    } catch { Write-Warning "AI triage failed: $_ — continuing without enrichment." }
+} else {
+    if (Test-Path $triageFile) { Remove-Item $triageFile -Force -ErrorAction SilentlyContinue }
+}
+$triageArg = if (Test-Path $triageFile) { @{ TriagePath = $triageFile } } else { @{} }
+
 # --- Generate reports ---
 $htmlReport = Join-Path $OutputPath 'report.html'
 $mdReport   = Join-Path $OutputPath 'report.md'
 
 try {
-    & "$PSScriptRoot\New-HtmlReport.ps1" -InputPath $outputFile -OutputPath $htmlReport
+    & "$PSScriptRoot\New-HtmlReport.ps1" -InputPath $outputFile -OutputPath $htmlReport @triageArg
 } catch {
     Write-Warning "HTML report generation failed: $_"
 }
 
 try {
-    & "$PSScriptRoot\New-MdReport.ps1" -InputPath $outputFile -OutputPath $mdReport
+    & "$PSScriptRoot\New-MdReport.ps1" -InputPath $outputFile -OutputPath $mdReport @triageArg
 } catch {
     Write-Warning "Markdown report generation failed: $_"
 }

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -13,7 +13,8 @@
 [CmdletBinding()]
 param (
     [string] $InputPath = (Join-Path $PSScriptRoot 'output' 'results.json'),
-    [string] $OutputPath = (Join-Path $PSScriptRoot 'output' 'report.html')
+    [string] $OutputPath = (Join-Path $PSScriptRoot 'output' 'report.html'),
+    [string] $TriagePath = ''
 )
 
 Set-StrictMode -Version Latest

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -46,6 +46,19 @@ function SeverityClass([string]$s) {
     }
 }
 
+# --- Load triage data if available ---
+$triageFindings = @()
+$hasTriage = $false
+if ($TriagePath -and (Test-Path $TriagePath)) {
+    try {
+        $triageFindings = @(Get-Content $TriagePath -Raw | ConvertFrom-Json -ErrorAction Stop)
+        $triageFindings = @($triageFindings | Where-Object { $null -ne $_.AiPriority } | Sort-Object AiPriority)
+        if ($triageFindings.Count -gt 0) { $hasTriage = $true }
+    } catch {
+        Write-Warning "Could not load triage data from ${TriagePath}: $_"
+    }
+}
+
 # --- Per-source breakdown data ---
 $allSources = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara', 'maester', 'scorecard')
 $sourceLabels = @{ 'azqr' = 'Azure Quick Review'; 'psrule' = 'PSRule'; 'azgovviz' = 'AzGovViz'; 'alz-queries' = 'ALZ Queries'; 'wara' = 'WARA'; 'maester' = 'Maester'; 'scorecard' = 'Scorecard' }

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -47,9 +47,9 @@ function SeverityClass([string]$s) {
 }
 
 # --- Per-source breakdown data ---
-$allSources = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara', 'maester')
-$sourceLabels = @{ 'azqr' = 'Azure Quick Review'; 'psrule' = 'PSRule'; 'azgovviz' = 'AzGovViz'; 'alz-queries' = 'ALZ Queries'; 'wara' = 'WARA'; 'maester' = 'Maester' }
-$sourceColors = @{ 'azqr' = '#1565c0'; 'psrule' = '#6a1b9a'; 'azgovviz' = '#00838f'; 'alz-queries' = '#e65100'; 'wara' = '#2e7d32'; 'maester' = '#7b1fa2' }
+$allSources = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara', 'maester', 'scorecard')
+$sourceLabels = @{ 'azqr' = 'Azure Quick Review'; 'psrule' = 'PSRule'; 'azgovviz' = 'AzGovViz'; 'alz-queries' = 'ALZ Queries'; 'wara' = 'WARA'; 'maester' = 'Maester'; 'scorecard' = 'Scorecard' }
+$sourceColors = @{ 'azqr' = '#1565c0'; 'psrule' = '#6a1b9a'; 'azgovviz' = '#00838f'; 'alz-queries' = '#e65100'; 'wara' = '#2e7d32'; 'maester' = '#7b1fa2'; 'scorecard' = '#ff6f00' }
 $sourceGroups = $findings | Group-Object -Property Source
 $sourceCountMap = @{}
 foreach ($sg in $sourceGroups) { $sourceCountMap[$sg.Name] = $sg.Count }

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -47,9 +47,9 @@ function SeverityClass([string]$s) {
 }
 
 # --- Per-source breakdown data ---
-$allSources = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara')
-$sourceLabels = @{ 'azqr' = 'Azure Quick Review'; 'psrule' = 'PSRule'; 'azgovviz' = 'AzGovViz'; 'alz-queries' = 'ALZ Queries'; 'wara' = 'WARA' }
-$sourceColors = @{ 'azqr' = '#1565c0'; 'psrule' = '#6a1b9a'; 'azgovviz' = '#00838f'; 'alz-queries' = '#e65100'; 'wara' = '#2e7d32' }
+$allSources = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara', 'maester')
+$sourceLabels = @{ 'azqr' = 'Azure Quick Review'; 'psrule' = 'PSRule'; 'azgovviz' = 'AzGovViz'; 'alz-queries' = 'ALZ Queries'; 'wara' = 'WARA'; 'maester' = 'Maester' }
+$sourceColors = @{ 'azqr' = '#1565c0'; 'psrule' = '#6a1b9a'; 'azgovviz' = '#00838f'; 'alz-queries' = '#e65100'; 'wara' = '#2e7d32'; 'maester' = '#7b1fa2' }
 $sourceGroups = $findings | Group-Object -Property Source
 $sourceCountMap = @{}
 foreach ($sg in $sourceGroups) { $sourceCountMap[$sg.Name] = $sg.Count }

--- a/New-MdReport.ps1
+++ b/New-MdReport.ps1
@@ -14,7 +14,8 @@
 [CmdletBinding()]
 param (
     [string] $InputPath = (Join-Path $PSScriptRoot 'output' 'results.json'),
-    [string] $OutputPath = (Join-Path $PSScriptRoot 'output' 'report.md')
+    [string] $OutputPath = (Join-Path $PSScriptRoot 'output' 'report.md'),
+    [string] $TriagePath
 )
 
 Set-StrictMode -Version Latest
@@ -61,6 +62,27 @@ foreach ($src in $bySource) {
     $lines.Add("| $($src.Name) | $($src.Count) | $nc |")
 }
 $lines.Add('')
+
+# AI Triage section
+if ($TriagePath -and (Test-Path $TriagePath)) {
+    try {
+        $td = @(Get-Content $TriagePath -Raw | ConvertFrom-Json -ErrorAction Stop)
+        $te = @($td | Where-Object { $null -ne $_.AiPriority } | Sort-Object AiPriority)
+        if ($te.Count -gt 0) {
+            $lines.Add('## AI-Assisted Triage')
+            $lines.Add('')
+            $lines.Add('| # | Finding | Severity | Source | Risk | Remediation |')
+            $lines.Add('|---|---|---|---|---|---|')
+            foreach ($t in $te) {
+                $title = ($t.Title -replace '\|', '\\|')
+                $risk = ($t.AiRiskContext -replace '\|', '\\|' -replace "`n|`r", ' ')
+                $rem = ($t.AiRemediation -replace '\|', '\\|' -replace "`n|`r", ' ')
+                $lines.Add("| $($t.AiPriority) | $title | $($t.Severity) | $($t.Source) | $risk | $rem |")
+            }
+            $lines.Add('')
+        }
+    } catch { }
+}
 
 # Per-category sections
 $lines.Add('## Findings by category')

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -1,38 +1,255 @@
 # Permissions Reference — azure-analyzer
 
-## Principle
-All tools run with the minimum permissions required. No write permissions anywhere.
+## Core Principle
 
-## Azure permissions
+All tools operate **read-only** with no write permissions anywhere. Azure-analyzer uses only the minimum permissions required to assess your infrastructure.
 
-| Tool | Scope | Required role | Justification |
-|------|-------|--------------|---------------|
-| azqr | Subscription | Reader | Reads resource configurations for compliance checks |
-| PSRule for Azure | Subscription | Reader | Reads ARM/Bicep resources for rule evaluation |
-| AzGovViz | Management Group | Reader + Directory.Read.All | Enumerates hierarchy, policies, RBAC assignments |
-| ALZ Resource Graph queries | Subscription/Tenant | Reader | ARG queries are read-only |
-| WARA (Start-WARACollector) | Subscription | Reader | Reads resources via ARG for reliability assessment |
-| Maester | Tenant (Entra ID) | Directory.Read.All, Policy.Read.All, Reports.Read.All | Reads Entra ID security configuration via Microsoft Graph; requires `Connect-MgGraph` before running
+---
 
-## GitHub permissions
+## Required permissions by scope
 
-| Action | Required scope | Notes |
-|--------|---------------|-------|
-| Read repo contents | `contents: read` | Checked out source |
-| Write security results | `security-events: write` | CodeQL SARIF upload |
-| Read Actions | `actions: read` | CodeQL workflow scanning |
+### Azure (Reader — all resource tools)
 
-## Supply Chain (Scorecard) permissions
+| Tool | Scope | Role | Why |
+|------|-------|------|-----|
+| **azqr** | Subscription | Reader | Scans resource configurations for compliance checks |
+| **PSRule for Azure** | Subscription | Reader | Evaluates resources against rule-based policies |
+| **AzGovViz** | Management Group | Reader | Crawls governance hierarchy, policies, and RBAC assignments |
+| **ALZ Resource Graph queries** | Subscription or MG | Reader | Runs 132 custom ARG queries for Azure architecture assessment |
+| **WARA** | Subscription | Reader | Collects Well-Architected Framework reliability assessment data |
 
-| Tool | Scope | Required credential | Justification |
-|------|-------|---------------------|---------------|
-| OpenSSF Scorecard | Repository | `GITHUB_AUTH_TOKEN` (optional) | GitHub API token for authenticated scans (recommended to avoid rate limiting); reads repository metadata and branch protection settings |
+**How to grant:**
+```powershell
+# Option 1: Azure CLI
+az role assignment create \
+  --assignee <principal-id-or-email> \
+  --role Reader \
+  --scope /subscriptions/<subscription-id>
 
-## Azure DevOps permissions
-No ADO integration currently planned.
+# Option 2: PowerShell
+New-AzRoleAssignment `
+  -ObjectId <principal-id> `
+  -RoleDefinitionName Reader `
+  -Scope "/subscriptions/<subscription-id>"
+```
+
+**Where to find IDs:**
+- **Object ID (service principal):** `az ad sp show --id <app-id> --query id`
+- **Object ID (user):** `az ad user show --id <email> --query id`
+- **Subscription ID:** `az account show --query id`
+
+---
+
+### Microsoft Graph (Maester — identity security)
+
+Maester requires delegated or application permissions to read Entra ID security configuration.
+
+| Permission | Type | Why |
+|------------|------|-----|
+| **Directory.Read.All** | Application or Delegated | Read Entra ID users, groups, roles, and security configuration |
+| **Policy.Read.All** | Application or Delegated | Read conditional access policies, sign-in risk policies, and other security policies |
+| **Reports.Read.All** | Application or Delegated | Read sign-in reports and audit logs for security assessment |
+| **DirectoryRecommendations.Read.All** | Application or Delegated | Read Entra ID recommendations (preview feature) |
+
+**How to grant:**
+
+For interactive use (delegated):
+```powershell
+# Connect to Graph with required scopes
+$scopes = @(
+  "Directory.Read.All",
+  "Policy.Read.All",
+  "Reports.Read.All",
+  "DirectoryRecommendations.Read.All"
+)
+Connect-MgGraph -Scopes $scopes
+
+# Run Maester
+.\Invoke-AzureAnalyzer.ps1 -IncludeTools 'maester'
+```
+
+For service principals (application permissions):
+1. Go to **Azure Portal** → **Entra ID** → **App registrations** → **Your app**
+2. Select **API permissions**
+3. Click **Add a permission** → **Microsoft Graph**
+4. Choose **Application permissions**
+5. Search for and select: `Directory.Read.All`, `Policy.Read.All`, `Reports.Read.All`, `DirectoryRecommendations.Read.All`
+6. Click **Grant admin consent** (requires Entra ID admin)
+
+**Important:** Maester does **NOT** modify your tenant. All permissions are read-only.
+
+---
+
+### GitHub (Scorecard — repository security)
+
+OpenSSF Scorecard evaluates repository security practices. Authentication is optional but **strongly recommended** to avoid rate limits.
+
+| Token type | Scopes needed | Rate limit | Cost |
+|------------|--------------|-----------|------|
+| Unauthenticated | None (public repos) | 10 requests/minute | Free; very restrictive |
+| Classic PAT | `repo` (or `public_repo` for public repos only) | 5,000 requests/hour | Free tier with GitHub account |
+| Fine-grained PAT | Repository access: **Read** | 15,000 requests/hour | Free; more secure |
+
+**How to grant:**
+
+**Option 1: Classic PAT (simplest)**
+```powershell
+# 1. Create token at https://github.com/settings/tokens/new
+#    Scopes: repo (or public_repo for public repos only)
+#    Name: azure-analyzer-scorecard
+#    Expiration: 90 days
+
+# 2. Set environment variable
+$env:GITHUB_AUTH_TOKEN = "ghp_..."
+
+# 3. Run Scorecard
+.\Invoke-AzureAnalyzer.ps1 -IncludeTools 'scorecard' -Repository "github.com/org/repo"
+```
+
+**Option 2: Fine-grained PAT (recommended)**
+```powershell
+# 1. Create token at https://github.com/settings/personal-access-tokens/new
+#    Permissions: Repository permissions → Contents: Read
+#    Resource owner: Select your organization
+#    Repositories: Select the repo(s) to scan
+
+# 2. Set environment variable
+$env:GITHUB_AUTH_TOKEN = (gh auth token)  # or manually paste the token
+
+# 3. Run
+.\Invoke-AzureAnalyzer.ps1 -IncludeTools 'scorecard' -Repository "github.com/org/repo"
+```
+
+**Option 3: GitHub CLI (automatic)**
+```powershell
+# If you already have GitHub CLI authenticated
+$env:GITHUB_AUTH_TOKEN = (gh auth token)
+.\Invoke-AzureAnalyzer.ps1 -IncludeTools 'scorecard' -Repository "github.com/org/repo"
+```
+
+---
+
+### Optional: GitHub Copilot SDK (AI triage)
+
+When running with `-EnableAiTriage`, non-compliant findings are sent to GitHub Copilot for AI analysis and remediation suggestions. **This is completely optional.**
+
+| Requirement | Details |
+|-------------|---------|
+| **License** | GitHub Copilot Individual, Business, or Enterprise (if not licensed, AI triage is skipped) |
+| **Token** | PAT with `copilot` scope, or existing `GITHUB_TOKEN` if already authenticated |
+| **Environment variable** | `COPILOT_GITHUB_TOKEN` or `GITHUB_TOKEN` |
+| **Privacy** | No data is sent to Copilot services unless `-EnableAiTriage` flag is used |
+
+**How to grant:**
+
+```powershell
+# 1. Create Copilot-scoped PAT at https://github.com/settings/personal-access-tokens/new
+#    Permissions: Copilot scope only
+#    Name: azure-analyzer-copilot
+#    Expiration: 90 days
+
+# 2. Set environment variable
+$env:COPILOT_GITHUB_TOKEN = "ghp_..."
+
+# 3. Run with AI triage enabled
+.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -EnableAiTriage
+
+# If you don't have Copilot licensed, the tool skips this step with a warning
+```
+
+**Privacy note:** When Copilot SDK is enabled, only non-compliant finding details (title, severity, remediation) are sent for analysis. No credential or resource data is included.
+
+---
+
+## Permission matrix (quick reference)
+
+| Tool | Azure Reader | Microsoft Graph | GitHub Token | Copilot License |
+|------|-------------|-----------------|-------------|-----------------|
+| **azqr** | ✅ Required | — | — | — |
+| **PSRule** | ✅ Required | — | — | — |
+| **AzGovViz** | ✅ Required | — | — | — |
+| **ALZ Queries** | ✅ Required | — | — | — |
+| **WARA** | ✅ Required | — | — | — |
+| **Maester** | — | ✅ Required | — | — |
+| **Scorecard** | — | — | ⚡ Recommended | — |
+| **AI Triage** | — | — | ⚡ Recommended | ⚠️ Optional |
+
+- ✅ = Required for tool to function
+- ⚡ = Strongly recommended (improves rate limits, feature completeness)
+- ⚠️ = Optional (license required only if you want AI analysis)
+- — = Not required for this tool
+
+---
+
+## Least-privilege principle
+
+Azure-analyzer follows the principle of least privilege:
+
+1. **Read-only everywhere** — No write permissions on any scope (Azure, Graph, GitHub)
+2. **Scoped to subscriptions/tenants** — Not broader than necessary
+3. **Graceful degradation** — Missing permissions don't fail the run; the affected tool is skipped with a warning
+4. **Tool-specific controls** — Use `-IncludeTools` or `-ExcludeTools` to run only what you have access to
+
+**Example: Run only tools you have permissions for**
+```powershell
+# If you don't have Microsoft Graph permissions, just run Azure tools
+.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ExcludeTools 'maester'
+
+# Or explicitly include only what you need
+.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -IncludeTools 'azqr','psrule'
+```
+
+---
 
 ## What we do NOT need
-- No Contributor or Owner roles
-- No write permissions to any Azure resource
-- No Key Vault access (no secrets stored in KV by this tool)
-- No network permissions
+
+- ❌ **Contributor** or **Owner** roles — Reader is sufficient
+- ❌ **Write permissions** to any Azure resource
+- ❌ **Key Vault access** — No secrets are read from or stored in Key Vault
+- ❌ **Network permissions** — No virtual network or firewall rules are modified
+- ❌ **Azure DevOps permissions** — No ADO integration planned
+- ❌ **Service Principal Password** — Only object ID is needed for role assignment
+
+---
+
+## Troubleshooting
+
+### Azure authentication
+```powershell
+# Check current Azure context
+Get-AzContext
+
+# Switch subscriptions if needed
+Set-AzContext -SubscriptionId "<subscription-id>"
+
+# Verify Reader permissions on your subscription
+$role = Get-AzRoleAssignment -ObjectId (Get-AzContext).Account.ExtendedProperties.HomeAccountId -RoleDefinitionName Reader
+if ($role) { Write-Host "✅ Reader role confirmed" } else { Write-Host "❌ Reader role not found" }
+```
+
+### Microsoft Graph authentication
+```powershell
+# Check Graph connection
+Get-MgContext
+
+# Re-authenticate with required scopes if needed
+Disconnect-MgGraph
+Connect-MgGraph -Scopes "Directory.Read.All", "Policy.Read.All", "Reports.Read.All"
+```
+
+### GitHub authentication
+```powershell
+# Verify token is set
+if ($env:GITHUB_AUTH_TOKEN) { Write-Host "✅ Token is set" } else { Write-Host "❌ Token not found in env" }
+
+# Test token rate limits
+curl -H "Authorization: token $env:GITHUB_AUTH_TOKEN" https://api.github.com/rate_limit | jq '.rate_limit'
+```
+
+---
+
+## See also
+
+- [README.md](README.md) — Quick start and tool overview
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Development and PR process
+- [SECURITY.md](SECURITY.md) — Security practices and disclosure

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -12,6 +12,7 @@ All tools run with the minimum permissions required. No write permissions anywhe
 | AzGovViz | Management Group | Reader + Directory.Read.All | Enumerates hierarchy, policies, RBAC assignments |
 | ALZ Resource Graph queries | Subscription/Tenant | Reader | ARG queries are read-only |
 | WARA (Start-WARACollector) | Subscription | Reader | Reads resources via ARG for reliability assessment |
+| Maester | Tenant (Entra ID) | Directory.Read.All, Policy.Read.All, Reports.Read.All | Reads Entra ID security configuration via Microsoft Graph; requires `Connect-MgGraph` before running
 
 ## GitHub permissions
 
@@ -20,6 +21,12 @@ All tools run with the minimum permissions required. No write permissions anywhe
 | Read repo contents | `contents: read` | Checked out source |
 | Write security results | `security-events: write` | CodeQL SARIF upload |
 | Read Actions | `actions: read` | CodeQL workflow scanning |
+
+## Supply Chain (Scorecard) permissions
+
+| Tool | Scope | Required credential | Justification |
+|------|-------|---------------------|---------------|
+| OpenSSF Scorecard | Repository | `GITHUB_AUTH_TOKEN` (optional) | GitHub API token for authenticated scans (recommended to avoid rate limiting); reads repository metadata and branch protection settings |
 
 ## Azure DevOps permissions
 No ADO integration currently planned.

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -40,6 +40,51 @@ New-AzRoleAssignment `
 
 ---
 
+### Management group recursion
+
+When you provide `-ManagementGroupId`, azure-analyzer automatically discovers all child subscriptions and tailors tool execution based on scope:
+
+| Tool scope | Behavior |
+|------------|----------|
+| **Subscription-scoped** (azqr, PSRule, WARA) | Runs **per discovered subscription** |
+| **MG-scoped** (AzGovViz, ALZ Queries) | Runs **once at the MG level** |
+| **Tenant-scoped** (Maester) | Runs **once for the entire tenant** |
+| **Repo-scoped** (Scorecard) | Independent of Azure hierarchy; runs for specified repo only |
+
+**Required permissions for recursion:**
+- `Reader` on the management group (auto-inherited to all child subscriptions)
+- **OR** `Reader` on each individual subscription (if you lack MG-level permissions)
+
+**Discovery behavior:**
+- **Tenant root group:** Include all subscriptions in the tenant
+- **Specific MG:** Include only the MG and its direct children (recursive)
+- **No recursion:** Use `-Recurse:$false` to scan only the specified MG, without discovering child subscriptions
+
+**Examples:**
+
+```powershell
+# Scan entire tenant from root MG
+# Discovers all subscriptions; azqr/PSRule/WARA run per sub
+.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "00000000-0000-0000-0000-000000000000"
+
+# Scan specific MG subtree
+# E.g., "my-landing-zone" — discovers child subs, runs sub-tools per discovery
+.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "my-landing-zone"
+
+# MG-level tools only, skip per-subscription recursion
+# AzGovViz and ALZ Queries run for "prod-mg"; azqr/PSRule/WARA skipped
+.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "prod-mg" -Recurse:$false
+
+# Combine MG recursion with tool filtering
+# Scan entire MG tree, but only run Maester (Entra ID security)
+.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "tenant-root" -IncludeTools 'maester'
+
+# Scan MG tree for governance + reliability, skip compliance checks
+.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "my-mg" -ExcludeTools 'azqr','psrule'
+```
+
+---
+
 ### Microsoft Graph (Maester — identity security)
 
 Maester requires delegated or application permissions to read Entra ID security configuration.
@@ -209,6 +254,12 @@ Azure-analyzer follows the principle of least privilege:
 - ❌ **Network permissions** — No virtual network or firewall rules are modified
 - ❌ **Azure DevOps permissions** — No ADO integration planned
 - ❌ **Service Principal Password** — Only object ID is needed for role assignment
+
+### AI Triage (optional)
+
+| Credential | Purpose |
+|---|---|
+| `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` | Sends non-compliant finding data to GitHub Copilot API for AI-assisted triage. Only used when `-EnableAiTriage` is set. `ghs_` tokens NOT supported. See [docs/ai-triage.md](docs/ai-triage.md). |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,32 +4,22 @@ Automated Azure assessment that bundles **azqr**, **PSRule for Azure**, **AzGovV
 
 ## Quick Start
 
-### Option 1: Install from PSGallery (recommended)
-
 ```powershell
-# 1. Install the module
-Install-Module AzureAnalyzer -Scope CurrentUser
+# 1. Clone the repository
+git clone https://github.com/martinopedal/azure-analyzer.git
+cd azure-analyzer
 
 # 2. Connect to Azure
 Connect-AzAccount -TenantId "<your-tenant-id>"
 
-# 3. Run
+# 3. Import the module
+Import-Module ./AzureAnalyzer.psd1
+
+# 4. Run an assessment
 Invoke-AzureAnalyzer -SubscriptionId "<your-subscription-id>"
 ```
 
 Results land in `output/` — a JSON file, an HTML dashboard, and a Markdown report. That's it.
-
-### Option 2: Clone and run from source
-
-```powershell
-# 1. Clone & connect
-git clone https://github.com/martinopedal/azure-analyzer.git
-cd azure-analyzer
-Connect-AzAccount -TenantId "<your-tenant-id>"
-
-# 2. Run
-.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "<your-subscription-id>"
-```
 
 ## What you get
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ Automated Azure assessment that bundles **azqr**, **PSRule for Azure**, **AzGovV
 
 ## Quick Start
 
+### Option 1: Install from PSGallery (recommended)
+
+```powershell
+# 1. Install the module
+Install-Module AzureAnalyzer -Scope CurrentUser
+
+# 2. Connect to Azure
+Connect-AzAccount -TenantId "<your-tenant-id>"
+
+# 3. Run
+Invoke-AzureAnalyzer -SubscriptionId "<your-subscription-id>"
+```
+
+Results land in `output/` — a JSON file, an HTML dashboard, and a Markdown report. That's it.
+
+### Option 2: Clone and run from source
+
 ```powershell
 # 1. Clone & connect
 git clone https://github.com/martinopedal/azure-analyzer.git
@@ -13,8 +30,6 @@ Connect-AzAccount -TenantId "<your-tenant-id>"
 # 2. Run
 .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "<your-subscription-id>"
 ```
-
-Results land in `output/` — a JSON file, an HTML dashboard, and a Markdown report. That's it.
 
 ## What you get
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,46 @@ After a run, `output/` contains:
 
 ### HTML Report features
 
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Azure Analyzer Report                                      │
+│  Generated: 2025-04-15 10:30 UTC                            │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ┌──────────┐  Scanned 18 resources across 7 tools.         │
+│  │          │  33% compliant overall.                        │
+│  │   33%    │  5 high-severity findings require              │
+│  │  ◉ donut │  immediate action.                            │
+│  │          │                                                │
+│  └──────────┘                                                │
+│                                                             │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐       │
+│  │ Total    │ │ High     │ │ Medium   │ │ Compliant│       │
+│  │   18     │ │    5     │ │    5     │ │   33%    │       │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘       │
+│                                                             │
+│  Findings by source                                         │
+│  ├─ Azure Quick Review  ████████████░░░░░  3                │
+│  ├─ PSRule              ████████████████░  4                │
+│  ├─ AzGovViz            ████████████░░░░░  3                │
+│  ├─ ALZ Queries         ████████████████░  4                │
+│  └─ WARA                ████████████████░  4                │
+│                                                             │
+│  Tool coverage                                              │
+│  ✅ Azure Quick Review  ✅ PSRule  ✅ AzGovViz               │
+│  ✅ ALZ Queries         ✅ WARA    ✅ Maester                │
+│  ✅ Scorecard                                               │
+│                                                             │
+│  Findings by category                                       │
+│  ▸ Compute (2)                                              │
+│  ▸ Identity (2)                                             │
+│  ▸ Networking (4)     ← click to expand sortable table      │
+│  ▸ Reliability (4)                                          │
+│  ▸ Security (4)                                             │
+│  ▸ Storage (2)                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
 - Executive summary with compliance %, resource count, high-severity callout
 - Pure-CSS donut chart (no JavaScript)
 - Per-source horizontal bar chart
@@ -54,11 +94,56 @@ After a run, `output/` contains:
 
 ### Markdown Report features
 
-- GitHub callouts (WARNING/NOTE/TIP) based on severity
-- Mermaid pie chart (rendered natively on GitHub)
-- Per-source emoji severity badges
-- Collapsible per-category finding tables
-- Tool coverage matrix
+- **Executive summary** — GitHub-flavored callouts (WARNING/NOTE/TIP) based on severity
+- **Mermaid pie chart** — compliance breakdown (rendered natively on GitHub)
+- **Severity badges** — per-source emoji indicators (🔴 High, 🟠 Med, 🟡 Low, 🟢 All compliant)
+- **Collapsible sections** — per-category finding tables via `<details>` tags
+- **Tool coverage matrix** — shows which tools ran vs were skipped
+
+<details>
+<summary>📊 Preview: Markdown report output</summary>
+
+The Markdown report renders natively on GitHub with tables, action-plan sections, and per-source breakdowns.
+
+> **Summary**
+>
+> | Metric | Count |
+> |---|---|
+> | Total findings | 18 |
+> | Non-compliant | 12 |
+> | Compliant | 6 |
+> | High severity | 5 |
+> | Medium severity | 5 |
+> | Low severity | 2 |
+> | Info | 6 |
+>
+> **By source**
+>
+> | Source | Findings | Non-compliant |
+> |---|---|---|
+> | azqr | 3 | 2 |
+> | psrule | 4 | 3 |
+> | azgovviz | 3 | 2 |
+> | alz-queries | 4 | 2 |
+> | wara | 4 | 3 |
+> | maester | 2 | 1 |
+> | scorecard | 1 | 1 |
+
+The report groups findings by category, then prioritizes action:
+
+> **Fix now (High, non-compliant)**
+>
+> | Title | Source | Detail |
+> |---|---|---|
+> | NSG has no inbound rules restricting SSH access | azqr | NSG allows SSH from any source |
+> | Key Vault soft delete is disabled | azqr | Risks permanent data loss |
+> | Owner role assigned to external guest user | azgovviz | Guest has Owner on subscription |
+> | Public IPs without DDoS protection | alz-queries | 3 public IPs unprotected |
+> | App Service plan has only 1 instance | wara | Single point of failure |
+
+</details>
+
+> 💡 Full sample reports are available in [`samples/`](samples/) — open `sample-report.html` in a browser or view `sample-report.md` on GitHub.
 
 ### Report structure
 
@@ -78,8 +163,12 @@ After a run, `output/` contains:
 | PSRule for Azure | latest | `Install-Module PSRule.Rules.Azure` |
 | AzGovViz | latest | [Download](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting) to `tools/AzGovViz/` |
 | WARA | latest | `Install-Module WARA` (auto-installed if missing) |
+| Maester | latest | `Install-Module Maester -Scope CurrentUser` |
+| OpenSSF Scorecard | latest | Download from https://github.com/ossf/scorecard/releases |
 
-All tools need at minimum **Reader** on subscriptions in scope. See [PERMISSIONS.md](PERMISSIONS.md) for details.
+**Important notes:**
+- Maester requires `Connect-MgGraph` before running (authenticates to Microsoft Graph for Entra ID assessment)
+- Scorecard analyzes repository security posture; provide `GITHUB_AUTH_TOKEN` environment variable for authenticated API access (optional but recommended for rate limits)
 
 ## Usage
 
@@ -103,6 +192,8 @@ All tools need at minimum **Reader** on subscriptions in scope. See [PERMISSIONS
 | 3 | **[AzGovViz](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting)** | Governance hierarchy — management group structure, RBAC assignments, policy compliance, orphaned resources | PowerShell script crawls the tenant tree and reports governance anomalies |
 | 4 | **[ALZ Queries](https://github.com/martinopedal/alz-graph-queries)** | Azure Landing Zone compliance — 132 ARG queries from Azure review checklists covering networking, identity, compute, storage | Runs each query against Azure Resource Graph and checks the `compliant` column |
 | 5 | **[WARA](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2)** | Reliability posture — single points of failure, missing geo-replication, health probe config, zone redundancy | PSGallery module runs the Well-Architected Reliability Assessment collector |
+| 6 | **[Maester](https://github.com/maester365/maester)** | Entra ID security configuration — EIDSCA and CISA baseline compliance checks for identity posture | PowerShell module runs Pester tests against Microsoft Graph and tenant configuration |
+| 7 | **[OpenSSF Scorecard](https://github.com/ossf/scorecard)** | Repository supply chain security — branch protection, dependency pinning, CI/CD, commit signing practices | CLI scans a GitHub repository and scores security controls (0-10 per category) |
 
 ## Schema reference
 
@@ -111,7 +202,7 @@ All findings are merged into `output/results.json` using a unified 10-field sche
 | Field | Type | Description |
 |---|---|---|
 | `Id` | string | Unique finding identifier |
-| `Source` | string | `azqr`, `psrule`, `azgovviz`, `alz-queries`, or `wara` |
+| `Source` | string | `azqr`, `psrule`, `azgovviz`, `alz-queries`, `wara`, `maester`, or `scorecard` |
 | `Category` | string | e.g. Security, Reliability, Networking, Compute, Storage, Identity |
 | `Title` | string | Short finding title |
 | `Severity` | string | `Critical`, `High`, `Medium`, `Low`, or `Info` |
@@ -177,6 +268,8 @@ This tool wraps the following open-source projects. See [THIRD_PARTY_NOTICES.md]
 | PSRule for Azure | [Azure/PSRule.Rules.Azure](https://github.com/Azure/PSRule.Rules.Azure) | MIT |
 | WARA | [Azure/Azure-Proactive-Resiliency-Library-v2](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2) | MIT |
 | ALZ Query Data | [martinopedal/alz-graph-queries](https://github.com/martinopedal/alz-graph-queries) (derived from [Azure/review-checklists](https://github.com/Azure/review-checklists)) | MIT |
+| Maester | [maester365/maester](https://github.com/maester365/maester) | MIT |
+| OpenSSF Scorecard | [ossf/scorecard](https://github.com/ossf/scorecard) | Apache 2.0 |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Run **only specific tools** or **exclude certain tools** with `-IncludeTools` (a
 
 **Valid tool names:** `azqr`, `psrule`, `azgovviz`, `alz-queries`, `wara`, `maester`, `scorecard`
 
-You can use `-IncludeTools` and `-ExcludeTools` together (inclusion list is evaluated first, then exclusions are applied). Useful for "all except" patterns or custom combinations.
+Use `-IncludeTools` OR `-ExcludeTools` (not both). The orchestrator throws if you specify both.
 
 ### What each tool does
 

--- a/README.md
+++ b/README.md
@@ -236,12 +236,16 @@ All findings are merged into `output/results.json` using a unified 10-field sche
 
 ## Permissions
 
-| Scope | Role |
-|---|---|
-| Subscriptions / management groups | `Reader` |
-| Resource groups | `Reader` (inherited) |
+All tools operate read-only. No write permissions required anywhere.
 
-No write permissions are required. All tools operate read-only. See [PERMISSIONS.md](PERMISSIONS.md) for a full per-tool breakdown.
+| Scope | What needs it |
+|-------|--------------|
+| **Azure Reader** | azqr, PSRule, AzGovViz, ALZ Queries, WARA |
+| **Microsoft Graph** (read) | Maester — Entra ID security |
+| **GitHub token** (optional) | Scorecard — repo security (recommended for rate limits) |
+| **Copilot license** (optional) | AI triage — fully optional; only used with `-EnableAiTriage` flag |
+
+See [PERMISSIONS.md](PERMISSIONS.md) for exact scopes, token types, setup commands, and troubleshooting.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ cd azure-analyzer
 # 2. Connect to Azure
 Connect-AzAccount -TenantId "<your-tenant-id>"
 
-# 3. Import the module
+# 3. Import and run
 Import-Module ./AzureAnalyzer.psd1
-
-# 4. Run an assessment
 Invoke-AzureAnalyzer -SubscriptionId "<your-subscription-id>"
+# That's it. Missing tools are auto-installed on first run.
 ```
 
 Results land in `output/` — a JSON file, an HTML dashboard, and a Markdown report. That's it.
@@ -30,6 +29,7 @@ After a run, `output/` contains:
 | `results.json` | All findings in a unified 10-field schema |
 | `report.html` | Offline HTML dashboard — donut chart, stat cards, per-source bars, filterable tables, print-friendly |
 | `report.md` | GitHub-flavored Markdown — summary tables, per-category findings, action plan |
+| `triage.json` | *(optional)* AI-enriched findings — generated with `-EnableAiTriage` |
 
 **Reports are auto-generated** after the run writes `results.json` — no manual step needed.
 
@@ -181,12 +181,32 @@ The report groups findings by category, then prioritizes action:
 # Single subscription
 .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "00000000-0000-0000-0000-000000000000"
 
-# Management group (scans all child subscriptions)
-.\Invoke-AzureAnalyzer.ps1 -ManagementGroup "my-landing-zone"
+# Management group (auto-discovers child subscriptions, scans recursively)
+.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "my-landing-zone"
 
-# Skip tools you don't have installed
-.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -SkipAzGovViz -SkipPSRule
+# Tenant root (scan all subscriptions in tenant)
+.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "tenant-root-group-id"
+
+# MG tools only (no per-subscription recursion)
+.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "my-mg" -Recurse:$false
+
+# Combine scopes for complete picture
+.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "..." -Repository "github.com/org/repo"
 ```
+
+### Management Group hierarchy
+
+When you provide `-ManagementGroupId`, subscription-scoped tools (azqr, PSRule, WARA) automatically run per discovered child subscription:
+
+| Scope | Behavior |
+|-------|----------|
+| **Single subscription** | Run tools once for that subscription |
+| **Management group with `-Recurse:$true` (default)** | Discover all child subscriptions; run sub-scoped tools per subscription; run MG-scoped tools once at MG level |
+| **Management group with `-Recurse:$false`** | Run only MG-scoped tools (AzGovViz, ALZ Queries); skip per-subscription tools |
+| **Tenant root group** | Discover all subscriptions in tenant; run sub-scoped tools per subscription |
+
+**Permission requirements:**
+- `Reader` on the management group (inherited to child subscriptions) **OR** `Reader` on each individual subscription
 
 ### Scoped Runs
 
@@ -194,12 +214,15 @@ Run **only specific tools** or **exclude certain tools** with `-IncludeTools` (a
 
 | Use Case | Command |
 |----------|---------|
-| **Full assessment** (default) | `.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ManagementGroupId "..." -Repository "github.com/org/repo"` |
+| **Full assessment** | `.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ManagementGroupId "..." -Repository "github.com/org/repo"` |
+| **Entire MG tree** | `.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "my-mg"` |
+| **MG governance only** (no per-sub scanning) | `.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "my-mg" -Recurse:$false` |
 | **Azure resources only** | `.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ExcludeTools 'maester','scorecard'` |
 | **Identity security only** (Entra ID) | `.\Invoke-AzureAnalyzer.ps1 -IncludeTools 'maester'` |
 | **Repository security only** | `.\Invoke-AzureAnalyzer.ps1 -IncludeTools 'scorecard' -Repository "github.com/org/repo"` |
-| **Everything except governance** | `.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ExcludeTools 'azgovviz'` |
+| **MG tree + repo security** | `.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "..." -IncludeTools 'azgovviz','alz-queries','scorecard' -Repository "..."` |
 | **Compliance checks only** | `.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -IncludeTools 'azqr','psrule'` |
+| **Everything except governance** | `.\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "..." -ExcludeTools 'azgovviz'` |
 
 **Valid tool names:** `azqr`, `psrule`, `azgovviz`, `alz-queries`, `wara`, `maester`, `scorecard`
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,23 @@ The report groups findings by category, then prioritizes action:
 .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -SkipAzGovViz -SkipPSRule
 ```
 
+### Scoped Runs
+
+Run **only specific tools** or **exclude certain tools** with `-IncludeTools` (allowlist) and `-ExcludeTools` (blocklist). Mix and match for focused assessments:
+
+| Use Case | Command |
+|----------|---------|
+| **Full assessment** (default) | `.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ManagementGroupId "..." -Repository "github.com/org/repo"` |
+| **Azure resources only** | `.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ExcludeTools 'maester','scorecard'` |
+| **Identity security only** (Entra ID) | `.\Invoke-AzureAnalyzer.ps1 -IncludeTools 'maester'` |
+| **Repository security only** | `.\Invoke-AzureAnalyzer.ps1 -IncludeTools 'scorecard' -Repository "github.com/org/repo"` |
+| **Everything except governance** | `.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -ExcludeTools 'azgovviz'` |
+| **Compliance checks only** | `.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -IncludeTools 'azqr','psrule'` |
+
+**Valid tool names:** `azqr`, `psrule`, `azgovviz`, `alz-queries`, `wara`, `maester`, `scorecard`
+
+You can use `-IncludeTools` and `-ExcludeTools` together (inclusion list is evaluated first, then exclusions are applied). Useful for "all except" patterns or custom combinations.
+
 ### What each tool does
 
 | # | Tool | What it assesses | How it works |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -57,3 +57,21 @@ This project invokes, wraps, or depends on the following open-source tools. None
 - **Copyright:** Copyright (c) Microsoft Corporation
 - **License:** MIT License
 - **Note:** The alz-graph-queries project (used by azure-analyzer) derives from this upstream project. This represents the original ALZ checklist data from which the ARG queries were generated.
+
+---
+
+## Maester
+- **Source:** https://github.com/maester365/maester
+- **Copyright:** Copyright (c) Maester365 contributors
+- **License:** MIT License
+- **Install:** `Install-Module Maester -Scope CurrentUser`
+- **Usage:** Invoked via `Invoke-Maester` to assess Entra ID security configuration against EIDSCA and CISA baselines
+
+---
+
+## OpenSSF Scorecard
+- **Source:** https://github.com/ossf/scorecard
+- **Copyright:** Copyright (c) OpenSSF Contributors
+- **License:** Apache License 2.0
+- **Install:** Download from https://github.com/ossf/scorecard/releases
+- **Usage:** Invoked via `scorecard` CLI to assess repository security practices (branch protection, dependency pinning, CI configuration)

--- a/docs/ai-triage.md
+++ b/docs/ai-triage.md
@@ -4,6 +4,8 @@
 
 When enabled, AI triage enriches non-compliant findings with priority ranking, risk context, and actionable remediation guidance using the [GitHub Copilot SDK](https://github.com/github/copilot-sdk).
 
+> **⚠️ Preview SDK:** The `github-copilot-sdk` package is currently at version **0.1.x (preview)**. The API surface may change in future releases. Pin your version if stability is critical: `pip install github-copilot-sdk==0.1.*`
+
 ## What it does
 
 With `-EnableAiTriage`, after all assessment tools finish:
@@ -21,6 +23,17 @@ With `-EnableAiTriage`, after all assessment tools finish:
 Reports automatically include an AI Triage Summary section when `triage.json` is present.
 
 **Without `-EnableAiTriage`**, none of this runs. No Python is called, no token is checked, no warnings appear. The feature has zero footprint when disabled.
+
+## ⚠️ Data privacy warning
+
+**When AI triage is enabled, non-compliant finding data is sent to GitHub Copilot services.**
+
+This includes finding titles, severity, details, remediation text, and Azure resource IDs. This data is processed under your existing [GitHub Copilot agreement](https://github.com/features/copilot).
+
+- **Compliant findings are never sent** — only non-compliant findings are transmitted
+- **Strictly opt-in** — nothing is sent unless you explicitly pass `-EnableAiTriage`
+- **Without the flag, zero data leaves your machine**
+- A privacy notice is displayed in the console before any data is sent
 
 ## Requirements
 
@@ -41,6 +54,16 @@ These are only needed if you choose to use AI triage:
    ```bash
    export COPILOT_GITHUB_TOKEN="github_pat_..."
    ```
+
+### Authentication
+
+The SDK resolves credentials in this order:
+
+1. Token passed explicitly (azure-analyzer sets this from env vars below)
+2. `GITHUB_TOKEN` environment variable
+3. `gh auth login` session (GitHub CLI)
+
+Azure-analyzer checks these env vars and passes the first one found to the SDK:
 
 | Token variable | Priority |
 |---|---|
@@ -69,21 +92,14 @@ If any prerequisite is missing when `-EnableAiTriage` is passed, the tool warns 
 | SDK not installed | "AI triage requires github-copilot-sdk. Install with: pip install github-copilot-sdk. Skipping." |
 | No token / no license | "AI triage requires a GitHub Copilot license. Set COPILOT_GITHUB_TOKEN with a PAT that has the 'copilot' scope. Skipping." |
 
-## Models and fallback chain
+## Model selection
 
-| Priority | Model | Notes |
+The script discovers available models at runtime via `list_models()` and selects from a preferred list:
+
+| Preference | Model | Notes |
 |----------|-------|-------|
-| 1 (default) | `gpt-4.1` | Cost-effective, good at structured JSON |
-| 2 (fallback) | `claude-sonnet-4` | Strong reasoning fallback |
-| 3 (fallback) | `gpt-5-mini` | Lightweight last-resort |
+| 1st choice | `gpt-4.1` | Cost-effective, good at structured JSON |
+| 2nd choice | `claude-sonnet-4` | Strong reasoning fallback |
+| 3rd choice | `gpt-5-mini` | Lightweight last-resort |
 
-Each model is retried up to 3 times with exponential backoff before falling back.
-
-## Privacy and data handling
-
-> **When AI triage is enabled**, non-compliant finding data (titles, details, resource IDs, remediation text) is sent to the **GitHub Copilot API**.
-
-- Data is processed under your existing [GitHub Copilot agreement](https://github.com/features/copilot)
-- Compliant findings are **never** sent
-- The feature is strictly **opt-in** — nothing is sent unless you pass `-EnableAiTriage`
-- Without the flag, zero data leaves your machine
+If none of the preferred models are available (model names may change as the SDK evolves), the script falls back to whatever models `list_models()` returns. Each model is retried up to 3 times with exponential backoff before trying the next.

--- a/docs/ai-triage.md
+++ b/docs/ai-triage.md
@@ -1,23 +1,89 @@
-# AI-Assisted Triage
+# Optional: AI-Assisted Triage (requires GitHub Copilot license)
 
-Optional AI triage using the GitHub Copilot SDK. Enabled with `-EnableAiTriage`.
+> **This feature is entirely optional.** Azure Analyzer works fully without it — all seven assessment tools, unified JSON output, and HTML/Markdown reports are completely independent of AI triage. The triage is a bonus enrichment layer for teams that have GitHub Copilot.
 
-## Setup
-1. Python 3.10+
-2. `pip install github-copilot-sdk`
-3. Set `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` (PAT, NOT ghs_)
+When enabled, AI triage enriches non-compliant findings with priority ranking, risk context, and actionable remediation guidance using the [GitHub Copilot SDK](https://github.com/github/copilot-sdk).
+
+## What it does
+
+With `-EnableAiTriage`, after all assessment tools finish:
+
+1. Reads `output/results.json`
+2. Groups non-compliant findings by severity into batches
+3. Sends each batch to GitHub Copilot for expert analysis
+4. Enriches each finding with:
+   - **AiPriority** — fix-first ranking (1 = most urgent) based on blast radius and exploitability
+   - **AiRiskContext** — what could go wrong if this finding is not addressed
+   - **AiRemediation** — concrete remediation steps (not just "see docs")
+   - **AiRelatedFindings** — IDs of other findings sharing a root cause
+5. Writes `output/triage.json` with all original findings plus the AI fields
+
+Reports automatically include an AI Triage Summary section when `triage.json` is present.
+
+**Without `-EnableAiTriage`**, none of this runs. No Python is called, no token is checked, no warnings appear. The feature has zero footprint when disabled.
+
+## Requirements
+
+### GitHub Copilot license
+
+AI triage requires an active **GitHub Copilot** subscription — Individual, Business, or Enterprise. Without a Copilot license, you cannot use this feature. The triage calls count against your normal Copilot usage quota (not a separately billed API).
+
+### Setup steps
+
+These are only needed if you choose to use AI triage:
+
+1. **Python 3.10+** — install from [python.org](https://www.python.org/downloads/)
+2. **GitHub Copilot SDK** — install manually (this is NOT auto-installed):
+   ```bash
+   pip install github-copilot-sdk
+   ```
+3. **Copilot-scoped token** — create a PAT at [github.com/settings/tokens](https://github.com/settings/tokens) with the `copilot` scope, then set it:
+   ```bash
+   export COPILOT_GITHUB_TOKEN="github_pat_..."
+   ```
+
+| Token variable | Priority |
+|---|---|
+| `COPILOT_GITHUB_TOKEN` | Checked first (recommended) |
+| `GH_TOKEN` | Checked second |
+| `GITHUB_TOKEN` | Checked third |
+
+**Supported token types:** `github_pat_` (PAT), `gho_` (OAuth), `ghu_` (user).
+**NOT supported:** `ghs_` (GitHub Actions GITHUB_TOKEN) — these do not have Copilot API access.
 
 ## Usage
+
 ```powershell
+# With AI triage (optional)
 .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -EnableAiTriage
+
+# Without AI triage (default — the tool works exactly the same)
+.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..."
 ```
 
-## Output
-Enriches each finding with: AiPriority, AiRiskContext, AiRemediation, AiRelatedFindings.
-Writes `output/triage.json`. Reports auto-include triage section.
+If any prerequisite is missing when `-EnableAiTriage` is passed, the tool warns with a specific message and continues without AI enrichment:
 
-## Models
-gpt-4.1 (default) > claude-sonnet-4 > gpt-5-mini. 3 retries with exponential backoff.
+| Missing prerequisite | Warning message |
+|---|---|
+| Python not installed | "AI triage requires Python 3.10+. Skipping." |
+| SDK not installed | "AI triage requires github-copilot-sdk. Install with: pip install github-copilot-sdk. Skipping." |
+| No token / no license | "AI triage requires a GitHub Copilot license. Set COPILOT_GITHUB_TOKEN with a PAT that has the 'copilot' scope. Skipping." |
 
-## Privacy
-Non-compliant finding data sent to GitHub Copilot API. Opt-in only. Uses Copilot quota.
+## Models and fallback chain
+
+| Priority | Model | Notes |
+|----------|-------|-------|
+| 1 (default) | `gpt-4.1` | Cost-effective, good at structured JSON |
+| 2 (fallback) | `claude-sonnet-4` | Strong reasoning fallback |
+| 3 (fallback) | `gpt-5-mini` | Lightweight last-resort |
+
+Each model is retried up to 3 times with exponential backoff before falling back.
+
+## Privacy and data handling
+
+> **When AI triage is enabled**, non-compliant finding data (titles, details, resource IDs, remediation text) is sent to the **GitHub Copilot API**.
+
+- Data is processed under your existing [GitHub Copilot agreement](https://github.com/features/copilot)
+- Compliant findings are **never** sent
+- The feature is strictly **opt-in** — nothing is sent unless you pass `-EnableAiTriage`
+- Without the flag, zero data leaves your machine

--- a/docs/ai-triage.md
+++ b/docs/ai-triage.md
@@ -1,0 +1,23 @@
+# AI-Assisted Triage
+
+Optional AI triage using the GitHub Copilot SDK. Enabled with `-EnableAiTriage`.
+
+## Setup
+1. Python 3.10+
+2. `pip install github-copilot-sdk`
+3. Set `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` (PAT, NOT ghs_)
+
+## Usage
+```powershell
+.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "..." -EnableAiTriage
+```
+
+## Output
+Enriches each finding with: AiPriority, AiRiskContext, AiRemediation, AiRelatedFindings.
+Writes `output/triage.json`. Reports auto-include triage section.
+
+## Models
+gpt-4.1 (default) > claude-sonnet-4 > gpt-5-mini. 3 retries with exponential backoff.
+
+## Privacy
+Non-compliant finding data sent to GitHub Copilot API. Opt-in only. Uses Copilot quota.

--- a/modules/Invoke-AlzQueries.ps1
+++ b/modules/Invoke-AlzQueries.ps1
@@ -35,6 +35,8 @@ if (-not (Get-Module -Name Az.ResourceGraph -ListAvailable -ErrorAction Silently
     Write-Warning "Az.ResourceGraph module not installed. Skipping ALZ queries. Run: Install-Module Az.ResourceGraph"
     return [PSCustomObject]@{
         Source   = 'alz-queries'
+        Status   = 'Skipped'
+        Message  = 'Az.ResourceGraph not installed'
         Findings = @()
     }
 }
@@ -46,6 +48,8 @@ if (-not (Test-Path $QueriesFile)) {
     Write-Warning "Clone https://github.com/martinopedal/alz-graph-queries and run with -QueriesFile path."
     return [PSCustomObject]@{
         Source   = 'alz-queries'
+        Status   = 'Skipped'
+        Message  = 'Query file not found'
         Findings = @()
     }
 }
@@ -57,6 +61,8 @@ if ($queryable.Count -eq 0) {
     Write-Warning "No queryable items found in $QueriesFile"
     return [PSCustomObject]@{
         Source   = 'alz-queries'
+        Status   = 'Skipped'
+        Message  = 'No queryable items found'
         Findings = @()
     }
 }
@@ -123,5 +129,7 @@ foreach ($item in $queryable) {
 
 return [PSCustomObject]@{
     Source   = 'alz-queries'
+    Status   = 'Success'
+    Message  = ''
     Findings = $findings.ToArray()
 }

--- a/modules/Invoke-AzGovViz.ps1
+++ b/modules/Invoke-AzGovViz.ps1
@@ -41,6 +41,8 @@ if (-not $azGovVizScript) {
     Write-Warning "AzGovViz (AzGovVizParallel.ps1) not found. Skipping. Clone from https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting"
     return [PSCustomObject]@{
         Source   = 'azgovviz'
+        Status   = 'Skipped'
+        Message  = 'AzGovVizParallel.ps1 not found'
         Findings = @()
     }
 }
@@ -72,12 +74,16 @@ try {
 
     return [PSCustomObject]@{
         Source   = 'azgovviz'
+        Status   = 'Success'
+        Message  = ''
         Findings = $findings
     }
 } catch {
     Write-Warning "AzGovViz run failed: $_"
     return [PSCustomObject]@{
         Source   = 'azgovviz'
+        Status   = 'Failed'
+        Message  = "$_"
         Findings = @()
     }
 }

--- a/modules/Invoke-Azqr.ps1
+++ b/modules/Invoke-Azqr.ps1
@@ -31,6 +31,8 @@ if (-not (Test-AzqrInstalled)) {
     Write-Warning "azqr is not installed. Skipping Azqr scan. Install from https://azure.github.io/azqr"
     return [PSCustomObject]@{
         Source   = 'azqr'
+        Status   = 'Skipped'
+        Message  = 'azqr not installed'
         Findings = @()
     }
 }
@@ -61,12 +63,16 @@ try {
 
     return [PSCustomObject]@{
         Source   = 'azqr'
+        Status   = 'Success'
+        Message  = ''
         Findings = $findings
     }
 } catch {
     Write-Warning "azqr scan failed: $_"
     return [PSCustomObject]@{
         Source   = 'azqr'
+        Status   = 'Failed'
+        Message  = "$_"
         Findings = @()
     }
 }

--- a/modules/Invoke-CopilotTriage.ps1
+++ b/modules/Invoke-CopilotTriage.ps1
@@ -70,6 +70,10 @@ if (-not (Test-Path $scriptPath)) {
 }
 
 # --- Run triage ---
+Write-Host ''
+Write-Host '  ⚠ DATA NOTICE: Non-compliant finding data (titles, details, resource IDs)' -ForegroundColor Yellow
+Write-Host '    will be sent to GitHub Copilot services for AI analysis.' -ForegroundColor Yellow
+Write-Host ''
 Write-Host 'Running AI triage enrichment...' -ForegroundColor Magenta
 try {
     & $py $scriptPath --input $InputPath --output $OutputPath 2>&1 | ForEach-Object {

--- a/modules/Invoke-CopilotTriage.ps1
+++ b/modules/Invoke-CopilotTriage.ps1
@@ -1,0 +1,24 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $InputPath = (Join-Path $PSScriptRoot '..' 'output' 'results.json'),
+    [string] $OutputPath = (Join-Path $PSScriptRoot '..' 'output' 'triage.json')
+)
+Set-StrictMode -Version Latest
+try { $v = & python3 --version 2>&1; if ($LASTEXITCODE -ne 0) { $v = & python --version 2>&1 } } catch { try { $v = & python --version 2>&1 } catch { Write-Warning 'AI Triage: Python not found'; return $null } }
+if (-not ($v -match 'Python (\d+)\.(\d+)') -or [int]$Matches[1] -lt 3 -or [int]$Matches[2] -lt 10) { Write-Warning 'AI Triage: Python 3.10+ required'; return $null }
+$py = if ($v -match 'python3') { 'python3' } else { 'python' }
+try { & $py -c 'import copilot' 2>&1 | Out-Null; if ($LASTEXITCODE -ne 0) { throw } } catch { Write-Warning 'AI Triage: pip install github-copilot-sdk'; return $null }
+$tk = $env:COPILOT_GITHUB_TOKEN; if (-not $tk) { $tk = $env:GH_TOKEN }; if (-not $tk) { $tk = $env:GITHUB_TOKEN }
+if (-not $tk) { Write-Warning 'AI Triage: No token'; return $null }
+if ($tk.StartsWith('ghs_')) { Write-Warning 'AI Triage: ghs_ unsupported'; return $null }
+if (-not (Test-Path $InputPath)) { Write-Warning "AI Triage: $InputPath not found"; return $null }
+$sp = Join-Path $PSScriptRoot 'Invoke-CopilotTriage.py'
+if (-not (Test-Path $sp)) { Write-Warning 'AI Triage: Python script missing'; return $null }
+Write-Host 'Running AI triage...' -ForegroundColor Magenta
+try {
+    & $py $sp --input $InputPath --output $OutputPath 2>&1 | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+    if ($LASTEXITCODE -ne 0) { Write-Warning "AI Triage: exit code $LASTEXITCODE"; return $null }
+    if (-not (Test-Path $OutputPath)) { Write-Warning 'AI Triage: triage.json not created'; return $null }
+    return (Get-Content $OutputPath -Raw | ConvertFrom-Json -ErrorAction Stop)
+} catch { Write-Warning "AI Triage: $_"; return $null }

--- a/modules/Invoke-CopilotTriage.ps1
+++ b/modules/Invoke-CopilotTriage.ps1
@@ -1,24 +1,92 @@
 #Requires -Version 7.0
+<#
+.SYNOPSIS
+    Optional AI triage enrichment using the GitHub Copilot SDK.
+.DESCRIPTION
+    Checks prerequisites (Python 3.10+, github-copilot-sdk, Copilot-scoped token),
+    then calls the Python triage script. Never throws — returns $null on any failure
+    so the main pipeline continues without AI enrichment.
+    Requires a GitHub Copilot license (Individual, Business, or Enterprise).
+#>
 [CmdletBinding()]
 param(
     [string] $InputPath = (Join-Path $PSScriptRoot '..' 'output' 'results.json'),
     [string] $OutputPath = (Join-Path $PSScriptRoot '..' 'output' 'triage.json')
 )
 Set-StrictMode -Version Latest
-try { $v = & python3 --version 2>&1; if ($LASTEXITCODE -ne 0) { $v = & python --version 2>&1 } } catch { try { $v = & python --version 2>&1 } catch { Write-Warning 'AI Triage: Python not found'; return $null } }
-if (-not ($v -match 'Python (\d+)\.(\d+)') -or [int]$Matches[1] -lt 3 -or [int]$Matches[2] -lt 10) { Write-Warning 'AI Triage: Python 3.10+ required'; return $null }
-$py = if ($v -match 'python3') { 'python3' } else { 'python' }
-try { & $py -c 'import copilot' 2>&1 | Out-Null; if ($LASTEXITCODE -ne 0) { throw } } catch { Write-Warning 'AI Triage: pip install github-copilot-sdk'; return $null }
-$tk = $env:COPILOT_GITHUB_TOKEN; if (-not $tk) { $tk = $env:GH_TOKEN }; if (-not $tk) { $tk = $env:GITHUB_TOKEN }
-if (-not $tk) { Write-Warning 'AI Triage: No token'; return $null }
-if ($tk.StartsWith('ghs_')) { Write-Warning 'AI Triage: ghs_ unsupported'; return $null }
-if (-not (Test-Path $InputPath)) { Write-Warning "AI Triage: $InputPath not found"; return $null }
-$sp = Join-Path $PSScriptRoot 'Invoke-CopilotTriage.py'
-if (-not (Test-Path $sp)) { Write-Warning 'AI Triage: Python script missing'; return $null }
-Write-Host 'Running AI triage...' -ForegroundColor Magenta
+
+# --- Check 1: Python 3.10+ ---
+$py = $null
 try {
-    & $py $sp --input $InputPath --output $OutputPath 2>&1 | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
-    if ($LASTEXITCODE -ne 0) { Write-Warning "AI Triage: exit code $LASTEXITCODE"; return $null }
-    if (-not (Test-Path $OutputPath)) { Write-Warning 'AI Triage: triage.json not created'; return $null }
-    return (Get-Content $OutputPath -Raw | ConvertFrom-Json -ErrorAction Stop)
-} catch { Write-Warning "AI Triage: $_"; return $null }
+    $v = & python3 --version 2>&1
+    if ($LASTEXITCODE -eq 0 -and $v -match 'Python (\d+)\.(\d+)' -and [int]$Matches[1] -ge 3 -and [int]$Matches[2] -ge 10) {
+        $py = 'python3'
+    }
+} catch { }
+if (-not $py) {
+    try {
+        $v = & python --version 2>&1
+        if ($LASTEXITCODE -eq 0 -and $v -match 'Python (\d+)\.(\d+)' -and [int]$Matches[1] -ge 3 -and [int]$Matches[2] -ge 10) {
+            $py = 'python'
+        }
+    } catch { }
+}
+if (-not $py) {
+    Write-Warning 'AI triage requires Python 3.10+. Skipping.'
+    return $null
+}
+
+# --- Check 2: github-copilot-sdk installed ---
+try {
+    & $py -c 'import copilot' 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw }
+} catch {
+    Write-Warning 'AI triage requires github-copilot-sdk. Install with: pip install github-copilot-sdk. Skipping.'
+    return $null
+}
+
+# --- Check 3: Copilot token available ---
+$tk = $env:COPILOT_GITHUB_TOKEN
+if (-not $tk) { $tk = $env:GH_TOKEN }
+if (-not $tk) { $tk = $env:GITHUB_TOKEN }
+if (-not $tk) {
+    Write-Warning "AI triage requires a GitHub Copilot license. Set COPILOT_GITHUB_TOKEN with a PAT that has the 'copilot' scope. Skipping."
+    return $null
+}
+if ($tk.StartsWith('ghs_')) {
+    Write-Warning "AI triage does not support GitHub Actions tokens (ghs_). Use a PAT with the 'copilot' scope. Skipping."
+    return $null
+}
+
+# --- Validate inputs ---
+if (-not (Test-Path $InputPath)) {
+    Write-Warning "AI triage: input file not found — $InputPath. Skipping."
+    return $null
+}
+$scriptPath = Join-Path $PSScriptRoot 'Invoke-CopilotTriage.py'
+if (-not (Test-Path $scriptPath)) {
+    Write-Warning 'AI triage: Python script not found. Skipping.'
+    return $null
+}
+
+# --- Run triage ---
+Write-Host 'Running AI triage enrichment...' -ForegroundColor Magenta
+try {
+    & $py $scriptPath --input $InputPath --output $OutputPath 2>&1 | ForEach-Object {
+        Write-Host "  $_" -ForegroundColor DarkGray
+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "AI triage: Python script exited with code $LASTEXITCODE. Skipping."
+        return $null
+    }
+    if (-not (Test-Path $OutputPath)) {
+        Write-Warning 'AI triage: triage.json was not created. Skipping.'
+        return $null
+    }
+    $triage = Get-Content $OutputPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    Write-Host "AI triage complete — enriched findings written to $OutputPath" -ForegroundColor Green
+    return $triage
+} catch {
+    Write-Warning "AI triage: unexpected error — $_. Skipping."
+    return $null
+}

--- a/modules/Invoke-CopilotTriage.py
+++ b/modules/Invoke-CopilotTriage.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""AI triage for azure-analyzer."""
+import argparse,asyncio,json,os,sys
+try:
+    from copilot import CopilotClient
+except ImportError:
+    print('ERROR: pip install github-copilot-sdk',file=sys.stderr);sys.exit(1)
+SYSTEM_PROMPT="You are an Azure security expert. Triage findings: priority(1=fix first), risk, remediation, related. JSON array only."
+DEFAULT_MODEL='gpt-4.1'
+FALLBACK=['claude-sonnet-4','gpt-5-mini']
+BATCH=12
+RETRIES=3
+def load(p):
+    with open(p,'r',encoding='utf-8') as f: d=json.load(f)
+    return d.get('Findings',d) if isinstance(d,dict) else d
+def batch(findings):
+    s=sorted(findings,key=lambda f:{'High':0,'Medium':1,'Low':2,'Info':3}.get(f.get('Severity','Info'),3))
+    return [s[i:i+BATCH] for i in range(0,len(s),BATCH)]
+async def triage_batch(client,b,idx,total):
+    prompt=f'Triage {len(b)} findings:\\n{json.dumps([{k:f.get(k,"") for k in ("Id","Source","Category","Title","Severity","Detail","Remediation","ResourceId")} for f in b],indent=2)}'
+    ids={f.get('Id') for f in b}
+    for model in [DEFAULT_MODEL]+FALLBACK:
+        for attempt in range(RETRIES):
+            try:
+                print(f'  Batch {idx+1}/{total}: {model} attempt {attempt+1}',file=sys.stderr)
+                r=client.create_session(model=model,system_message=SYSTEM_PROMPT).send(prompt)
+                t=r.strip()
+                if t.startswith('$$$'+'$$$'): t='\\n'.join(l for l in t.split('\\n') if not l.strip().startswith('$$$'+'$$$')).strip()
+                e=json.loads(t)
+                return {x['Id']:x for x in e if x.get('Id') in ids}
+            except Exception as ex: print(f'    {ex}',file=sys.stderr)
+            await asyncio.sleep(2.0*(2**attempt))
+    return {}
+async def run(inp,out):
+    findings=load(inp);nc=[f for f in findings if not f.get('Compliant',True)]
+    if not nc: write(findings,{},out);return
+    print(f'Triaging {len(nc)} findings',file=sys.stderr)
+    batches=batch(nc);client=CopilotClient();enrichments={}
+    for i,b in enumerate(batches): enrichments.update(await triage_batch(client,b,i,len(batches)))
+    write(findings,enrichments,out);print(f'Done: {len(enrichments)}/{len(nc)} enriched',file=sys.stderr)
+def write(findings,enrichments,path):
+    out=[]
+    for f in findings:
+        e=dict(f);fid=f.get('Id','')
+        if fid in enrichments: ai=enrichments[fid];e.update(AiPriority=ai.get('AiPriority'),AiRiskContext=ai.get('AiRiskContext',''),AiRemediation=ai.get('AiRemediation',''),AiRelatedFindings=ai.get('AiRelatedFindings',[]))
+        else: e.update(AiPriority=None,AiRiskContext='',AiRemediation='',AiRelatedFindings=[])
+        out.append(e)
+    out.sort(key=lambda x:(x['AiPriority'] is None,x['AiPriority'] or 9999))
+    os.makedirs(os.path.dirname(path) or '.',exist_ok=True)
+    with open(path,'w',encoding='utf-8') as f: json.dump(out,f,indent=2,ensure_ascii=False)
+def main():
+    p=argparse.ArgumentParser();p.add_argument('--input',default='output/results.json');p.add_argument('--output',default='output/triage.json')
+    a=p.parse_args()
+    if not os.path.isfile(a.input): print(f'ERROR: {a.input} not found',file=sys.stderr);sys.exit(1)
+    tk=os.environ.get('COPILOT_GITHUB_TOKEN') or os.environ.get('GH_TOKEN') or os.environ.get('GITHUB_TOKEN')
+    if not tk: print('ERROR: No token',file=sys.stderr);sys.exit(1)
+    if tk.startswith('ghs_'): print('ERROR: ghs_ unsupported',file=sys.stderr);sys.exit(1)
+    try: asyncio.run(run(a.input,a.output))
+    except Exception as e: print(f'ERROR: {e}',file=sys.stderr);sys.exit(1)
+if __name__=='__main__': main()

--- a/modules/Invoke-CopilotTriage.py
+++ b/modules/Invoke-CopilotTriage.py
@@ -1,60 +1,270 @@
 #!/usr/bin/env python3
-"""AI triage for azure-analyzer."""
-import argparse,asyncio,json,os,sys
+"""
+Invoke-CopilotTriage.py — AI triage enrichment for azure-analyzer findings.
+
+Uses the GitHub Copilot SDK (github-copilot-sdk, preview 0.1.x) to enrich
+non-compliant assessment findings with priority ranking, risk context,
+remediation guidance, and root-cause grouping.
+
+Requires: pip install github-copilot-sdk
+Auth:     COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN env var, or gh auth login
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+
 try:
     from copilot import CopilotClient
 except ImportError:
-    print('ERROR: pip install github-copilot-sdk',file=sys.stderr);sys.exit(1)
-SYSTEM_PROMPT="You are an Azure security expert. Triage findings: priority(1=fix first), risk, remediation, related. JSON array only."
-DEFAULT_MODEL='gpt-4.1'
-FALLBACK=['claude-sonnet-4','gpt-5-mini']
-BATCH=12
-RETRIES=3
-def load(p):
-    with open(p,'r',encoding='utf-8') as f: d=json.load(f)
-    return d.get('Findings',d) if isinstance(d,dict) else d
-def batch(findings):
-    s=sorted(findings,key=lambda f:{'High':0,'Medium':1,'Low':2,'Info':3}.get(f.get('Severity','Info'),3))
-    return [s[i:i+BATCH] for i in range(0,len(s),BATCH)]
-async def triage_batch(client,b,idx,total):
-    prompt=f'Triage {len(b)} findings:\\n{json.dumps([{k:f.get(k,"") for k in ("Id","Source","Category","Title","Severity","Detail","Remediation","ResourceId")} for f in b],indent=2)}'
-    ids={f.get('Id') for f in b}
-    for model in [DEFAULT_MODEL]+FALLBACK:
-        for attempt in range(RETRIES):
+    print(
+        "ERROR: github-copilot-sdk is not installed.\n"
+        "Install with: pip install github-copilot-sdk",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+SYSTEM_PROMPT = """\
+You are an Azure security and compliance expert.
+You are triaging assessment findings from multiple tools \
+(azqr, PSRule, AzGovViz, ALZ queries, WARA, Maester, Scorecard).
+For each batch of findings, provide:
+1. Priority ranking (1 = fix first) based on blast radius and exploitability
+2. Risk context: what happens if this isn't fixed
+3. Specific remediation steps (not just "see docs")
+4. Group related findings that share a root cause
+
+Respond ONLY with a JSON array. Each element must have exactly these fields:
+{"Id":"<id>","AiPriority":<int 1-N>,"AiRiskContext":"<text>",\
+"AiRemediation":"<text>","AiRelatedFindings":["<id>",...]}
+
+Rules:
+- One element per finding in the batch.
+- AiPriority must be unique within the batch (no ties).
+- AiRelatedFindings lists Ids of OTHER findings sharing a root cause (empty if none).
+- Do NOT wrap in markdown code fences. No text outside the JSON array."""
+
+# Preferred models, tried in order. Actual availability checked via list_models().
+PREFERRED_MODELS = ["gpt-4.1", "claude-sonnet-4", "gpt-5-mini"]
+BATCH_SIZE = 12
+MAX_RETRIES = 3
+BASE_DELAY = 2.0
+
+
+def load_findings(path: str) -> list[dict]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict) and "Findings" in data:
+        return data["Findings"]
+    if isinstance(data, list):
+        return data
+    raise ValueError(f"Unexpected JSON structure in {path}")
+
+
+def batch_findings(findings: list[dict]) -> list[list[dict]]:
+    severity_order = {"High": 0, "Medium": 1, "Low": 2, "Info": 3}
+    ordered = sorted(
+        findings,
+        key=lambda f: severity_order.get(f.get("Severity", "Info"), 3),
+    )
+    return [ordered[i : i + BATCH_SIZE] for i in range(0, len(ordered), BATCH_SIZE)]
+
+
+def build_prompt(batch: list[dict]) -> str:
+    fields = ("Id", "Source", "Category", "Title", "Severity",
+              "Detail", "Remediation", "ResourceId")
+    simplified = [{k: f.get(k, "") for k in fields} for f in batch]
+    return (
+        f"Triage these {len(batch)} non-compliant Azure assessment findings. "
+        f"Prioritise by blast radius and exploitability.\n\n"
+        f"{json.dumps(simplified, indent=2)}"
+    )
+
+
+def parse_response(text: str) -> list[dict]:
+    text = text.strip()
+    # Strip markdown code fences if the model wrapped its response
+    if text.startswith("```"):
+        lines = [l for l in text.split("\n") if not l.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+    return json.loads(text)
+
+
+async def resolve_models(client: CopilotClient) -> list[str]:
+    """Pick models from PREFERRED_MODELS that are actually available."""
+    try:
+        available = {m.id for m in await client.list_models()}
+        models = [m for m in PREFERRED_MODELS if m in available]
+        if models:
+            return models
+        # None of our preferred models matched — use whatever is available
+        print(
+            f"  Preferred models not found. Available: {sorted(available)}",
+            file=sys.stderr,
+        )
+        return sorted(available)[:3] if available else PREFERRED_MODELS
+    except Exception as exc:
+        print(f"  Could not list models ({exc}), using defaults.", file=sys.stderr)
+        return PREFERRED_MODELS
+
+
+async def triage_batch(
+    client: CopilotClient,
+    models: list[str],
+    batch: list[dict],
+    batch_index: int,
+    total_batches: int,
+) -> dict[str, dict]:
+    prompt = build_prompt(batch)
+    batch_ids = {f.get("Id") for f in batch}
+
+    for model in models:
+        for attempt in range(MAX_RETRIES):
             try:
-                print(f'  Batch {idx+1}/{total}: {model} attempt {attempt+1}',file=sys.stderr)
-                r=client.create_session(model=model,system_message=SYSTEM_PROMPT).send(prompt)
-                t=r.strip()
-                if t.startswith('$$$'+'$$$'): t='\\n'.join(l for l in t.split('\\n') if not l.strip().startswith('$$$'+'$$$')).strip()
-                e=json.loads(t)
-                return {x['Id']:x for x in e if x.get('Id') in ids}
-            except Exception as ex: print(f'    {ex}',file=sys.stderr)
-            await asyncio.sleep(2.0*(2**attempt))
+                print(
+                    f"  Batch {batch_index + 1}/{total_batches}: "
+                    f"model={model}, attempt={attempt + 1}/{MAX_RETRIES}",
+                    file=sys.stderr,
+                )
+                async with await client.create_session(
+                    model=model, system_message=SYSTEM_PROMPT
+                ) as session:
+                    response = await session.send(prompt)
+
+                enrichments = parse_response(response)
+                if not isinstance(enrichments, list):
+                    raise ValueError("AI response is not a JSON array")
+                return {e["Id"]: e for e in enrichments if e.get("Id") in batch_ids}
+
+            except json.JSONDecodeError as exc:
+                print(f"    JSON parse error: {exc}", file=sys.stderr)
+            except Exception as exc:
+                print(f"    Error: {exc}", file=sys.stderr)
+
+            await asyncio.sleep(BASE_DELAY * (2 ** attempt))
+
+        print(f"    Model {model} exhausted retries, trying next.", file=sys.stderr)
+
+    print(
+        f"  WARNING: Batch {batch_index + 1} failed on all models.",
+        file=sys.stderr,
+    )
     return {}
-async def run(inp,out):
-    findings=load(inp);nc=[f for f in findings if not f.get('Compliant',True)]
-    if not nc: write(findings,{},out);return
-    print(f'Triaging {len(nc)} findings',file=sys.stderr)
-    batches=batch(nc);client=CopilotClient();enrichments={}
-    for i,b in enumerate(batches): enrichments.update(await triage_batch(client,b,i,len(batches)))
-    write(findings,enrichments,out);print(f'Done: {len(enrichments)}/{len(nc)} enriched',file=sys.stderr)
-def write(findings,enrichments,path):
-    out=[]
-    for f in findings:
-        e=dict(f);fid=f.get('Id','')
-        if fid in enrichments: ai=enrichments[fid];e.update(AiPriority=ai.get('AiPriority'),AiRiskContext=ai.get('AiRiskContext',''),AiRemediation=ai.get('AiRemediation',''),AiRelatedFindings=ai.get('AiRelatedFindings',[]))
-        else: e.update(AiPriority=None,AiRiskContext='',AiRemediation='',AiRelatedFindings=[])
-        out.append(e)
-    out.sort(key=lambda x:(x['AiPriority'] is None,x['AiPriority'] or 9999))
-    os.makedirs(os.path.dirname(path) or '.',exist_ok=True)
-    with open(path,'w',encoding='utf-8') as f: json.dump(out,f,indent=2,ensure_ascii=False)
+
+
+async def run_triage(input_path: str, output_path: str, token: str) -> None:
+    all_findings = load_findings(input_path)
+    non_compliant = [f for f in all_findings if not f.get("Compliant", True)]
+
+    if not non_compliant:
+        print("No non-compliant findings to triage.", file=sys.stderr)
+        write_output(all_findings, {}, output_path)
+        return
+
+    print(f"Triaging {len(non_compliant)} non-compliant findings...", file=sys.stderr)
+
+    # Privacy notice (mandatory)
+    print(
+        "NOTE: Non-compliant finding data (titles, details, resource IDs) "
+        "will be sent to GitHub Copilot services for analysis.",
+        file=sys.stderr,
+    )
+
+    batches = batch_findings(non_compliant)
+    print(f"Split into {len(batches)} batch(es) of up to {BATCH_SIZE}.", file=sys.stderr)
+
+    # Pass token explicitly; SDK also checks GITHUB_TOKEN env and gh auth login
+    async with CopilotClient(github_token=token) as client:
+        models = await resolve_models(client)
+        print(f"Using models: {', '.join(models)}", file=sys.stderr)
+
+        all_enrichments: dict[str, dict] = {}
+        for i, batch in enumerate(batches):
+            result = await triage_batch(client, models, batch, i, len(batches))
+            all_enrichments.update(result)
+
+    write_output(all_findings, all_enrichments, output_path)
+    print(
+        f"Triage complete. {len(all_enrichments)}/{len(non_compliant)} "
+        f"findings enriched.",
+        file=sys.stderr,
+    )
+
+
+def write_output(
+    all_findings: list[dict],
+    enrichments: dict[str, dict],
+    output_path: str,
+) -> None:
+    output = []
+    for f in all_findings:
+        entry = dict(f)
+        fid = f.get("Id", "")
+        if fid in enrichments:
+            ai = enrichments[fid]
+            entry.update(
+                AiPriority=ai.get("AiPriority"),
+                AiRiskContext=ai.get("AiRiskContext", ""),
+                AiRemediation=ai.get("AiRemediation", ""),
+                AiRelatedFindings=ai.get("AiRelatedFindings", []),
+            )
+        else:
+            entry.update(
+                AiPriority=None, AiRiskContext="",
+                AiRemediation="", AiRelatedFindings=[],
+            )
+        output.append(entry)
+
+    output.sort(key=lambda x: (x["AiPriority"] is None, x["AiPriority"] or 9999))
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+    print(f"Wrote triage output to {output_path}", file=sys.stderr)
+
+
 def main():
-    p=argparse.ArgumentParser();p.add_argument('--input',default='output/results.json');p.add_argument('--output',default='output/triage.json')
-    a=p.parse_args()
-    if not os.path.isfile(a.input): print(f'ERROR: {a.input} not found',file=sys.stderr);sys.exit(1)
-    tk=os.environ.get('COPILOT_GITHUB_TOKEN') or os.environ.get('GH_TOKEN') or os.environ.get('GITHUB_TOKEN')
-    if not tk: print('ERROR: No token',file=sys.stderr);sys.exit(1)
-    if tk.startswith('ghs_'): print('ERROR: ghs_ unsupported',file=sys.stderr);sys.exit(1)
-    try: asyncio.run(run(a.input,a.output))
-    except Exception as e: print(f'ERROR: {e}',file=sys.stderr);sys.exit(1)
-if __name__=='__main__': main()
+    parser = argparse.ArgumentParser(
+        description="AI triage enrichment for azure-analyzer findings"
+    )
+    parser.add_argument("--input", default=os.path.join("output", "results.json"))
+    parser.add_argument("--output", default=os.path.join("output", "triage.json"))
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.input):
+        print(f"ERROR: Input file not found: {args.input}", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve token: COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN
+    # The SDK constructor also accepts github_token= or falls back to GITHUB_TOKEN / gh auth login
+    token = (
+        os.environ.get("COPILOT_GITHUB_TOKEN")
+        or os.environ.get("GH_TOKEN")
+        or os.environ.get("GITHUB_TOKEN")
+    )
+    if not token:
+        print(
+            "ERROR: No Copilot token found. Set COPILOT_GITHUB_TOKEN, "
+            "GH_TOKEN, or GITHUB_TOKEN with a PAT that has the 'copilot' scope.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if token.startswith("ghs_"):
+        print(
+            "ERROR: GitHub Actions tokens (ghs_) do not have Copilot API access. "
+            "Use a PAT (github_pat_), OAuth (gho_), or user (ghu_) token.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        asyncio.run(run_triage(args.input, args.output, token))
+    except Exception as exc:
+        print(f"ERROR: Triage failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/Invoke-Maester.ps1
+++ b/modules/Invoke-Maester.ps1
@@ -22,21 +22,21 @@ if (-not (Get-Module -ListAvailable -Name Maester)) {
         Install-Module -Name Maester -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
     } catch {
         Write-Warning "Could not install Maester module: $_. Returning empty result."
-        return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+        return [PSCustomObject]@{ Source = 'maester'; Status = 'Skipped'; Message = 'Could not install Maester module'; Findings = @() }
     }
 }
 
 Import-Module Maester -ErrorAction SilentlyContinue
 if (-not (Get-Command Invoke-Maester -ErrorAction SilentlyContinue)) {
     Write-Warning "Maester module loaded but Invoke-Maester not found. Returning empty result."
-    return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+    return [PSCustomObject]@{ Source = 'maester'; Status = 'Skipped'; Message = 'Could not install Maester module'; Findings = @() }
 }
 
 # Verify Microsoft Graph connection
 $mgContext = Get-MgContext -ErrorAction SilentlyContinue
 if (-not $mgContext) {
     Write-Warning "No Microsoft Graph connection found. Run Connect-MgGraph before using Maester. Returning empty result."
-    return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+    return [PSCustomObject]@{ Source = 'maester'; Status = 'Skipped'; Message = 'No Microsoft Graph connection'; Findings = @() }
 }
 
 # Run Maester assessment
@@ -44,12 +44,12 @@ try {
     $result = Invoke-Maester -PassThru -Quiet -ErrorAction Stop
 } catch {
     Write-Warning "Maester assessment failed: $_. Returning empty result."
-    return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+    return [PSCustomObject]@{ Source = 'maester'; Status = 'Failed'; Message = "$_"; Findings = @() }
 }
 
 if (-not $result -or -not $result.Tests) {
     Write-Warning "Maester returned no test results."
-    return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+    return [PSCustomObject]@{ Source = 'maester'; Status = 'Failed'; Message = 'No test results returned'; Findings = @() }
 }
 
 # Map tests to flat finding objects
@@ -92,4 +92,4 @@ foreach ($test in $result.Tests) {
     })
 }
 
-return [PSCustomObject]@{ Source = 'maester'; Findings = $findings }
+return [PSCustomObject]@{ Source = 'maester'; Status = 'Success'; Message = ''; Findings = $findings }

--- a/modules/Invoke-Maester.ps1
+++ b/modules/Invoke-Maester.ps1
@@ -1,0 +1,95 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Wrapper for Maester — Entra ID / identity security posture assessment.
+.DESCRIPTION
+    Installs/imports the Maester module if needed, verifies a Microsoft Graph
+    connection exists, runs Invoke-Maester -PassThru -Quiet, and returns
+    findings as PSObjects. Gracefully degrades if Maester is not available,
+    Graph is not connected, or the assessment fails.
+.EXAMPLE
+    .\Invoke-Maester.ps1
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+
+# Ensure Maester module is available
+if (-not (Get-Module -ListAvailable -Name Maester)) {
+    try {
+        Write-Warning "Maester module not found. Installing from PSGallery..."
+        Install-Module -Name Maester -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
+    } catch {
+        Write-Warning "Could not install Maester module: $_. Returning empty result."
+        return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+    }
+}
+
+Import-Module Maester -ErrorAction SilentlyContinue
+if (-not (Get-Command Invoke-Maester -ErrorAction SilentlyContinue)) {
+    Write-Warning "Maester module loaded but Invoke-Maester not found. Returning empty result."
+    return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+}
+
+# Verify Microsoft Graph connection
+$mgContext = Get-MgContext -ErrorAction SilentlyContinue
+if (-not $mgContext) {
+    Write-Warning "No Microsoft Graph connection found. Run Connect-MgGraph before using Maester. Returning empty result."
+    return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+}
+
+# Run Maester assessment
+try {
+    $result = Invoke-Maester -PassThru -Quiet -ErrorAction Stop
+} catch {
+    Write-Warning "Maester assessment failed: $_. Returning empty result."
+    return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+}
+
+if (-not $result -or -not $result.Tests) {
+    Write-Warning "Maester returned no test results."
+    return [PSCustomObject]@{ Source = 'maester'; Findings = @() }
+}
+
+# Map tests to flat finding objects
+$findings = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+foreach ($test in $result.Tests) {
+    # Derive severity from tags (default to Medium)
+    $severity = 'Medium'
+    if ($test.Tag) {
+        $tagStr = ($test.Tag -join ' ').ToLowerInvariant()
+        if ($tagStr -match 'critical|high') { $severity = 'High' }
+        elseif ($tagStr -match 'low') { $severity = 'Low' }
+    }
+
+    # Map Result to Compliant: Passed/Skipped → true, Failed → false
+    $compliant = $test.Result -ne 'Failed'
+
+    # Extract detail from ErrorRecord if present
+    $detail = ''
+    if ($test.ErrorRecord) {
+        $detail = ($test.ErrorRecord | ForEach-Object { $_.ToString() }) -join '; '
+    }
+
+    # Extract category from Block.Name
+    $category = 'Identity'
+    if ($test.Block -and $test.Block.Name) {
+        $category = $test.Block.Name
+    }
+
+    $findings.Add([PSCustomObject]@{
+        Id           = [guid]::NewGuid().ToString()
+        Category     = $category
+        Title        = $test.Name ?? 'Unknown'
+        Severity     = $severity
+        Compliant    = $compliant
+        Detail       = $detail
+        Remediation  = ''
+        ResourceId   = ''
+        LearnMoreUrl = ''
+    })
+}
+
+return [PSCustomObject]@{ Source = 'maester'; Findings = $findings }

--- a/modules/Invoke-Maester.ps1
+++ b/modules/Invoke-Maester.ps1
@@ -7,6 +7,7 @@
     connection exists, runs Invoke-Maester -PassThru -Quiet, and returns
     findings as PSObjects. Gracefully degrades if Maester is not available,
     Graph is not connected, or the assessment fails.
+    Requires: Connect-MgGraph -Scopes (Get-MtGraphScope)
 .EXAMPLE
     .\Invoke-Maester.ps1
 #>
@@ -29,33 +30,33 @@ if (-not (Get-Module -ListAvailable -Name Maester)) {
 Import-Module Maester -ErrorAction SilentlyContinue
 if (-not (Get-Command Invoke-Maester -ErrorAction SilentlyContinue)) {
     Write-Warning "Maester module loaded but Invoke-Maester not found. Returning empty result."
-    return [PSCustomObject]@{ Source = 'maester'; Status = 'Skipped'; Message = 'Could not install Maester module'; Findings = @() }
+    return [PSCustomObject]@{ Source = 'maester'; Status = 'Skipped'; Message = 'Invoke-Maester command not available'; Findings = @() }
 }
 
 # Verify Microsoft Graph connection
 $mgContext = Get-MgContext -ErrorAction SilentlyContinue
 if (-not $mgContext) {
-    Write-Warning "No Microsoft Graph connection found. Run Connect-MgGraph before using Maester. Returning empty result."
-    return [PSCustomObject]@{ Source = 'maester'; Status = 'Skipped'; Message = 'No Microsoft Graph connection'; Findings = @() }
+    Write-Warning "No Microsoft Graph connection found. Run 'Connect-MgGraph -Scopes (Get-MtGraphScope)' before using Maester. Returning empty result."
+    return [PSCustomObject]@{ Source = 'maester'; Status = 'Skipped'; Message = 'No Microsoft Graph connection. Run: Connect-MgGraph -Scopes (Get-MtGraphScope)'; Findings = @() }
 }
 
-# Run Maester assessment
+# Run Maester assessment — returns a Pester TestResultContainer
 try {
-    $result = Invoke-Maester -PassThru -Quiet -ErrorAction Stop
+    $container = Invoke-Maester -PassThru -Quiet -ErrorAction Stop
 } catch {
     Write-Warning "Maester assessment failed: $_. Returning empty result."
     return [PSCustomObject]@{ Source = 'maester'; Status = 'Failed'; Message = "$_"; Findings = @() }
 }
 
-if (-not $result -or -not $result.Tests) {
+if (-not $container -or -not $container.Result) {
     Write-Warning "Maester returned no test results."
     return [PSCustomObject]@{ Source = 'maester'; Status = 'Failed'; Message = 'No test results returned'; Findings = @() }
 }
 
-# Map tests to flat finding objects
+# Map Pester TestResult objects to flat findings
 $findings = [System.Collections.Generic.List[PSCustomObject]]::new()
 
-foreach ($test in $result.Tests) {
+foreach ($test in $container.Result) {
     # Derive severity from tags (default to Medium)
     $severity = 'Medium'
     if ($test.Tag) {
@@ -64,7 +65,7 @@ foreach ($test in $result.Tests) {
         elseif ($tagStr -match 'low') { $severity = 'Low' }
     }
 
-    # Map Result to Compliant: Passed/Skipped → true, Failed → false
+    # Map Result: Passed/Skipped/NotRun → compliant, Failed → non-compliant
     $compliant = $test.Result -ne 'Failed'
 
     # Extract detail from ErrorRecord if present
@@ -73,7 +74,7 @@ foreach ($test in $result.Tests) {
         $detail = ($test.ErrorRecord | ForEach-Object { $_.ToString() }) -join '; '
     }
 
-    # Extract category from Block.Name
+    # Extract category from parent Block name
     $category = 'Identity'
     if ($test.Block -and $test.Block.Name) {
         $category = $test.Block.Name

--- a/modules/Invoke-Maester.ps1
+++ b/modules/Invoke-Maester.ps1
@@ -16,15 +16,10 @@ param()
 
 Set-StrictMode -Version Latest
 
-# Ensure Maester module is available
+# Check Maester module is available (centralized Install-Prerequisites handles installation)
 if (-not (Get-Module -ListAvailable -Name Maester)) {
-    try {
-        Write-Warning "Maester module not found. Installing from PSGallery..."
-        Install-Module -Name Maester -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
-    } catch {
-        Write-Warning "Could not install Maester module: $_. Returning empty result."
-        return [PSCustomObject]@{ Source = 'maester'; Status = 'Skipped'; Message = 'Could not install Maester module'; Findings = @() }
-    }
+    Write-Warning "Maester module not found. Install with: Install-Module Maester -Scope CurrentUser"
+    return [PSCustomObject]@{ Source = 'maester'; Status = 'Skipped'; Message = 'Maester module not installed. Run: Install-Module Maester -Scope CurrentUser'; Findings = @() }
 }
 
 Import-Module Maester -ErrorAction SilentlyContinue

--- a/modules/Invoke-PSRule.ps1
+++ b/modules/Invoke-PSRule.ps1
@@ -36,6 +36,8 @@ if (-not (Test-PSRuleInstalled)) {
     Write-Warning "PSRule.Rules.Azure is not installed. Skipping PSRule scan. Run: Install-Module PSRule.Rules.Azure"
     return [PSCustomObject]@{
         Source   = 'psrule'
+        Status   = 'Skipped'
+        Message  = 'PSRule.Rules.Azure not installed'
         Findings = @()
     }
 }
@@ -68,12 +70,16 @@ try {
 
     return [PSCustomObject]@{
         Source   = 'psrule'
+        Status   = 'Success'
+        Message  = ''
         Findings = @($findings)
     }
 } catch {
     Write-Warning "PSRule scan failed: $_"
     return [PSCustomObject]@{
         Source   = 'psrule'
+        Status   = 'Failed'
+        Message  = "$_"
         Findings = @()
     }
 }

--- a/modules/Invoke-Scorecard.ps1
+++ b/modules/Invoke-Scorecard.ps1
@@ -9,12 +9,17 @@
     Never throws — designed for graceful degradation in the orchestrator.
 .PARAMETER Repository
     The repository to scan (e.g., "github.com/martinopedal/azure-analyzer").
+.PARAMETER Threshold
+    Minimum score (0-10) to consider a check compliant. Default is 7.
 #>
 [CmdletBinding()]
 param (
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
-    [string] $Repository
+    [string] $Repository,
+
+    [ValidateRange(0, 10)]
+    [int] $Threshold = 7
 )
 
 Set-StrictMode -Version Latest
@@ -28,12 +33,18 @@ if (-not (Test-ScorecardInstalled)) {
     Write-Warning "scorecard is not installed. Skipping Scorecard scan. Install from https://github.com/ossf/scorecard/releases"
     return [PSCustomObject]@{
         Source   = 'scorecard'
+        Status   = 'Skipped'
         Findings = @()
     }
 }
 
+# Warn if no GitHub auth token is set (authenticated requests get higher rate limits)
+if (-not $env:GITHUB_AUTH_TOKEN -and -not $env:GITHUB_TOKEN) {
+    Write-Warning "Neither GITHUB_AUTH_TOKEN nor GITHUB_TOKEN is set. Scorecard will use unauthenticated requests (lower rate limits)."
+}
+
 try {
-    Write-Verbose "Running scorecard for repository $Repository"
+    Write-Verbose "Running scorecard for repository $Repository (threshold=$Threshold)"
     $rawOutput = scorecard --repo=$Repository --format=json 2>&1
     $json = $rawOutput | Out-String | ConvertFrom-Json -ErrorAction Stop
 
@@ -47,15 +58,22 @@ try {
         foreach ($check in $json.checks) {
             $score = [int]$check.score
 
-            # Skip checks that were not evaluated
-            if ($score -eq -1) { continue }
-
-            # Map score to severity: 0-3=High, 4-6=Medium, 7-9=Low, 10=Info
-            $severity = switch ($score) {
-                { $_ -le 3 } { 'High' }
-                { $_ -le 6 } { 'Medium' }
-                { $_ -le 9 } { 'Low' }
-                default      { 'Info' }
+            if ($score -eq -1) {
+                # score = -1 means the check errored/failed to run — treat as non-compliant
+                $severity  = 'High'
+                $compliant = $false
+                $detail    = "Check failed to run"
+                if ($check.reason) { $detail += ": $($check.reason)" }
+            } else {
+                # Map score to severity: 0-3=High, 4-6=Medium, 7-9=Low, 10=Info
+                $severity = switch ($score) {
+                    { $_ -le 3 } { 'High' }
+                    { $_ -le 6 } { 'Medium' }
+                    { $_ -le 9 } { 'Low' }
+                    default      { 'Info' }
+                }
+                $compliant = $score -ge $Threshold
+                $detail    = $check.reason ?? ''
             }
 
             $learnMoreUrl = ''
@@ -68,8 +86,8 @@ try {
                 Category     = 'Supply Chain'
                 Title        = $check.name ?? 'Unknown'
                 Severity     = $severity
-                Compliant    = $score -ge 7
-                Detail       = $check.reason ?? ''
+                Compliant    = $compliant
+                Detail       = "$detail (score $score/10)"
                 Remediation  = ''
                 ResourceId   = $repoName
                 LearnMoreUrl = $learnMoreUrl
@@ -79,12 +97,14 @@ try {
 
     return [PSCustomObject]@{
         Source   = 'scorecard'
+        Status   = 'Success'
         Findings = $findings
     }
 } catch {
     Write-Warning "Scorecard scan failed: $_"
     return [PSCustomObject]@{
         Source   = 'scorecard'
+        Status   = 'Failed'
         Findings = @()
     }
 }

--- a/modules/Invoke-Scorecard.ps1
+++ b/modules/Invoke-Scorecard.ps1
@@ -34,6 +34,7 @@ if (-not (Test-ScorecardInstalled)) {
     return [PSCustomObject]@{
         Source   = 'scorecard'
         Status   = 'Skipped'
+        Message  = 'scorecard CLI not installed. Download from https://github.com/ossf/scorecard/releases'
         Findings = @()
     }
 }
@@ -98,6 +99,7 @@ try {
     return [PSCustomObject]@{
         Source   = 'scorecard'
         Status   = 'Success'
+        Message  = ''
         Findings = $findings
     }
 } catch {
@@ -105,6 +107,7 @@ try {
     return [PSCustomObject]@{
         Source   = 'scorecard'
         Status   = 'Failed'
+        Message  = "$_"
         Findings = @()
     }
 }

--- a/modules/Invoke-WARA.ps1
+++ b/modules/Invoke-WARA.ps1
@@ -32,14 +32,14 @@ if (-not (Get-Module -ListAvailable -Name WARA)) {
         Install-Module -Name WARA -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
     } catch {
         Write-Warning "Could not install WARA module: $_. Returning empty result."
-        return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+        return [PSCustomObject]@{ Source = 'wara'; Status = 'Skipped'; Message = 'Could not install WARA module'; Findings = @() }
     }
 }
 
 Import-Module WARA -ErrorAction SilentlyContinue
 if (-not (Get-Command Start-WARACollector -ErrorAction SilentlyContinue)) {
     Write-Warning "WARA module loaded but Start-WARACollector not found. Returning empty result."
-    return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+    return [PSCustomObject]@{ Source = 'wara'; Status = 'Skipped'; Message = 'Could not install WARA module'; Findings = @() }
 }
 
 # Resolve tenant
@@ -48,7 +48,7 @@ if (-not $TenantId) {
     $TenantId = $ctx?.Tenant?.Id
     if (-not $TenantId) {
         Write-Warning "No TenantId provided and no Az context found. Returning empty result."
-        return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+        return [PSCustomObject]@{ Source = 'wara'; Status = 'Failed'; Message = 'No TenantId and no Az context'; Findings = @() }
     }
 }
 
@@ -66,7 +66,7 @@ try {
 } catch {
     Pop-Location
     Write-Warning "WARA collector failed: $_. Returning empty result."
-    return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+    return [PSCustomObject]@{ Source = 'wara'; Status = 'Failed'; Message = "$_"; Findings = @() }
 }
 
 # Find the newest JSON output file
@@ -76,7 +76,7 @@ $jsonFile = Get-ChildItem -Path $OutputPath -Filter "WARA_File_*.json" |
 
 if (-not $jsonFile) {
     Write-Warning "WARA collector ran but no output JSON found in $OutputPath."
-    return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+    return [PSCustomObject]@{ Source = 'wara'; Status = 'Failed'; Message = 'No output JSON produced'; Findings = @() }
 }
 
 # Parse findings
@@ -84,7 +84,7 @@ try {
     $raw = Get-Content $jsonFile.FullName -Raw | ConvertFrom-Json -ErrorAction Stop
 } catch {
     Write-Warning "Could not parse WARA JSON: $_"
-    return [PSCustomObject]@{ Source = 'wara'; Findings = @() }
+    return [PSCustomObject]@{ Source = 'wara'; Status = 'Failed'; Message = "JSON parse error: $_"; Findings = @() }
 }
 
 # Map to flat finding objects — WARA JSON has a 'ImpactedResources' or 'Recommendations' array
@@ -112,4 +112,4 @@ foreach ($rec in $recommendations) {
     })
 }
 
-return [PSCustomObject]@{ Source = 'wara'; Findings = $findings }
+return [PSCustomObject]@{ Source = 'wara'; Status = 'Success'; Message = ''; Findings = $findings }

--- a/modules/Invoke-WARA.ps1
+++ b/modules/Invoke-WARA.ps1
@@ -25,15 +25,10 @@ param (
 
 Set-StrictMode -Version Latest
 
-# Ensure WARA module is available
+# Check WARA module is available (centralized Install-Prerequisites handles installation)
 if (-not (Get-Module -ListAvailable -Name WARA)) {
-    try {
-        Write-Warning "WARA module not found. Installing from PSGallery..."
-        Install-Module -Name WARA -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
-    } catch {
-        Write-Warning "Could not install WARA module: $_. Returning empty result."
-        return [PSCustomObject]@{ Source = 'wara'; Status = 'Skipped'; Message = 'Could not install WARA module'; Findings = @() }
-    }
+    Write-Warning "WARA module not found. Install with: Install-Module WARA -Scope CurrentUser"
+    return [PSCustomObject]@{ Source = 'wara'; Status = 'Skipped'; Message = 'WARA module not installed. Run: Install-Module WARA -Scope CurrentUser'; Findings = @() }
 }
 
 Import-Module WARA -ErrorAction SilentlyContinue

--- a/samples/sample-report.html
+++ b/samples/sample-report.html
@@ -10,32 +10,37 @@
   h1 { font-size: 22px; margin-bottom: 4px; }
   h2 { font-size: 16px; margin: 24px 0 12px; border-bottom: 1px solid #ddd; padding-bottom: 6px; }
   .subtitle { color: #666; font-size: 12px; margin-bottom: 24px; }
-
-  /* Executive summary */
-  .exec-summary { background: #fff; border-radius: 8px; padding: 24px 28px; margin-bottom: 24px; box-shadow: 0 2px 6px rgba(0,0,0,0.08); display: flex; gap: 28px; align-items: center; flex-wrap: wrap; }
-  .donut { width: 140px; height: 140px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
-  .donut-inner { width: 90px; height: 90px; border-radius: 50%; background: #fff; display: flex; align-items: center; justify-content: center; font-size: 24px; font-weight: 700; }
-  .exec-text { flex: 1; min-width: 200px; }
-  .exec-text p { font-size: 15px; line-height: 1.6; color: #333; margin-bottom: 6px; }
-  .exec-text .exec-highlight { font-size: 17px; font-weight: 600; color: #1a1a1a; }
-
-  /* Stat cards */
+  
+  /* Stat cards - 6 essentials: clickable, one active at a time, bold border */
   .cards { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 24px; }
-  .card { background: #fff; border-radius: 6px; padding: 16px 20px; min-width: 120px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .card { background: #fff; border-radius: 6px; padding: 16px 20px; min-width: 120px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); cursor: pointer; transition: border 0.2s; border: 2px solid transparent; }
+  .card:hover { box-shadow: 0 2px 6px rgba(0,0,0,0.12); }
+  .card.active { border-color: #1565c0; border-width: 3px; font-weight: 600; }
   .card-label { font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.5px; }
   .card-value { font-size: 28px; font-weight: 700; margin-top: 2px; }
   .card-total .card-value { color: #1a1a1a; }
   .card-high .card-value { color: #d32f2f; }
   .card-medium .card-value { color: #e65100; }
   .card-low .card-value { color: #f9a825; }
-  .card-ok .card-value { color: #2e7d32; }
+  .card-info .card-value { color: #666; }
+
+  /* Executive summary */
+  .exec-summary { background: #fff; border-radius: 6px; padding: 20px 24px; margin-bottom: 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
+  .exec-summary p { font-size: 14px; line-height: 1.6; color: #333; margin-bottom: 4px; }
+  .exec-summary strong { color: #1a1a1a; }
+
+  /* Filter banner */
+  .filter-banner { display: none; background: #e3f2fd; border-left: 4px solid #1565c0; padding: 12px 16px; margin-bottom: 16px; border-radius: 4px; font-size: 13px; color: #0d47a1; }
+  .filter-banner.active { display: block; }
+  .filter-banner a { color: #0d47a1; font-weight: 600; cursor: pointer; text-decoration: underline; margin-left: 8px; }
+  .filter-banner a:hover { text-decoration: none; }
 
   /* Per-source bars */
-  .source-section { background: #fff; border-radius: 8px; padding: 20px 24px; margin-bottom: 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
+  .source-section { background: #fff; border-radius: 6px; padding: 20px 24px; margin-bottom: 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
   .bar-row { display: flex; align-items: center; margin-bottom: 8px; }
   .bar-label { width: 130px; font-size: 13px; font-weight: 500; flex-shrink: 0; }
   .bar-track { flex: 1; height: 20px; background: #eee; border-radius: 4px; overflow: hidden; margin: 0 10px; }
-  .bar-fill { height: 100%; border-radius: 4px; transition: width 0.3s; }
+  .bar-fill { height: 100%; border-radius: 4px; }
   .bar-count { width: 40px; text-align: right; font-size: 13px; font-weight: 600; }
 
   /* Tool coverage */
@@ -44,7 +49,7 @@
   .tool-active { background: #e8f5e9; color: #1b5e20; }
   .tool-skipped { background: #fff3e0; color: #bf360c; }
 
-  /* Findings tables */
+  /* Findings tables - 6 essentials: severity borders, zebra stripe, sort arrows, text truncation */
   details { background: #fff; border-radius: 6px; margin-bottom: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
   summary { padding: 12px 16px; cursor: pointer; user-select: none; font-size: 14px; }
   summary:hover { background: #f9f9f9; }
@@ -58,7 +63,22 @@
   .findings-table td { padding: 7px 10px; border-top: 1px solid #f0f0f0; vertical-align: top; }
   .findings-table td a { color: #1565c0; word-break: break-all; }
   .findings-table td.resource-id { font-size: 11px; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .findings-table tr:hover td { background: #fafafa; }
+  .findings-table td.detail-cell { max-width: 250px; cursor: help; }
+  
+  /* Severity left-border (3px) + zebra striping */
+  .findings-table tr:nth-child(odd) td { background: #fafafa; }
+  .findings-table tr:hover td { background: #f0f0f0; }
+  .findings-table tr[data-severity="High"] { border-left: 3px solid #d32f2f; }
+  .findings-table tr[data-severity="Medium"] { border-left: 3px solid #e65100; }
+  .findings-table tr[data-severity="Low"] { border-left: 3px solid #f9a825; }
+  .findings-table tr[data-severity="Info"] { border-left: 3px solid #999; }
+  
+  /* Sort arrows */
+  .findings-table th.sortable::after { content: ' ↕'; font-size: 10px; opacity: 0.5; }
+  .findings-table th.sort-asc::after { content: ' ↑'; opacity: 1; }
+  .findings-table th.sort-desc::after { content: ' ↓'; opacity: 1; }
+
+  /* Badge colors */
   .badge { display: inline-block; padding: 2px 7px; border-radius: 3px; font-size: 11px; font-weight: 600; }
   .sev-high { background: #fde8e8; color: #c62828; }
   .sev-medium { background: #fff3e0; color: #bf360c; }
@@ -67,98 +87,70 @@
   .badge-ok { background: #e8f5e9; color: #1b5e20; }
   .badge-fail { background: #fce4ec; color: #880e4f; }
 
-  /* Print-friendly styles */
+  /* Print styles */
   @media print {
     body { background: #fff; padding: 12px; }
-    .no-print, .filter-box, .filter-input { display: none !important; }
+    .filter-box, .filter-input, .filter-banner { display: none !important; }
     .findings-table th { cursor: default; }
     .findings-table th:hover { background: #f0f0f0; }
     details { break-inside: avoid; }
     .findings-table tr { page-break-inside: avoid; }
-    .exec-summary, .source-section, .card, details { box-shadow: none; border: 1px solid #ddd; }
-    a { color: #1a1a1a; text-decoration: underline; }
   }
 </style>
 </head>
 <body>
-<h1>Azure Analyzer Report</h1>
-<p class="subtitle">Generated: 2026-04-15 21:22 UTC</p>
 
-<!-- Executive Summary with Donut Chart -->
+<h1>Azure Analyzer Report</h1>
+<p class="subtitle">Generated: 2026-04-15 22:01 UTC</p>
+
+<!-- Executive Summary -->
 <div class="exec-summary">
-  <div class="donut" style="background:conic-gradient(#2e7d32 0% 33%, #d32f2f 33% 100%);">
-    <div class="donut-inner">33%</div>
-  </div>
-  <div class="exec-text">
-    <p class="exec-highlight">Scanned 18 resources across 5 tools. 33% compliant overall.</p>
-    <p>5 high-severity findings require immediate action.</p>
-    <p>5 medium-severity and 2 low-severity findings also detected across 6 categories.</p>
-  </div>
+  <p><strong>Scanned 5 resources across 5 tools</strong></p>
+  <p>20% compliant overall. 2 high-severity findings require action. 1 medium-severity and 1 low-severity findings detected.</p>
 </div>
 
+<!-- Stat Cards (6 essentials: clickable, one active at a time, bold border) -->
 <div class="cards">
-  <div class="card card-total"><div class="card-label">Total findings</div><div class="card-value">18</div></div>
-  <div class="card card-high"><div class="card-label">High (non-compliant)</div><div class="card-value">5</div></div>
-  <div class="card card-medium"><div class="card-label">Medium (non-compliant)</div><div class="card-value">5</div></div>
-  <div class="card card-low"><div class="card-label">Low (non-compliant)</div><div class="card-value">2</div></div>
-  <div class="card card-ok"><div class="card-label">Compliant %</div><div class="card-value">33%</div></div>
+  <div class="card card-total" onclick="toggleFilterBySeverity(null)"><div class="card-label">Total</div><div class="card-value">5</div></div>
+  <div class="card card-high" onclick="toggleFilterBySeverity('High')"><div class="card-label">High</div><div class="card-value">2</div></div>
+  <div class="card card-medium" onclick="toggleFilterBySeverity('Medium')"><div class="card-label">Medium</div><div class="card-value">1</div></div>
+  <div class="card card-low" onclick="toggleFilterBySeverity('Low')"><div class="card-label">Low</div><div class="card-value">1</div></div>
+  <div class="card card-info" onclick="toggleFilterBySeverity('Info')"><div class="card-label">Info</div><div class="card-value">1</div></div>
+</div>
+
+<!-- Filter Indicator Banner (6 essentials: shows "Showing X findings — Clear") -->
+<div class="filter-banner" id="filterBanner">
+  <span id="filterText"></span>
+  <a onclick="clearAllFilters()">Clear</a>
 </div>
 
 <!-- Per-Source Breakdown -->
 <h2>Findings by source</h2>
 <div class="source-section">
-<div class="bar-row">
-  <span class="bar-label">Azure Quick Review</span>
-  <div class="bar-track">
-    <div class="bar-fill" style="width:75%;background:#1565c0;"></div>
-  </div>
-  <span class="bar-count">3</span>
-</div>
-<div class="bar-row">
-  <span class="bar-label">PSRule</span>
-  <div class="bar-track">
-    <div class="bar-fill" style="width:100%;background:#6a1b9a;"></div>
-  </div>
-  <span class="bar-count">4</span>
-</div>
-<div class="bar-row">
-  <span class="bar-label">AzGovViz</span>
-  <div class="bar-track">
-    <div class="bar-fill" style="width:75%;background:#00838f;"></div>
-  </div>
-  <span class="bar-count">3</span>
-</div>
-<div class="bar-row">
-  <span class="bar-label">ALZ Queries</span>
-  <div class="bar-track">
-    <div class="bar-fill" style="width:100%;background:#e65100;"></div>
-  </div>
-  <span class="bar-count">4</span>
-</div>
-<div class="bar-row">
-  <span class="bar-label">WARA</span>
-  <div class="bar-track">
-    <div class="bar-fill" style="width:100%;background:#2e7d32;"></div>
-  </div>
-  <span class="bar-count">4</span>
-</div>
+<div class='bar-row'><span class='bar-label'>Azure Quick Review</span><div class='bar-track'><div class='bar-fill' style='width: 100%; background: #1565c0;'></div></div><span class='bar-count'>1</span></div>
+<div class='bar-row'><span class='bar-label'>PSRule</span><div class='bar-track'><div class='bar-fill' style='width: 100%; background: #6a1b9a;'></div></div><span class='bar-count'>1</span></div>
+<div class='bar-row'><span class='bar-label'>AzGovViz</span><div class='bar-track'><div class='bar-fill' style='width: 100%; background: #00838f;'></div></div><span class='bar-count'>1</span></div>
+<div class='bar-row'><span class='bar-label'>ALZ Queries</span><div class='bar-track'><div class='bar-fill' style='width: 100%; background: #e65100;'></div></div><span class='bar-count'>1</span></div>
+<div class='bar-row'><span class='bar-label'>WARA</span><div class='bar-track'><div class='bar-fill' style='width: 100%; background: #2e7d32;'></div></div><span class='bar-count'>1</span></div>
 </div>
 
 <!-- Tool Coverage Summary -->
 <h2>Tool coverage</h2>
 <div class="tool-coverage">
-<span class='tool-badge tool-active' title='Produced results'>&#x2705; Azure Quick Review</span>
-<span class='tool-badge tool-active' title='Produced results'>&#x2705; PSRule</span>
-<span class='tool-badge tool-active' title='Produced results'>&#x2705; AzGovViz</span>
-<span class='tool-badge tool-active' title='Produced results'>&#x2705; ALZ Queries</span>
-<span class='tool-badge tool-active' title='Produced results'>&#x2705; WARA</span>
+<span class='tool-badge tool-active' title='Produced results'>✅ Azure Quick Review</span>
+<span class='tool-badge tool-active' title='Produced results'>✅ PSRule</span>
+<span class='tool-badge tool-active' title='Produced results'>✅ AzGovViz</span>
+<span class='tool-badge tool-active' title='Produced results'>✅ ALZ Queries</span>
+<span class='tool-badge tool-active' title='Produced results'>✅ WARA</span>
+<span class='tool-badge tool-skipped' title='No results / skipped'>⚠️ Maester</span>
 </div>
 
+<!-- Findings by Category -->
 <h2>Findings by category</h2>
 <details id="cat-compute">
-  <summary><strong>Compute</strong> <span class="cat-count">(2)</span></summary>
-  <div class="filter-box no-print"><input type="text" placeholder="Filter rows..." onkeyup="filterTable(this,'tbl-compute-0')" class="filter-input"></div>
-  <table id="tbl-compute-0" class="findings-table sortable">
+  <summary><strong>Compute</strong> <span class="cat-count">(1)</span></summary>
+  <div class="filter-box"><input type="text" placeholder="Filter this category..." onkeyup="filterTable(this)" class="filter-input"></div>
+  <table class="findings-table">
     <thead>
       <tr>
         <th onclick="sortTable(this)">Title</th>
@@ -172,15 +164,14 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td>Virtual machine scale set uses latest OS image</td><td><span class='badge sev-info'>Info</span></td><td>alz-queries</td><td><span class="badge badge-ok">Yes</span></td><td>VMSS is using the latest patched Ubuntu 22.04 LTS image</td><td></td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-compute/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-web-frontend</td><td></td></tr>
-      <tr><td>Virtual machine does not use managed disks</td><td><span class='badge sev-medium'>Medium</span></td><td>psrule</td><td><span class="badge badge-fail">No</span></td><td>VM uses unmanaged disks which lack built-in redundancy and simplified management</td><td>Migrate to managed disks using the Azure portal or PowerShell Convert-AzVMManagedDisk</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-compute/providers/Microsoft.Compute/virtualMachines/vm-app-backend-01</td><td><a href="https://learn.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
+      <tr data-severity="High" data-source="azgovviz"><td>VM uses unencrypted OS disk</td><td><span class='badge sev-high'>High</span></td><td>azgovviz</td><td><span class="badge badge-fail">No</span></td><td class="detail-cell" title="Virtual machine uses standard unencrypted OS disk">Virtual machine uses standard unencrypted OS disk</td><td>Enable encryption at rest</td><td class="resource-id">/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1</td><td></td></tr>
     </tbody>
   </table>
 </details>
-<details id="cat-identity">
-  <summary><strong>Identity</strong> <span class="cat-count">(2)</span></summary>
-  <div class="filter-box no-print"><input type="text" placeholder="Filter rows..." onkeyup="filterTable(this,'tbl-identity-1')" class="filter-input"></div>
-  <table id="tbl-identity-1" class="findings-table sortable">
+<details id="cat-data">
+  <summary><strong>Data</strong> <span class="cat-count">(1)</span></summary>
+  <div class="filter-box"><input type="text" placeholder="Filter this category..." onkeyup="filterTable(this)" class="filter-input"></div>
+  <table class="findings-table">
     <thead>
       <tr>
         <th onclick="sortTable(this)">Title</th>
@@ -194,15 +185,14 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td>Subscription has Owner role assigned to external guest user</td><td><span class='badge sev-high'>High</span></td><td>azgovviz</td><td><span class="badge badge-fail">No</span></td><td>Guest user external-vendor@outlook.com has Owner role on subscription</td><td>Remove Owner from guest accounts; use scoped Contributor or custom roles instead</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444</td><td><a href="https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-external-users" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
-      <tr><td>Managed identity used for Key Vault access</td><td><span class='badge sev-info'>Info</span></td><td>alz-queries</td><td><span class="badge badge-ok">Yes</span></td><td>Application uses managed identity instead of service principal secrets for Key Vault access</td><td></td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-security/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-app-keyvault</td><td></td></tr>
+      <tr data-severity="Low" data-source="alz-queries"><td>SQL Database has no backup</td><td><span class='badge sev-low'>Low</span></td><td>alz-queries</td><td><span class="badge badge-fail">No</span></td><td class="detail-cell" title="SQL database has no backup policy configured">SQL database has no backup policy configured</td><td>Configure backup retention</td><td class="resource-id">/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Sql/servers/sqlsrv1/databases/db1</td><td></td></tr>
     </tbody>
   </table>
 </details>
 <details id="cat-networking">
-  <summary><strong>Networking</strong> <span class="cat-count">(4)</span></summary>
-  <div class="filter-box no-print"><input type="text" placeholder="Filter rows..." onkeyup="filterTable(this,'tbl-networking-2')" class="filter-input"></div>
-  <table id="tbl-networking-2" class="findings-table sortable">
+  <summary><strong>Networking</strong> <span class="cat-count">(1)</span></summary>
+  <div class="filter-box"><input type="text" placeholder="Filter this category..." onkeyup="filterTable(this)" class="filter-input"></div>
+  <table class="findings-table">
     <thead>
       <tr>
         <th onclick="sortTable(this)">Title</th>
@@ -216,41 +206,14 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td>NSG has no inbound rules restricting SSH access</td><td><span class='badge sev-high'>High</span></td><td>azqr</td><td><span class="badge badge-fail">No</span></td><td>Network Security Group allows SSH (port 22) from any source address</td><td>Restrict SSH access to specific IP ranges or use Azure Bastion. See https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-networking/providers/Microsoft.Network/networkSecurityGroups/nsg-frontend</td><td><a href="https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
-      <tr><td>Public IP addresses found without DDoS protection</td><td><span class='badge sev-high'>High</span></td><td>alz-queries</td><td><span class="badge badge-fail">No</span></td><td>3 public IP addresses are not protected by Azure DDoS Protection Standard</td><td>Enable DDoS Protection Standard on the virtual network or use DDoS IP protection</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-networking/providers/Microsoft.Network/publicIPAddresses/pip-appgw-frontend</td><td><a href="https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-overview" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
-      <tr><td>Load balancer health probe is correctly configured</td><td><span class='badge sev-info'>Info</span></td><td>wara</td><td><span class="badge badge-ok">Yes</span></td><td>Standard Load Balancer has custom health probe on /health endpoint</td><td></td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-networking/providers/Microsoft.Network/loadBalancers/lb-api-prod</td><td></td></tr>
-      <tr><td>AKS cluster does not use Azure CNI networking</td><td><span class='badge sev-medium'>Medium</span></td><td>psrule</td><td><span class="badge badge-fail">No</span></td><td>Cluster uses kubenet instead of Azure CNI, limiting network policy support</td><td>Recreate cluster with Azure CNI or migrate using overlay networking</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-aks/providers/Microsoft.ContainerService/managedClusters/aks-prod-001</td><td><a href="https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
-    </tbody>
-  </table>
-</details>
-<details id="cat-reliability">
-  <summary><strong>Reliability</strong> <span class="cat-count">(4)</span></summary>
-  <div class="filter-box no-print"><input type="text" placeholder="Filter rows..." onkeyup="filterTable(this,'tbl-reliability-3')" class="filter-input"></div>
-  <table id="tbl-reliability-3" class="findings-table sortable">
-    <thead>
-      <tr>
-        <th onclick="sortTable(this)">Title</th>
-        <th onclick="sortTable(this)">Severity</th>
-        <th onclick="sortTable(this)">Source</th>
-        <th onclick="sortTable(this)">Compliant</th>
-        <th>Detail</th>
-        <th>Remediation</th>
-        <th onclick="sortTable(this)">Resource ID</th>
-        <th>Learn More</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr><td>App Service plan has only 1 instance</td><td><span class='badge sev-high'>High</span></td><td>wara</td><td><span class="badge badge-fail">No</span></td><td>Production App Service plan has a single instance, creating a single point of failure</td><td>Scale out to at least 2 instances and enable zone redundancy</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-web/providers/Microsoft.Web/serverFarms/asp-api-prod</td><td><a href="https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
-      <tr><td>Cosmos DB account does not have multi-region writes enabled</td><td><span class='badge sev-low'>Low</span></td><td>wara</td><td><span class="badge badge-fail">No</span></td><td>Cosmos DB account is configured with single-region writes, limiting write availability during regional outages</td><td>Enable multi-region writes in the Cosmos DB account replication settings</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-data/providers/Microsoft.DocumentDB/databaseAccounts/cosmos-orders-prod</td><td><a href="https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-multi-master" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
-      <tr><td>Diagnostic settings not configured for App Service</td><td><span class='badge sev-low'>Low</span></td><td>psrule</td><td><span class="badge badge-fail">No</span></td><td>App Service does not have diagnostic settings configured for Log Analytics</td><td>Configure diagnostic settings to send logs to a Log Analytics workspace</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-web/providers/Microsoft.Web/sites/app-api-gateway</td><td><a href="https://learn.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
-      <tr><td>Azure Cache for Redis has no geo-replication configured</td><td><span class='badge sev-medium'>Medium</span></td><td>wara</td><td><span class="badge badge-fail">No</span></td><td>Redis cache is deployed in a single region without geo-replication for DR</td><td>Configure active or passive geo-replication for cross-region failover</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-cache/providers/Microsoft.Cache/redis/redis-session-prod</td><td><a href="https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-geo-replication" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
+      <tr data-severity="Info" data-source="wara"><td>Network security group is well-configured</td><td><span class='badge sev-info'>Info</span></td><td>wara</td><td><span class="badge badge-ok">Yes</span></td><td class="detail-cell" title="NSG has appropriate rules and restrictions">NSG has appropriate rules and restrictions</td><td>No action needed</td><td class="resource-id">/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityGroups/nsg1</td><td></td></tr>
     </tbody>
   </table>
 </details>
 <details id="cat-security">
-  <summary><strong>Security</strong> <span class="cat-count">(4)</span></summary>
-  <div class="filter-box no-print"><input type="text" placeholder="Filter rows..." onkeyup="filterTable(this,'tbl-security-4')" class="filter-input"></div>
-  <table id="tbl-security-4" class="findings-table sortable">
+  <summary><strong>Security</strong> <span class="cat-count">(1)</span></summary>
+  <div class="filter-box"><input type="text" placeholder="Filter this category..." onkeyup="filterTable(this)" class="filter-input"></div>
+  <table class="findings-table">
     <thead>
       <tr>
         <th onclick="sortTable(this)">Title</th>
@@ -264,17 +227,14 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td>Key Vault soft delete is disabled</td><td><span class='badge sev-high'>High</span></td><td>azqr</td><td><span class="badge badge-fail">No</span></td><td>Key Vault does not have soft delete enabled, risking permanent data loss</td><td>Enable soft delete on the Key Vault via portal or CLI</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-security/providers/Microsoft.KeyVault/vaults/kv-prod-secrets</td><td><a href="https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
-      <tr><td>Azure SQL Database TDE is enabled</td><td><span class='badge sev-info'>Info</span></td><td>psrule</td><td><span class="badge badge-ok">Yes</span></td><td>Transparent Data Encryption is enabled on the SQL Database</td><td></td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-data/providers/Microsoft.Sql/servers/sql-prod-east/databases/db-orders</td><td></td></tr>
-      <tr><td>Tag policy inheritance is correctly configured</td><td><span class='badge sev-info'>Info</span></td><td>azgovviz</td><td><span class="badge badge-ok">Yes</span></td><td>Tag inheritance policy is assigned and enforced across subscriptions</td><td></td><td class="resource-id">/providers/Microsoft.Management/managementGroups/mg-root</td><td></td></tr>
-      <tr><td>No Azure Policy assigned at management group scope</td><td><span class='badge sev-medium'>Medium</span></td><td>azgovviz</td><td><span class="badge badge-fail">No</span></td><td>Management group 'mg-platform' has zero policy assignments, leaving governance gaps</td><td>Assign ALZ default policy set at the management group level</td><td class="resource-id">/providers/Microsoft.Management/managementGroups/mg-platform</td><td><a href="https://learn.microsoft.com/en-us/azure/governance/policy/overview" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
+      <tr data-severity="Medium" data-source="psrule"><td>Key Vault logging disabled</td><td><span class='badge sev-medium'>Medium</span></td><td>psrule</td><td><span class="badge badge-fail">No</span></td><td class="detail-cell" title="Key Vault doesn't have logging enabled for access tracking">Key Vault doesn't have logging enabled for access tracking</td><td>Enable Key Vault logging</td><td class="resource-id">/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.KeyVault/vaults/kv1</td><td></td></tr>
     </tbody>
   </table>
 </details>
 <details id="cat-storage">
-  <summary><strong>Storage</strong> <span class="cat-count">(2)</span></summary>
-  <div class="filter-box no-print"><input type="text" placeholder="Filter rows..." onkeyup="filterTable(this,'tbl-storage-5')" class="filter-input"></div>
-  <table id="tbl-storage-5" class="findings-table sortable">
+  <summary><strong>Storage</strong> <span class="cat-count">(1)</span></summary>
+  <div class="filter-box"><input type="text" placeholder="Filter this category..." onkeyup="filterTable(this)" class="filter-input"></div>
+  <table class="findings-table">
     <thead>
       <tr>
         <th onclick="sortTable(this)">Title</th>
@@ -288,34 +248,70 @@
       </tr>
     </thead>
     <tbody>
-      <tr><td>Storage account uses HTTPS-only transport</td><td><span class='badge sev-info'>Info</span></td><td>azqr</td><td><span class="badge badge-ok">Yes</span></td><td>Storage account correctly enforces HTTPS-only connections</td><td></td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-data/providers/Microsoft.Storage/storageAccounts/stproddata001</td><td></td></tr>
-      <tr><td>Storage account allows public blob access</td><td><span class='badge sev-medium'>Medium</span></td><td>alz-queries</td><td><span class="badge badge-fail">No</span></td><td>Storage account has AllowBlobPublicAccess set to true</td><td>Set AllowBlobPublicAccess to false on the storage account</td><td class="resource-id">/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-data/providers/Microsoft.Storage/storageAccounts/stprodlogs002</td><td><a href="https://learn.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-prevent" target="_blank" rel="noopener noreferrer">Learn more</a></td></tr>
+      <tr data-severity="High" data-source="azqr"><td>Storage account has public access</td><td><span class='badge sev-high'>High</span></td><td>azqr</td><td><span class="badge badge-fail">No</span></td><td class="detail-cell" title="Storage account allows public access without firewall rules">Storage account allows public access without firewall rules</td><td>Enable firewall and restrict access</td><td class="resource-id">/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/sa1</td><td><a href="https://docs.microsoft.com" target="_blank" rel="noopener">Learn more</a></td></tr>
     </tbody>
   </table>
 </details>
 
 <script>
+let state = { severity: null };
+function toggleFilterBySeverity(s) {
+  state.severity = state.severity === s ? null : s;
+  applyFilters();
+  updateBanner();
+}
+function clearAllFilters() {
+  state = { severity: null };
+  applyFilters();
+  updateBanner();
+}
+function applyFilters() {
+  const rows = document.querySelectorAll('.findings-table tbody tr');
+  let shown = 0;
+  rows.forEach(r => {
+    const match = !state.severity || r.dataset.severity === state.severity;
+    r.style.display = match ? '' : 'none';
+    if (match) shown++;
+  });
+  document.querySelectorAll('.card').forEach(c => c.classList.remove('active'));
+  if (state.severity) {
+    document.querySelector('.card-' + state.severity.toLowerCase()).classList.add('active');
+  }
+}
+function updateBanner() {
+  const banner = document.getElementById('filterBanner');
+  const shown = document.querySelectorAll('.findings-table tbody tr:not([style*="display: none"])').length;
+  if (state.severity) {
+    banner.classList.add('active');
+    document.getElementById('filterText').textContent = 'Showing ' + shown + ' findings';
+  } else {
+    banner.classList.remove('active');
+  }
+}
 function sortTable(th) {
   const table = th.closest('table');
   const tbody = table.querySelector('tbody');
-  const rows = Array.from(tbody.querySelectorAll('tr'));
+  const rows = Array.from(tbody.querySelectorAll('tr')).filter(r => r.style.display !== 'none');
   const idx = Array.from(th.parentNode.children).indexOf(th);
-  const asc = th.dataset.sort !== 'asc';
-  th.dataset.sort = asc ? 'asc' : 'desc';
+  const col = th.dataset.sort === 'asc' ? 'desc' : 'asc';
+  th.parentNode.querySelectorAll('th').forEach(h => h.classList.remove('sort-asc', 'sort-desc'));
+  th.classList.add('sort-' + col);
+  th.dataset.sort = col;
   rows.sort((a, b) => {
     const ta = a.cells[idx].textContent.trim();
     const tb = b.cells[idx].textContent.trim();
-    return asc ? ta.localeCompare(tb) : tb.localeCompare(ta);
+    const cmp = isNaN(ta) ? ta.localeCompare(tb) : Number(ta) - Number(tb);
+    return col === 'asc' ? cmp : -cmp;
   });
   rows.forEach(r => tbody.appendChild(r));
 }
-function filterTable(input, tableId) {
-  var filter = input.value.toLowerCase();
-  var rows = document.getElementById(tableId).getElementsByTagName('tr');
-  for (var i = 1; i < rows.length; i++) {
-    rows[i].style.display = rows[i].textContent.toLowerCase().includes(filter) ? '' : 'none';
-  }
+function filterTable(input) {
+  const filter = input.value.toLowerCase();
+  input.closest('details').querySelectorAll('tbody tr').forEach(r => {
+    r.style.display = r.textContent.toLowerCase().includes(filter) ? '' : 'none';
+  });
 }
 </script>
+
 </body>
 </html>

--- a/samples/sample-results.json
+++ b/samples/sample-results.json
@@ -258,7 +258,7 @@
     "Title": "Branch-Protection",
     "Severity": "High",
     "Compliant": false,
-    "Detail": "branch protection is not enabled on development/release branches — score 2/10",
+    "Detail": "branch protection is not enabled on development/release branches (score 2/10)",
     "Remediation": "",
     "ResourceId": "github.com/martinopedal/azure-analyzer",
     "LearnMoreUrl": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection"
@@ -270,7 +270,7 @@
     "Title": "Pinned-Dependencies",
     "Severity": "Medium",
     "Compliant": false,
-    "Detail": "dependency not pinned by hash detected in GitHub Actions workflow — score 5/10",
+    "Detail": "dependency not pinned by hash detected in GitHub Actions workflow (score 5/10)",
     "Remediation": "",
     "ResourceId": "github.com/martinopedal/azure-analyzer",
     "LearnMoreUrl": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies"
@@ -282,7 +282,7 @@
     "Title": "Code-Review",
     "Severity": "Low",
     "Compliant": true,
-    "Detail": "all changesets reviewed before merge — score 8/10",
+    "Detail": "all changesets reviewed before merge (score 8/10)",
     "Remediation": "",
     "ResourceId": "github.com/martinopedal/azure-analyzer",
     "LearnMoreUrl": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review"
@@ -294,7 +294,7 @@
     "Title": "SAST",
     "Severity": "Info",
     "Compliant": true,
-    "Detail": "SAST tool detected: CodeQL — score 10/10",
+    "Detail": "SAST tool detected: CodeQL (score 10/10)",
     "Remediation": "",
     "ResourceId": "github.com/martinopedal/azure-analyzer",
     "LearnMoreUrl": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast"

--- a/samples/sample-results.json
+++ b/samples/sample-results.json
@@ -250,5 +250,53 @@
     "Remediation": "",
     "ResourceId": "",
     "LearnMoreUrl": ""
+  },
+  {
+    "Id": "scorecard-bp-001",
+    "Source": "scorecard",
+    "Category": "Supply Chain",
+    "Title": "Branch-Protection",
+    "Severity": "High",
+    "Compliant": false,
+    "Detail": "branch protection is not enabled on development/release branches — score 2/10",
+    "Remediation": "",
+    "ResourceId": "github.com/martinopedal/azure-analyzer",
+    "LearnMoreUrl": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection"
+  },
+  {
+    "Id": "scorecard-pd-002",
+    "Source": "scorecard",
+    "Category": "Supply Chain",
+    "Title": "Pinned-Dependencies",
+    "Severity": "Medium",
+    "Compliant": false,
+    "Detail": "dependency not pinned by hash detected in GitHub Actions workflow — score 5/10",
+    "Remediation": "",
+    "ResourceId": "github.com/martinopedal/azure-analyzer",
+    "LearnMoreUrl": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies"
+  },
+  {
+    "Id": "scorecard-cr-003",
+    "Source": "scorecard",
+    "Category": "Supply Chain",
+    "Title": "Code-Review",
+    "Severity": "Low",
+    "Compliant": true,
+    "Detail": "all changesets reviewed before merge — score 8/10",
+    "Remediation": "",
+    "ResourceId": "github.com/martinopedal/azure-analyzer",
+    "LearnMoreUrl": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review"
+  },
+  {
+    "Id": "scorecard-sa-004",
+    "Source": "scorecard",
+    "Category": "Supply Chain",
+    "Title": "SAST",
+    "Severity": "Info",
+    "Compliant": true,
+    "Detail": "SAST tool detected: CodeQL — score 10/10",
+    "Remediation": "",
+    "ResourceId": "github.com/martinopedal/azure-analyzer",
+    "LearnMoreUrl": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast"
   }
 ]

--- a/samples/sample-results.json
+++ b/samples/sample-results.json
@@ -214,5 +214,41 @@
     "Remediation": "",
     "ResourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg-prod-security/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-app-keyvault",
     "LearnMoreUrl": ""
+  },
+  {
+    "Id": "maester-ca-001",
+    "Source": "maester",
+    "Category": "Conditional Access",
+    "Title": "No Conditional Access policy requires MFA for all users",
+    "Severity": "High",
+    "Compliant": false,
+    "Detail": "No policy enforces multi-factor authentication for all users, leaving accounts vulnerable to credential theft",
+    "Remediation": "Create a Conditional Access policy requiring MFA for all users with minimal exclusions",
+    "ResourceId": "",
+    "LearnMoreUrl": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-all-users-mfa"
+  },
+  {
+    "Id": "maester-auth-002",
+    "Source": "maester",
+    "Category": "Authentication Methods",
+    "Title": "Legacy authentication protocols are not blocked",
+    "Severity": "High",
+    "Compliant": false,
+    "Detail": "Legacy authentication protocols (IMAP, SMTP, POP3) are still permitted, bypassing MFA protections",
+    "Remediation": "Create a Conditional Access policy to block legacy authentication for all users",
+    "ResourceId": "",
+    "LearnMoreUrl": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication"
+  },
+  {
+    "Id": "maester-eidsca-003",
+    "Source": "maester",
+    "Category": "EIDSCA",
+    "Title": "Self-service password reset is correctly configured",
+    "Severity": "Info",
+    "Compliant": true,
+    "Detail": "SSPR is enabled for all users with appropriate authentication methods required",
+    "Remediation": "",
+    "ResourceId": "",
+    "LearnMoreUrl": ""
   }
 ]


### PR DESCRIPTION
## Summary

Adds two new assessment tool wrappers to azure-analyzer, bringing the total from 5 to 7:

### Tool #6: Maester (Entra ID security posture)
- Auto-installs from PSGallery, verifies Microsoft Graph connection
- Maps Pester test results to unified schema with severity from tags
- Runs unconditionally (tenant-scoped, not subscription-gated)

### Tool #7: OpenSSF Scorecard (supply chain security)
- Wraps \scorecard\ CLI binary (\scorecard --repo=... --format=json\)
- Maps check scores to severity: 0-3=High, 4-6=Medium, 7-9=Low, 10=Info
- Compliant threshold: score >= 7
- Skips unevaluated checks (score -1)
- New \-Repository\ parameter on orchestrator (optional, skipped if not provided)
- Set \GITHUB_AUTH_TOKEN\ env var for authenticated requests (higher rate limits)

### Report integration
- Both tools added to HTML report source arrays (\llSources\, \sourceLabels\, \sourceColors\)
- Maester: purple \#7b1fa2\; Scorecard: amber \#ff6f00\

### Sample data
- 3 Maester findings (Conditional Access, Authentication Methods, EIDSCA)
- 4 Scorecard findings (Branch-Protection, Pinned-Dependencies, Code-Review, SAST)

### Files changed
- \modules/Invoke-Maester.ps1\ — new wrapper
- \modules/Invoke-Scorecard.ps1\ — new wrapper
- \Invoke-AzureAnalyzer.ps1\ — orchestrator wiring for steps 6/7 and 7/7
- \New-HtmlReport.ps1\ — source arrays
- \samples/sample-results.json\ — sample findings
- \CHANGELOG.md\, \README.md\, \PERMISSIONS.md\ — documentation