### PR TITLE
fix: fall back to GITHUB_TOKEN in squad-issue-assign when PAT missing

### DIFF
--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -113,12 +113,17 @@ jobs:
 
             core.info(`Issue #${issue.number} assigned to ${assignedMember.name} (${assignedMember.role})`);
 
-      # Separate step: assign @copilot using PAT (required for coding agent)
+      # Separate step: assign @copilot using PAT (required for coding agent).
+      # Falls back to GITHUB_TOKEN when COPILOT_ASSIGN_TOKEN is not configured so
+      # the step runs and API rejection is caught by the script's try/catch
+      # instead of aborting with "Input required and not supplied: github-token".
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          HAS_COPILOT_PAT: ${{ secrets.COPILOT_ASSIGN_TOKEN != '' && '1' || '' }}
         with:
-          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -127,6 +132,10 @@ jobs:
             // Get the default branch name (main, master, etc.)
             const { data: repoData } = await github.rest.repos.get({ owner, repo });
             const baseBranch = repoData.default_branch;
+
+            if (!process.env.HAS_COPILOT_PAT) {
+              core.warning('COPILOT_ASSIGN_TOKEN not configured — attempting assignment with GITHUB_TOKEN. copilot-swe-agent[bot] assignment typically requires a PAT; configure the secret to enable autonomous cloud-agent pickup.');
+            }
 
             try {
               await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **`.github/workflows/squad-issue-assign.yml` — graceful fallback when `COPILOT_ASSIGN_TOKEN` is not configured**: The `Assign @copilot coding agent` step previously failed with `Error: Input required and not supplied: github-token` whenever a `squad:copilot` label was added to an issue in a repo without the PAT secret configured, filing a spurious `ci: failure in Squad Issue Assign` issue on every label event. Now falls back to `secrets.GITHUB_TOKEN` so `actions/github-script` receives a valid token, the API call runs through the existing try/catch, and a single `core.warning` documents the missing PAT instead of aborting the workflow. Matches the fallback pattern already used by `squad-heartbeat.yml`.
+
 ### Added
 - **Comment Triage Loop via 3-model rubber-duck gate**: Copilot comments on PRs *and* on linked issues are now triaged through **Opus 4.6 + Goldeneye + GPT-5.3-codex** as sync rubber-duck calls before any code change. Majority verdict drives `plan.md` + SQL todos; plan is rubber-ducked; implementation re-runs the 3-model gate on the diff. Codified in `.squad/ceremonies.md` → Cloud Agent PR Review (expanded agenda), `.squad/templates/skills/comment-triage/SKILL.md` (new SKILL), and `.github/copilot-instructions.md` → Cloud agent PR review contract. Applies equally to cloud agents (`copilot-swe-agent[bot]`) and background agents.
 - **Cloud agent PR review contract**:New `.github/workflows/copilot-agent-pr-review.yml` auto-requests Copilot code review on any PR authored by `copilot-swe-agent[bot]` and posts a policy comment stating that all Copilot review threads must be **Resolved** before the PR may be squash-merged. Codified in `.github/copilot-instructions.md` so both the authoring agent and maintainers see the review contract.


### PR DESCRIPTION
Fixes #85, #86, #87, #88 — the `Assign @copilot coding agent` step crashed with `Error: Input required and not supplied: github-token` every time a `squad:copilot` label was added to an issue, because `COPILOT_ASSIGN_TOKEN` is not configured as a repo secret. Four spurious `ci: failure in Squad Issue Assign` issues got filed overnight.

**Fix**: mirror the fallback already in `squad-heartbeat.yml` —

```yaml
github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
```

`actions/github-script` now receives a valid token, the API call runs through the existing try/catch, and the missing-PAT case is documented via `core.warning` instead of aborting the whole workflow.

Also adds a `HAS_COPILOT_PAT` env-gated log line so the warning surfaces once per run without leaking the secret value.

Docs:
- CHANGELOG Unreleased → Fixed

No test changes — this is a workflow-only fix verified against the observed failure signature in runs 24550522117 / 22779 / 23866 / 24451.