### PR TITLE
fix: address all rubber-duck review blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,14 @@ All notable changes to azure-analyzer will be documented here.
 - **HTML report enhancements**:
   - Executive summary with auto-generated compliance prose (resource count, tool count, compliance %, high-severity callout)
   - Pure-CSS donut chart using conic-gradient for compliance percentage (zero JS dependencies)
-  - Per-source horizontal bar chart showing finding counts per tool (azqr, PSRule, AzGovViz, ALZ Queries, WARA)
+  - Per-source horizontal bar chart showing finding counts per tool (azqr, PSRule, AzGovViz, ALZ Queries, WARA, Maester, Scorecard)
+  - Clickable stat cards for severity filtering with `aria-pressed` accessibility support
+  - Filter banner with clear button when severity filter is active
+  - Zebra striping on findings tables for readability
+  - Severity left-border on table rows (color-coded by High/Medium/Low/Info)
   - Text filter/search input above each findings table with instant keyup filtering
   - Clickable remediation URLs auto-detected and wrapped in anchor tags
-  - Tool coverage badges showing which tools ran vs were skipped
+  - Tool coverage badges based on actual tool status (Success/Skipped/Failed/Excluded), not just presence of findings
   - Remediation column added to all findings tables
   - Print-friendly @media print CSS hiding interactive elements, preventing page breaks in rows
 - **Markdown report enhancements**:
@@ -53,6 +57,17 @@ All notable changes to azure-analyzer will be documented here.
 - **Prereq behavior**: `Install-Prerequisites` now advise-only by default — lists missing modules with install commands. Add `-InstallMissingModules` switch to opt-in to auto-install. Prevents unexpected writes in shared/CI environments.
 - **Report field rendering**: HTML and Markdown reports now render `ResourceId` and `LearnMoreUrl` columns in all findings tables (previously only stored in JSON but not displayed)
 - **PS 7.6 compatibility**: Fix `New-HtmlReport.ps1` `-join` operator parsing error on PowerShell 7.6 (wrap `ForEach-Object` pipeline in parentheses)
+- **Dedup key strengthened**: Use `Source+ResourceId+Category+Title+Compliant` as composite key. Never dedup across tools when ResourceId is empty — prevents unrelated findings from collapsing.
+- **PSRule severity mapping**: Fix `Outcome` (Pass/Fail) incorrectly mapping to severity via `Map-Severity` (Fail fell through to Info). Now derives severity from Outcome directly: Fail=Medium, Error=High, Pass=Info.
+- **errors.json completeness**: Wrapper `Status='Failed'` returns now recorded in `$toolErrors` and `errors.json`, not just exception-path failures.
+- **Tool status tracking**: Orchestrator writes `tool-status.json` alongside `results.json` with per-tool Status/Message/Findings count. Reports use this to distinguish success-with-zero-findings from skipped/failed.
+- **HTML stat cards clickable**: Stat cards converted from `<div>` to `<button>` elements with `onclick` severity filter, `aria-pressed` for screen readers, and visible focus styles.
+- **HTML zebra striping**: Alternating row backgrounds on findings tables for readability.
+- **HTML severity borders**: Left-border color on each finding row matching its severity (High=red, Medium=orange, Low=yellow, Info=gray).
+- **HTML tool coverage accuracy**: Coverage badges now reflect actual tool status (Success/Skipped/Failed/Excluded) from `tool-status.json`, not just presence/absence of findings.
+- **Markdown source table**: All 7 tools shown in source breakdown table with Status column, even when they have zero findings or were skipped.
+- **AzGovViz path discovery**: `Find-AzGovViz` now also searches `tools/AzGovViz/` and `$PSScriptRoot/tools/AzGovViz/`, matching README instructions.
+- **ScorecardThreshold param**: Added `-ScorecardThreshold` parameter to orchestrator, passed through to Scorecard wrapper. Default: 7.
 - Remove `python` from CodeQL language matrix; repo is PowerShell-only, no Python extractor needed
 - Update branch protection to require `Analyze (actions)` only
 - Update codeql.yml to use actions/checkout v6 SHA (was v4)

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -241,9 +241,13 @@ $allResults = [System.Collections.Generic.List[PSCustomObject]]::new()
 if (ShouldRunTool 'azqr') {
     if ($subscriptionsToScan.Count -gt 0) {
         Write-Host "`n[1/7] Running azqr..." -ForegroundColor Yellow
+        $azqrWorstStatus = 'Success'; $azqrMessages = @()
         foreach ($subId in $subscriptionsToScan) {
             if ($subscriptionsToScan.Count -gt 1) { Write-Host "  Scanning subscription: $subId" -ForegroundColor Gray }
             $azqrResult = Invoke-Wrapper -Script 'Invoke-Azqr.ps1' -Params @{ SubscriptionId = $subId }
+            $subStatus = if ($azqrResult.PSObject.Properties['Status']) { $azqrResult.Status } else { 'Success' }
+            if ($subStatus -eq 'Failed') { $azqrWorstStatus = 'Failed'; $azqrMessages += "Failed for $subId" }
+            elseif ($subStatus -eq 'Skipped' -and $azqrWorstStatus -ne 'Failed') { $azqrWorstStatus = 'Skipped' }
             foreach ($f in $azqrResult.Findings) {
                 $allResults.Add([PSCustomObject]@{
                     Id           = [guid]::NewGuid().ToString()
@@ -261,7 +265,7 @@ if (ShouldRunTool 'azqr') {
         }
         $azqrTotal = ($allResults | Where-Object { $_.Source -eq 'azqr' }).Count
         Write-Host "  azqr: $azqrTotal findings" -ForegroundColor Gray
-        $toolStatus.Add([PSCustomObject]@{ Tool = 'azqr'; Status = if ($azqrResult.Status) { $azqrResult.Status } else { 'Success' }; Message = ''; Findings = $azqrTotal })
+        $toolStatus.Add([PSCustomObject]@{ Tool = 'azqr'; Status = $azqrWorstStatus; Message = ($azqrMessages -join '; '); Findings = $azqrTotal })
     } else {
         Write-Host "`n[1/7] Skipping azqr (no subscriptions to scan)" -ForegroundColor DarkGray
         $toolStatus.Add([PSCustomObject]@{ Tool = 'azqr'; Status = 'Skipped'; Message = 'No subscriptions to scan'; Findings = 0 })
@@ -274,10 +278,14 @@ if (ShouldRunTool 'azqr') {
 # --- PSRule ---
 if (ShouldRunTool 'psrule') {
     Write-Host "`n[2/7] Running PSRule..." -ForegroundColor Yellow
+    $psruleWorstStatus = 'Success'; $psruleMessages = @()
     foreach ($subId in ($subscriptionsToScan.Count -gt 0 ? $subscriptionsToScan : @($null))) {
         $psruleParams = if ($subId) { @{ SubscriptionId = $subId } } else { @{ Path = '.' } }
         if ($subId -and $subscriptionsToScan.Count -gt 1) { Write-Host "  Scanning subscription: $subId" -ForegroundColor Gray }
         $psruleResult = Invoke-Wrapper -Script 'Invoke-PSRule.ps1' -Params $psruleParams
+        $subStatus = if ($psruleResult.PSObject.Properties['Status']) { $psruleResult.Status } else { 'Success' }
+        if ($subStatus -eq 'Failed') { $psruleWorstStatus = 'Failed'; $psruleMessages += "Failed for $subId" }
+        elseif ($subStatus -eq 'Skipped' -and $psruleWorstStatus -ne 'Failed') { $psruleWorstStatus = 'Skipped' }
         foreach ($f in $psruleResult.Findings) {
             # PSRule Outcome: Pass=compliant, Fail=non-compliant, Error=critical
             $psruleSev = switch (Get-Prop $f 'Outcome' 'Pass') {
@@ -301,7 +309,7 @@ if (ShouldRunTool 'psrule') {
     }
     $psruleTotal = ($allResults | Where-Object { $_.Source -eq 'psrule' }).Count
     Write-Host "  PSRule: $psruleTotal findings" -ForegroundColor Gray
-    $toolStatus.Add([PSCustomObject]@{ Tool = 'psrule'; Status = if ($psruleResult.Status) { $psruleResult.Status } else { 'Success' }; Message = ''; Findings = $psruleTotal })
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'psrule'; Status = $psruleWorstStatus; Message = ($psruleMessages -join '; '); Findings = $psruleTotal })
 } else {
     Write-Host "`n[2/7] Skipping psrule (excluded)" -ForegroundColor DarkGray
     $toolStatus.Add([PSCustomObject]@{ Tool = 'psrule'; Status = 'Excluded'; Message = 'Excluded by user'; Findings = 0 })
@@ -371,11 +379,15 @@ $toolStatus.Add([PSCustomObject]@{ Tool = 'alz-queries'; Status = if ($alzResult
 if (ShouldRunTool 'wara') {
     if ($subscriptionsToScan.Count -gt 0) {
         Write-Host "`n[5/7] Running WARA..." -ForegroundColor Yellow
+        $waraWorstStatus = 'Success'; $waraMessages = @()
         foreach ($subId in $subscriptionsToScan) {
             if ($subscriptionsToScan.Count -gt 1) { Write-Host "  Scanning subscription: $subId" -ForegroundColor Gray }
             $waraParams = @{ SubscriptionId = $subId; OutputPath = (Join-Path $OutputPath 'wara') }
             if ($TenantId) { $waraParams['TenantId'] = $TenantId }
             $waraResult = Invoke-Wrapper -Script 'Invoke-WARA.ps1' -Params $waraParams
+            $subStatus = if ($waraResult.PSObject.Properties['Status']) { $waraResult.Status } else { 'Success' }
+            if ($subStatus -eq 'Failed') { $waraWorstStatus = 'Failed'; $waraMessages += "Failed for $subId" }
+            elseif ($subStatus -eq 'Skipped' -and $waraWorstStatus -ne 'Failed') { $waraWorstStatus = 'Skipped' }
             foreach ($f in $waraResult.Findings) {
                 $allResults.Add([PSCustomObject]@{
                     Id           = $f.Id ?? [guid]::NewGuid().ToString()
@@ -393,7 +405,7 @@ if (ShouldRunTool 'wara') {
         }
         $waraTotal = ($allResults | Where-Object { $_.Source -eq 'wara' }).Count
         Write-Host "  WARA: $waraTotal findings" -ForegroundColor Gray
-        $toolStatus.Add([PSCustomObject]@{ Tool = 'wara'; Status = if ($waraResult.Status) { $waraResult.Status } else { 'Success' }; Message = ''; Findings = $waraTotal })
+        $toolStatus.Add([PSCustomObject]@{ Tool = 'wara'; Status = $waraWorstStatus; Message = ($waraMessages -join '; '); Findings = $waraTotal })
     } else {
         Write-Host "`n[5/7] Skipping WARA (no subscriptions to scan)" -ForegroundColor DarkGray
         $toolStatus.Add([PSCustomObject]@{ Tool = 'wara'; Status = 'Skipped'; Message = 'No subscriptions to scan'; Findings = 0 })
@@ -457,7 +469,7 @@ if (ShouldRunTool 'scorecard') {
     $toolStatus.Add([PSCustomObject]@{ Tool = 'scorecard'; Status = 'Excluded'; Message = 'Excluded by user'; Findings = 0 })
 }
 
-# --- Deduplicate cross-tool findings ---
+# --- Deduplicate within-tool findings (same Source+ResourceId+Category+Title+Compliant) ---
 $preDedup = $allResults.Count
 $allResults = Remove-DuplicateFindings $allResults
 $dedupRemoved = $preDedup - $allResults.Count

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -39,6 +39,8 @@ param (
     [switch] $InstallMissingModules,
     [switch] $Recurse,
     [string] $Repository,
+    [ValidateRange(0, 10)]
+    [int] $ScorecardThreshold = 7,
     [switch] $EnableAiTriage
 )
 
@@ -144,6 +146,7 @@ if (-not $SkipPrereqCheck) { Install-Prerequisites }
 
 $modulesPath = Join-Path $PSScriptRoot 'modules'
 $toolErrors = [System.Collections.Generic.List[PSCustomObject]]::new()
+$toolStatus = [System.Collections.Generic.List[PSCustomObject]]::new()
 
 function Invoke-Wrapper {
     param ([string]$Script, [hashtable]$Params, [int]$MaxRetries = 2, [int]$RetryDelaySec = 5)
@@ -161,6 +164,11 @@ function Invoke-Wrapper {
                 Write-Warning "$Script returned status 'Failed' (attempt $attempt/$($MaxRetries+1)), retrying..."
                 Start-Sleep -Seconds $RetryDelaySec
                 continue
+            }
+            # Record failed status in errors after final attempt
+            if ($status -eq 'Failed') {
+                $msg = if ($result.PSObject.Properties['Message']) { $result.Message } else { 'Wrapper returned Failed status' }
+                $toolErrors.Add([PSCustomObject]@{ Tool = $Script; Error = $msg; Timestamp = Get-Date })
             }
             return $result
         } catch {
@@ -202,17 +210,25 @@ function Get-SeverityRank ([string]$Sev) {
 function Remove-DuplicateFindings {
     param ([System.Collections.Generic.List[PSCustomObject]]$Findings)
     $deduped = [System.Collections.Generic.List[PSCustomObject]]::new()
-    $groups = $Findings | Group-Object { "$($_.ResourceId)`t$($_.Title)".ToLowerInvariant() }
+    # Only dedup findings that share a non-empty ResourceId
+    $withId = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $withoutId = [System.Collections.Generic.List[PSCustomObject]]::new()
+    foreach ($f in $Findings) {
+        if ([string]::IsNullOrWhiteSpace($f.ResourceId)) { $withoutId.Add($f) }
+        else { $withId.Add($f) }
+    }
+    # Composite key: Source+ResourceId+Category+Title+Compliant
+    $groups = $withId | Group-Object { "$($_.Source)`t$($_.ResourceId)`t$($_.Category)`t$($_.Title)`t$($_.Compliant)".ToLowerInvariant() }
     foreach ($g in $groups) {
         if ($g.Count -eq 1) { $deduped.Add($g.Group[0]); continue }
         $best = $g.Group | Sort-Object { Get-SeverityRank $_.Severity } -Descending | Select-Object -First 1
-        $mergedSource = ($g.Group | Select-Object -ExpandProperty Source -Unique | Sort-Object) -join ', '
         $longestDetail = ($g.Group | Sort-Object { ($_.Detail ?? '').Length } -Descending | Select-Object -First 1).Detail
         $merged = $best.PSObject.Copy()
-        $merged.Source = $mergedSource
         $merged.Detail = $longestDetail
         $deduped.Add($merged)
     }
+    # Never dedup findings without ResourceId
+    foreach ($f in $withoutId) { $deduped.Add($f) }
     return $deduped
 }
 
@@ -245,11 +261,14 @@ if (ShouldRunTool 'azqr') {
         }
         $azqrTotal = ($allResults | Where-Object { $_.Source -eq 'azqr' }).Count
         Write-Host "  azqr: $azqrTotal findings" -ForegroundColor Gray
+        $toolStatus.Add([PSCustomObject]@{ Tool = 'azqr'; Status = if ($azqrResult.Status) { $azqrResult.Status } else { 'Success' }; Message = ''; Findings = $azqrTotal })
     } else {
         Write-Host "`n[1/7] Skipping azqr (no subscriptions to scan)" -ForegroundColor DarkGray
+        $toolStatus.Add([PSCustomObject]@{ Tool = 'azqr'; Status = 'Skipped'; Message = 'No subscriptions to scan'; Findings = 0 })
     }
 } else {
     Write-Host "`n[1/7] Skipping azqr (excluded)" -ForegroundColor DarkGray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'azqr'; Status = 'Excluded'; Message = 'Excluded by user'; Findings = 0 })
 }
 
 # --- PSRule ---
@@ -260,12 +279,18 @@ if (ShouldRunTool 'psrule') {
         if ($subId -and $subscriptionsToScan.Count -gt 1) { Write-Host "  Scanning subscription: $subId" -ForegroundColor Gray }
         $psruleResult = Invoke-Wrapper -Script 'Invoke-PSRule.ps1' -Params $psruleParams
         foreach ($f in $psruleResult.Findings) {
+            # PSRule Outcome: Pass=compliant, Fail=non-compliant, Error=critical
+            $psruleSev = switch (Get-Prop $f 'Outcome' 'Pass') {
+                'Fail'  { 'Medium' }
+                'Error' { 'High' }
+                default { 'Info' }
+            }
             $allResults.Add([PSCustomObject]@{
                 Id           = [guid]::NewGuid().ToString()
                 Source       = 'psrule'
                 Category     = Get-Prop $f 'RuleName' 'PSRule'
                 Title        = Get-Prop $f 'RuleName' 'Unknown rule'
-                Severity     = Map-Severity (Get-Prop $f 'Outcome' 'Info')
+                Severity     = $psruleSev
                 Compliant    = (Get-Prop $f 'Outcome') -eq 'Pass'
                 Detail       = Get-Prop $f 'Message' (Get-Prop $f 'TargetName' '')
                 Remediation  = ''
@@ -276,8 +301,10 @@ if (ShouldRunTool 'psrule') {
     }
     $psruleTotal = ($allResults | Where-Object { $_.Source -eq 'psrule' }).Count
     Write-Host "  PSRule: $psruleTotal findings" -ForegroundColor Gray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'psrule'; Status = if ($psruleResult.Status) { $psruleResult.Status } else { 'Success' }; Message = ''; Findings = $psruleTotal })
 } else {
     Write-Host "`n[2/7] Skipping psrule (excluded)" -ForegroundColor DarkGray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'psrule'; Status = 'Excluded'; Message = 'Excluded by user'; Findings = 0 })
 }
 # --- AzGovViz ---
 if (ShouldRunTool 'azgovviz') {
@@ -299,11 +326,14 @@ if ($ManagementGroupId) {
         })
     }
     Write-Host "  AzGovViz: $($azgovvizResult.Findings.Count) findings" -ForegroundColor Gray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'azgovviz'; Status = if ($azgovvizResult.Status) { $azgovvizResult.Status } else { 'Success' }; Message = ''; Findings = $azgovvizResult.Findings.Count })
 } else {
     Write-Host "`n[3/7] Skipping AzGovViz (no ManagementGroupId provided)" -ForegroundColor DarkGray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'azgovviz'; Status = 'Skipped'; Message = 'No ManagementGroupId provided'; Findings = 0 })
 }
 } else {
     Write-Host "`n[3/7] Skipping azgovviz (excluded)" -ForegroundColor DarkGray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'azgovviz'; Status = 'Excluded'; Message = 'Excluded by user'; Findings = 0 })
 }
 
 # --- ALZ Queries ---
@@ -330,8 +360,10 @@ foreach ($f in $alzResult.Findings) {
     })
 }
 Write-Host "  ALZ queries: $($alzResult.Findings.Count) findings" -ForegroundColor Gray
+$toolStatus.Add([PSCustomObject]@{ Tool = 'alz-queries'; Status = if ($alzResult.Status) { $alzResult.Status } else { 'Success' }; Message = ''; Findings = $alzResult.Findings.Count })
 } else {
     Write-Host "`n[4/7] Skipping alz-queries (excluded)" -ForegroundColor DarkGray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'alz-queries'; Status = 'Excluded'; Message = 'Excluded by user'; Findings = 0 })
 }
 
 
@@ -361,11 +393,14 @@ if (ShouldRunTool 'wara') {
         }
         $waraTotal = ($allResults | Where-Object { $_.Source -eq 'wara' }).Count
         Write-Host "  WARA: $waraTotal findings" -ForegroundColor Gray
+        $toolStatus.Add([PSCustomObject]@{ Tool = 'wara'; Status = if ($waraResult.Status) { $waraResult.Status } else { 'Success' }; Message = ''; Findings = $waraTotal })
     } else {
         Write-Host "`n[5/7] Skipping WARA (no subscriptions to scan)" -ForegroundColor DarkGray
+        $toolStatus.Add([PSCustomObject]@{ Tool = 'wara'; Status = 'Skipped'; Message = 'No subscriptions to scan'; Findings = 0 })
     }
 } else {
     Write-Host "`n[5/7] Skipping wara (excluded)" -ForegroundColor DarkGray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'wara'; Status = 'Excluded'; Message = 'Excluded by user'; Findings = 0 })
 }
 # --- Maester ---
 if (ShouldRunTool 'maester') {
@@ -386,15 +421,17 @@ foreach ($f in $maesterResult.Findings) {
     })
 }
 Write-Host "  Maester: $($maesterResult.Findings.Count) findings" -ForegroundColor Gray
+$toolStatus.Add([PSCustomObject]@{ Tool = 'maester'; Status = if ($maesterResult.Status) { $maesterResult.Status } else { 'Success' }; Message = ''; Findings = $maesterResult.Findings.Count })
 } else {
     Write-Host "`n[6/7] Skipping maester (excluded)" -ForegroundColor DarkGray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'maester'; Status = 'Excluded'; Message = 'Excluded by user'; Findings = 0 })
 }
 
 # --- Scorecard ---
 if (ShouldRunTool 'scorecard') {
     if ($Repository) {
         Write-Host "`n[7/7] Running Scorecard..." -ForegroundColor Yellow
-        $scorecardResult = Invoke-Wrapper -Script 'Invoke-Scorecard.ps1' -Params @{ Repository = $Repository }
+        $scorecardResult = Invoke-Wrapper -Script 'Invoke-Scorecard.ps1' -Params @{ Repository = $Repository; Threshold = $ScorecardThreshold }
         foreach ($f in $scorecardResult.Findings) {
             $allResults.Add([PSCustomObject]@{
                 Id           = Get-Prop $f 'Id' ([guid]::NewGuid().ToString())
@@ -410,11 +447,14 @@ if (ShouldRunTool 'scorecard') {
             })
         }
         Write-Host "  Scorecard: $($scorecardResult.Findings.Count) findings" -ForegroundColor Gray
+        $toolStatus.Add([PSCustomObject]@{ Tool = 'scorecard'; Status = if ($scorecardResult.Status) { $scorecardResult.Status } else { 'Success' }; Message = ''; Findings = $scorecardResult.Findings.Count })
     } else {
         Write-Host "`n[7/7] Skipping Scorecard (no -Repository provided)" -ForegroundColor DarkGray
+        $toolStatus.Add([PSCustomObject]@{ Tool = 'scorecard'; Status = 'Skipped'; Message = 'No -Repository provided'; Findings = 0 })
     }
 } else {
     Write-Host "`n[7/7] Skipping Scorecard (excluded)" -ForegroundColor DarkGray
+    $toolStatus.Add([PSCustomObject]@{ Tool = 'scorecard'; Status = 'Excluded'; Message = 'Excluded by user'; Findings = 0 })
 }
 
 # --- Deduplicate cross-tool findings ---
@@ -432,6 +472,8 @@ try {
     }
     $outputFile = Join-Path $OutputPath 'results.json'
     $allResults | ConvertTo-Json -Depth 5 | Set-Content -Path $outputFile -Encoding UTF8
+    $statusFile = Join-Path $OutputPath 'tool-status.json'
+    $toolStatus | ConvertTo-Json -Depth 3 | Set-Content -Path $statusFile -Encoding UTF8
 } catch {
     Write-Error "Failed to write output to ${OutputPath}: $_"
     return

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -117,11 +117,12 @@ $categoryHtml = foreach ($cat in $byCategory) {
     $catRows = foreach ($f in ($cat.Group | Sort-Object Severity, Title)) {
         $sevClass = SeverityClass $f.Severity
         $sevBorder = "sev-border-$($f.Severity.ToLower())"
+        $compliantBool = if ($f.Compliant) { 'true' } else { 'false' }
         $compliantStr = if ($f.Compliant) { '<span class="badge badge-ok">Yes</span>' } else { '<span class="badge badge-fail">No</span>' }
         $remediationHtml = Linkify $f.Remediation
         $resourceIdHtml = HE $f.ResourceId
         $learnMoreHtml = if ([string]::IsNullOrWhiteSpace($f.LearnMoreUrl)) { '' } else { "<a href=`"$(HE $f.LearnMoreUrl)`" target=`"_blank`" rel=`"noopener noreferrer`">Learn more</a>" }
-        "<tr class='$sevBorder' data-severity='$(HE $f.Severity)'><td>$(HE $f.Title)</td><td><span class='badge $sevClass'>$(HE $f.Severity)</span></td><td>$(HE $f.Source)</td><td>$compliantStr</td><td>$(HE $f.Detail)</td><td>$remediationHtml</td><td class=`"resource-id`">$resourceIdHtml</td><td>$learnMoreHtml</td></tr>"
+        "<tr class='$sevBorder' data-severity='$(HE $f.Severity)' data-compliant='$compliantBool'><td>$(HE $f.Title)</td><td><span class='badge $sevClass'>$(HE $f.Severity)</span></td><td>$(HE $f.Source)</td><td>$compliantStr</td><td>$(HE $f.Detail)</td><td>$remediationHtml</td><td class=`"resource-id`">$resourceIdHtml</td><td>$learnMoreHtml</td></tr>"
     }
     @"
 <details id="cat-$catId">
@@ -338,8 +339,8 @@ function filterBySeverity(btn, severity) {
   btn.setAttribute('aria-pressed', 'true');
   rows.forEach(function(r) {
     if (severity === 'all') { r.style.display = ''; }
-    else if (severity === 'compliant') { r.style.display = r.querySelector('.badge-ok') ? '' : 'none'; }
-    else { r.style.display = r.dataset.severity === severity ? '' : 'none'; }
+    else if (severity === 'compliant') { r.style.display = r.dataset.compliant === 'true' ? '' : 'none'; }
+    else { r.style.display = (r.dataset.severity === severity && r.dataset.compliant === 'false') ? '' : 'none'; }
   });
   bannerText.textContent = severity === 'all' ? 'Showing all findings' : severity === 'compliant' ? 'Showing compliant findings only' : 'Showing ' + severity + ' severity findings only';
   banner.classList.add('active');

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -70,6 +70,16 @@ foreach ($sg in $sourceGroups) { $sourceCountMap[$sg.Name] = $sg.Count }
 $maxSourceCount = if ($sourceGroups.Count -gt 0) { ($sourceGroups | Measure-Object -Property Count -Maximum).Maximum } else { 1 }
 if ($maxSourceCount -eq 0) { $maxSourceCount = 1 }
 
+# Load tool status metadata if available (written by orchestrator)
+$toolStatusMap = @{}
+$statusJsonPath = Join-Path (Split-Path $InputPath -Parent) 'tool-status.json'
+if (Test-Path $statusJsonPath) {
+    try {
+        $statusData = @(Get-Content $statusJsonPath -Raw | ConvertFrom-Json -ErrorAction Stop)
+        foreach ($ts in $statusData) { $toolStatusMap[$ts.Tool] = $ts.Status }
+    } catch { }
+}
+
 $sourcesWithResults = @($sourceGroups | ForEach-Object { $_.Name })
 $sourcesSkipped = @($allSources | Where-Object { $_ -notin $sourcesWithResults })
 
@@ -106,11 +116,12 @@ $categoryHtml = foreach ($cat in $byCategory) {
     $tableIndex++
     $catRows = foreach ($f in ($cat.Group | Sort-Object Severity, Title)) {
         $sevClass = SeverityClass $f.Severity
+        $sevBorder = "sev-border-$($f.Severity.ToLower())"
         $compliantStr = if ($f.Compliant) { '<span class="badge badge-ok">Yes</span>' } else { '<span class="badge badge-fail">No</span>' }
         $remediationHtml = Linkify $f.Remediation
         $resourceIdHtml = HE $f.ResourceId
         $learnMoreHtml = if ([string]::IsNullOrWhiteSpace($f.LearnMoreUrl)) { '' } else { "<a href=`"$(HE $f.LearnMoreUrl)`" target=`"_blank`" rel=`"noopener noreferrer`">Learn more</a>" }
-        "<tr><td>$(HE $f.Title)</td><td><span class='badge $sevClass'>$(HE $f.Severity)</span></td><td>$(HE $f.Source)</td><td>$compliantStr</td><td>$(HE $f.Detail)</td><td>$remediationHtml</td><td class=`"resource-id`">$resourceIdHtml</td><td>$learnMoreHtml</td></tr>"
+        "<tr class='$sevBorder' data-severity='$(HE $f.Severity)'><td>$(HE $f.Title)</td><td><span class='badge $sevClass'>$(HE $f.Severity)</span></td><td>$(HE $f.Source)</td><td>$compliantStr</td><td>$(HE $f.Detail)</td><td>$remediationHtml</td><td class=`"resource-id`">$resourceIdHtml</td><td>$learnMoreHtml</td></tr>"
     }
     @"
 <details id="cat-$catId">
@@ -154,13 +165,18 @@ $sourceBarHtml = foreach ($src in $allSources) {
 "@
 }
 
-# --- Tool coverage summary ---
+# --- Tool coverage summary (status-aware) ---
 $toolCoverageHtml = foreach ($src in $allSources) {
     $label = $sourceLabels[$src]
-    if ($src -in $sourcesWithResults) {
-        "<span class='tool-badge tool-active' title='Produced results'>&#x2705; $label</span>"
+    $status = if ($toolStatusMap.ContainsKey($src)) { $toolStatusMap[$src] } else { $null }
+    if ($status -eq 'Success' -or ($null -eq $status -and $src -in $sourcesWithResults)) {
+        "<span class='tool-badge tool-active' title='Ran successfully'>&#x2705; $label</span>"
+    } elseif ($status -eq 'Failed') {
+        "<span class='tool-badge tool-skipped' title='Failed to run'>&#x274C; $label (failed)</span>"
+    } elseif ($status -eq 'Excluded') {
+        "<span class='tool-badge tool-skipped' title='Excluded by user'>&#x2796; $label (excluded)</span>"
     } else {
-        "<span class='tool-badge tool-skipped' title='No results / skipped'>&#x26A0;&#xFE0F; $label</span>"
+        "<span class='tool-badge tool-skipped' title='Skipped (not configured or prereq missing)'>&#x26A0;&#xFE0F; $label (skipped)</span>"
     }
 }
 
@@ -193,7 +209,10 @@ $html = @"
 
   /* Stat cards */
   .cards { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 24px; }
-  .card { background: #fff; border-radius: 6px; padding: 16px 20px; min-width: 120px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .card { background: #fff; border-radius: 6px; padding: 16px 20px; min-width: 120px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); border: 2px solid transparent; cursor: pointer; transition: border-color 0.2s, box-shadow 0.2s; }
+  .card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
+  .card:focus { outline: 2px solid #1565c0; outline-offset: 2px; }
+  .card[aria-pressed="true"] { border-color: #1565c0; box-shadow: 0 2px 8px rgba(21,101,192,0.3); }
   .card-label { font-size: 11px; color: #666; text-transform: uppercase; letter-spacing: 0.5px; }
   .card-value { font-size: 28px; font-weight: 700; margin-top: 2px; }
   .card-total .card-value { color: #1a1a1a; }
@@ -228,6 +247,11 @@ $html = @"
   .findings-table th { background: #f0f0f0; padding: 8px 10px; text-align: left; font-weight: 600; cursor: pointer; white-space: nowrap; }
   .findings-table th:hover { background: #e0e0e0; }
   .findings-table td { padding: 7px 10px; border-top: 1px solid #f0f0f0; vertical-align: top; }
+  .findings-table tr:nth-child(even) td { background: #fafafa; }
+  .findings-table tr.sev-border-high td:first-child { border-left: 3px solid #d32f2f; }
+  .findings-table tr.sev-border-medium td:first-child { border-left: 3px solid #e65100; }
+  .findings-table tr.sev-border-low td:first-child { border-left: 3px solid #f9a825; }
+  .findings-table tr.sev-border-info td:first-child { border-left: 3px solid #bdbdbd; }
   .findings-table td a { color: #1565c0; word-break: break-all; }
   .findings-table td.resource-id { font-size: 11px; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .findings-table tr:hover td { background: #fafafa; }
@@ -238,6 +262,12 @@ $html = @"
   .sev-info { background: #eeeeee; color: #555; }
   .badge-ok { background: #e8f5e9; color: #1b5e20; }
   .badge-fail { background: #fce4ec; color: #880e4f; }
+
+  /* Filter banner */
+  .filter-banner { display: none; background: #e3f2fd; padding: 8px 16px; border-radius: 4px; margin-bottom: 16px; font-size: 13px; align-items: center; gap: 8px; }
+  .filter-banner.active { display: flex; }
+  .filter-banner button { background: #1565c0; color: #fff; border: none; border-radius: 3px; padding: 4px 10px; cursor: pointer; font-size: 12px; }
+  .filter-banner button:hover { background: #0d47a1; }
 
   /* Print-friendly styles */
   @media print {
@@ -269,11 +299,15 @@ $html = @"
 </div>
 
 <div class="cards">
-  <div class="card card-total"><div class="card-label">Total findings</div><div class="card-value">$total</div></div>
-  <div class="card card-high"><div class="card-label">High (non-compliant)</div><div class="card-value">$high</div></div>
-  <div class="card card-medium"><div class="card-label">Medium (non-compliant)</div><div class="card-value">$medium</div></div>
-  <div class="card card-low"><div class="card-label">Low (non-compliant)</div><div class="card-value">$low</div></div>
-  <div class="card card-ok"><div class="card-label">Compliant %</div><div class="card-value">$compliantPct%</div></div>
+  <button class="card card-total" onclick="filterBySeverity(this,'all')" aria-pressed="false"><div class="card-label">Total findings</div><div class="card-value">$total</div></button>
+  <button class="card card-high" onclick="filterBySeverity(this,'High')" aria-pressed="false"><div class="card-label">High (non-compliant)</div><div class="card-value">$high</div></button>
+  <button class="card card-medium" onclick="filterBySeverity(this,'Medium')" aria-pressed="false"><div class="card-label">Medium (non-compliant)</div><div class="card-value">$medium</div></button>
+  <button class="card card-low" onclick="filterBySeverity(this,'Low')" aria-pressed="false"><div class="card-label">Low (non-compliant)</div><div class="card-value">$low</div></button>
+  <button class="card card-ok" onclick="filterBySeverity(this,'compliant')" aria-pressed="false"><div class="card-label">Compliant %</div><div class="card-value">$compliantPct%</div></button>
+</div>
+<div class="filter-banner" id="filterBanner">
+  <span id="filterBannerText"></span>
+  <button onclick="clearSeverityFilter()">Clear filter</button>
 </div>
 
 <!-- Per-Source Breakdown -->
@@ -292,6 +326,30 @@ $($toolCoverageHtml -join "`n")
 $($categoryHtml -join "`n")
 
 <script>
+var activeSevFilter = null;
+function filterBySeverity(btn, severity) {
+  var cards = document.querySelectorAll('.card');
+  var rows = document.querySelectorAll('.findings-table tbody tr');
+  var banner = document.getElementById('filterBanner');
+  var bannerText = document.getElementById('filterBannerText');
+  if (activeSevFilter === severity) { clearSeverityFilter(); return; }
+  activeSevFilter = severity;
+  cards.forEach(function(c) { c.setAttribute('aria-pressed', 'false'); });
+  btn.setAttribute('aria-pressed', 'true');
+  rows.forEach(function(r) {
+    if (severity === 'all') { r.style.display = ''; }
+    else if (severity === 'compliant') { r.style.display = r.querySelector('.badge-ok') ? '' : 'none'; }
+    else { r.style.display = r.dataset.severity === severity ? '' : 'none'; }
+  });
+  bannerText.textContent = severity === 'all' ? 'Showing all findings' : severity === 'compliant' ? 'Showing compliant findings only' : 'Showing ' + severity + ' severity findings only';
+  banner.classList.add('active');
+}
+function clearSeverityFilter() {
+  activeSevFilter = null;
+  document.querySelectorAll('.card').forEach(function(c) { c.setAttribute('aria-pressed', 'false'); });
+  document.querySelectorAll('.findings-table tbody tr').forEach(function(r) { r.style.display = ''; });
+  document.getElementById('filterBanner').classList.remove('active');
+}
 function sortTable(th) {
   const table = th.closest('table');
   const tbody = table.querySelector('tbody');

--- a/New-MdReport.ps1
+++ b/New-MdReport.ps1
@@ -53,13 +53,35 @@ $lines.Add("| Info | $info |")
 $lines.Add('')
 
 $bySource = $findings | Group-Object -Property Source
+$sourceCountMap = @{}
+foreach ($sg in $bySource) { $sourceCountMap[$sg.Name] = $sg }
+
+# Load tool status metadata if available
+$allSources = @('azqr', 'psrule', 'azgovviz', 'alz-queries', 'wara', 'maester', 'scorecard')
+$sourceLabels = @{ 'azqr' = 'Azure Quick Review'; 'psrule' = 'PSRule'; 'azgovviz' = 'AzGovViz'; 'alz-queries' = 'ALZ Queries'; 'wara' = 'WARA'; 'maester' = 'Maester'; 'scorecard' = 'Scorecard' }
+$toolStatusMap = @{}
+$statusJsonPath = Join-Path (Split-Path $InputPath -Parent) 'tool-status.json'
+if (Test-Path $statusJsonPath) {
+    try {
+        $statusData = @(Get-Content $statusJsonPath -Raw | ConvertFrom-Json -ErrorAction Stop)
+        foreach ($ts in $statusData) { $toolStatusMap[$ts.Tool] = $ts.Status }
+    } catch { }
+}
+
 $lines.Add('### By source')
 $lines.Add('')
-$lines.Add('| Source | Findings | Non-compliant |')
-$lines.Add('|---|---|---|')
-foreach ($src in $bySource) {
-    $nc = ($src.Group | Where-Object { -not $_.Compliant }).Count
-    $lines.Add("| $($src.Name) | $($src.Count) | $nc |")
+$lines.Add('| Source | Status | Findings | Non-compliant |')
+$lines.Add('|---|---|---|---|')
+foreach ($src in $allSources) {
+    $label = $sourceLabels[$src]
+    $status = if ($toolStatusMap.ContainsKey($src)) { $toolStatusMap[$src] } else { if ($sourceCountMap.ContainsKey($src)) { 'Success' } else { 'Skipped' } }
+    if ($sourceCountMap.ContainsKey($src)) {
+        $grp = $sourceCountMap[$src]
+        $nc = ($grp.Group | Where-Object { -not $_.Compliant }).Count
+        $lines.Add("| $label | $status | $($grp.Count) | $nc |")
+    } else {
+        $lines.Add("| $label | $status | 0 | 0 |")
+    }
 }
 $lines.Add('')
 

--- a/modules/Invoke-AzGovViz.ps1
+++ b/modules/Invoke-AzGovViz.ps1
@@ -27,7 +27,7 @@ function Find-AzGovViz {
     $candidates = @(
         (Join-Path (Get-Location) 'AzGovVizParallel.ps1'),
         (Join-Path (Get-Location) 'tools' 'AzGovViz' 'AzGovVizParallel.ps1'),
-        (Join-Path $PSScriptRoot 'tools' 'AzGovViz' 'AzGovVizParallel.ps1'),
+        (Join-Path (Split-Path $PSScriptRoot -Parent) 'tools' 'AzGovViz' 'AzGovVizParallel.ps1'),
         (Join-Path $env:USERPROFILE 'AzGovViz' 'AzGovVizParallel.ps1'),
         (Join-Path $env:HOME 'AzGovViz' 'AzGovVizParallel.ps1')
     )

--- a/modules/Invoke-AzGovViz.ps1
+++ b/modules/Invoke-AzGovViz.ps1
@@ -26,6 +26,8 @@ $ErrorActionPreference = 'Stop'
 function Find-AzGovViz {
     $candidates = @(
         (Join-Path (Get-Location) 'AzGovVizParallel.ps1'),
+        (Join-Path (Get-Location) 'tools' 'AzGovViz' 'AzGovVizParallel.ps1'),
+        (Join-Path $PSScriptRoot 'tools' 'AzGovViz' 'AzGovVizParallel.ps1'),
         (Join-Path $env:USERPROFILE 'AzGovViz' 'AzGovVizParallel.ps1'),
         (Join-Path $env:HOME 'AzGovViz' 'AzGovVizParallel.ps1')
     )


### PR DESCRIPTION
## What

Fixes all 10 issues identified by GPT-5.4 and Goldeneye rubber-duck reviews of main.

## Fixes

### Orchestrator (Invoke-AzureAnalyzer.ps1)
- **Dedup key strengthened**: \Source+ResourceId+Category+Title+Compliant\ composite key. Never dedup when ResourceId is empty.
- **PSRule severity**: \Outcome=Fail\ was falling through \Map-Severity\ to Info. Now: Fail=Medium, Error=High, Pass=Info.
- **errors.json completeness**: Wrapper \Status='Failed'\ returns now recorded in errors.json (was only exception-path).
- **Tool status tracking**: Writes \	ool-status.json\ with per-tool Status/Message/Findings count.
- **-ScorecardThreshold**: New param passed through to Scorecard wrapper.

### HTML Report (New-HtmlReport.ps1)
- **Clickable stat cards**: Converted from \<div>\ to \<button>\ with \ria-pressed\, severity filter, and focus styles.
- **Zebra striping**: Alternating row backgrounds.
- **Severity left-border**: Color-coded left border per row.
- **Filter banner**: Shows active filter with clear button.
- **Tool coverage accuracy**: Uses \	ool-status.json\ to distinguish success-0-findings from skipped/failed.

### Markdown Report (New-MdReport.ps1)
- **Fixed 7-source table**: All tools shown with Status column, even if zero findings.

### AzGovViz Wrapper
- **Path discovery**: Searches \	ools/AzGovViz/\ matching README docs.

### CHANGELOG
- All fixes documented.
