### PR TITLE
fix: Invoke-Wrapper fallback paths return Status='Failed'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to azure-analyzer will be documented here.
 - Delete dead Python stubs (`src/run.py`, `src/__init__.py`) — orchestrator is PowerShell only
 
 ### Fixed
+- **Invoke-Wrapper fallback status**: Both fallback paths (script-not-found and exception-after-retries) now return `Status='Failed'` and `Message`, preventing `tool-status.json` and reports from falsely showing success after hard failures.
 - **Maester API mapping**: Fix `.Tests` → `.Result` to match Pester `TestResultContainer` returned by `Invoke-Maester -PassThru`. Handle `NotRun` status alongside `Passed`/`Skipped`.
 - **Graph scopes hint**: Warning message now shows `Connect-MgGraph -Scopes (Get-MtGraphScope)` with correct scope helper.
 - **Prereq behavior**: `Install-Prerequisites` now advise-only by default — lists missing modules with install commands. Add `-InstallMissingModules` switch to opt-in to auto-install. Prevents unexpected writes in shared/CI environments.

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -153,7 +153,7 @@ function Invoke-Wrapper {
     $scriptPath = Join-Path $modulesPath $Script
     if (-not (Test-Path $scriptPath)) {
         Write-Warning "$Script not found at $scriptPath"
-        return [PSCustomObject]@{ Source = $Script; Findings = @() }
+        return [PSCustomObject]@{ Source = $Script; Status = 'Failed'; Message = "Script not found: $scriptPath"; Findings = @() }
     }
     for ($attempt = 1; $attempt -le ($MaxRetries + 1); $attempt++) {
         try {
@@ -178,7 +178,7 @@ function Invoke-Wrapper {
             } else {
                 Write-Warning "$Script failed after $($MaxRetries+1) attempts: $_"
                 $toolErrors.Add([PSCustomObject]@{ Tool = $Script; Error = $_.Exception.Message; Timestamp = Get-Date })
-                return [PSCustomObject]@{ Source = $Script; Findings = @() }
+                return [PSCustomObject]@{ Source = $Script; Status = 'Failed'; Message = $_.Exception.Message; Findings = @() }
             }
         }
     }


### PR DESCRIPTION
Fixes the last finding from Goldeneye final validation: both fallback paths in \Invoke-Wrapper\ (script-not-found and exception-after-retries) now return \Status='Failed'\ and \Message\, preventing \	ool-status.json\, HTML coverage badges, and Markdown source table from falsely reporting success after hard failures.