### PR TITLE
chore(ops): bump heartbeat cron to 15min + fix stale governance line

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -1185,7 +1185,7 @@ This runs as a standalone local process (not inside Copilot) that:
 |-------|------|-----|
 | **In-session** | You're at the keyboard | "Ralph, go" — active loop while work exists |
 | **Local watchdog** | You're away but machine is on | `npx @bradygaster/squad-cli watch --interval 10` |
-| **Cloud heartbeat** | Fully unattended | `squad-heartbeat.yml` — event-based only (cron disabled) |
+| **Cloud heartbeat** | Fully unattended | `squad-heartbeat.yml` — cron (`*/15 * * * *`) + event-based (issues/PRs) |
 
 ### Ralph State
 

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -8,8 +8,8 @@ name: Squad Heartbeat (Ralph)
 
 on:
   schedule:
-    # Every 30 minutes — adjust via cron expression as needed
-    - cron: '*/30 * * * *'
+    # Every 15 minutes — drives CI watchdog (#104) + PR review gate (#105)
+    - cron: '*/15 * * * *'
 
   # React to completed work or new squad work
   issues:

--- a/.squad/templates/squad.agent.md
+++ b/.squad/templates/squad.agent.md
@@ -1185,7 +1185,7 @@ This runs as a standalone local process (not inside Copilot) that:
 |-------|------|-----|
 | **In-session** | You're at the keyboard | "Ralph, go" — active loop while work exists |
 | **Local watchdog** | You're away but machine is on | `npx @bradygaster/squad-cli watch --interval 10` |
-| **Cloud heartbeat** | Fully unattended | `squad-heartbeat.yml` — event-based only (cron disabled) |
+| **Cloud heartbeat** | Fully unattended | `squad-heartbeat.yml` — cron (`*/15 * * * *`) + event-based (issues/PRs) |
 
 ### Ralph State
 

--- a/.squad/templates/workflows/squad-heartbeat.yml
+++ b/.squad/templates/workflows/squad-heartbeat.yml
@@ -8,8 +8,8 @@ name: Squad Heartbeat (Ralph)
 
 on:
   schedule:
-    # Every 30 minutes — adjust via cron expression as needed
-    - cron: '*/30 * * * *'
+    # Every 15 minutes — drives CI watchdog (#104) + PR review gate (#105)
+    - cron: '*/15 * * * *'
 
   # React to completed work or new squad work
   issues:


### PR DESCRIPTION
**Two small ops tweaks.**

### 1. Heartbeat interval: 30min -> 15min
More responsive for the CI watchdog (#104) and PR review gate (#105) that Forge and Sentinel are building. Lower latency between a failure landing on main and Ralph picking it up.

### 2. Governance doc fix
'.github/agents/squad.agent.md' line 1188 said 'cron disabled' but cron is actually enabled. Corrected to reflect the actual cron + event-based model.

### Files
- '.github/workflows/squad-heartbeat.yml'
- '.squad/templates/workflows/squad-heartbeat.yml' (template sync)
- '.github/agents/squad.agent.md'
- '.squad/templates/squad.agent.md' (template sync)

### Docs
No CHANGELOG entry — ops internals, not user-visible. No PERMISSIONS/README changes.