### PR TITLE
chore(ops): notification hygiene — upsert PR gate comment + draft PR default (#113)

### DIFF
--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -180,10 +180,15 @@ git push -u origin squad/{issue-number}-{slug}
 
 **GitHub:**
 ```bash
-gh pr create --title "{title}" \
+# Open as draft by default — reduces reviewer email noise during iteration.
+# Flip to ready-for-review once CI is green and self-review is complete.
+gh pr create --draft --title "{title}" \
   --body "Closes #{issue-number}\n\n{description}" \
   --head squad/{issue-number}-{slug} \
   --base main
+
+# When ready:
+# gh pr ready {pr-number}
 ```
 
 **Azure DevOps:**
@@ -314,7 +319,8 @@ When spawning an agent to work on an issue, include this context block:
 2. Push branch
 3. Open PR using:
    ```
-   gh pr create --title "{title}" --body "Closes #{number}\n\n{description}" --head squad/{issue-number}-{slug} --base {base-branch}
+   gh pr create --draft --title "{title}" --body "Closes #{number}\n\n{description}" --head squad/{issue-number}-{slug} --base {base-branch}
+   # Mark ready only after CI green + self-review done: gh pr ready {pr-number}
    ```
 4. Report PR URL to coordinator
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Changed
+- **Notification hygiene (#113)** — reduce email noise from the automation loop:
+  - `modules/shared/Invoke-PRReviewGate.ps1` `Post-PRSummaryComment` now upserts a single PR summary comment via a `<!-- squad-pr-review-gate -->` marker. On re-runs, the existing comment is updated in place with `PATCH /repos/{owner}/{repo}/issues/comments/{id}` instead of creating a new comment each time. Review threads are no longer spammed with duplicate gate summaries.
+  - `.squad/templates/issue-lifecycle.md` spawn prompts now instruct agents to open PRs as drafts (`gh pr create --draft`) and flip to ready-for-review only after CI is green and self-review is complete. Cuts notification traffic during iteration.
+
 ### Added
 - Added CI failure watchdog (workflow + local helper) - #104
 

--- a/modules/shared/Invoke-PRReviewGate.ps1
+++ b/modules/shared/Invoke-PRReviewGate.ps1
@@ -562,8 +562,10 @@ function Post-PRSummaryComment {
         [switch] $DryRun
     )
 
+    $marker = '<!-- squad-pr-review-gate -->'
     $actions = @($Consensus.ActionPlan | ForEach-Object { "- $_" })
     $body = @"
+$marker
 ### PR Review Gate Summary
 
 - Verdict: **$($Consensus.ReviewerVerdict)**
@@ -573,12 +575,29 @@ function Post-PRSummaryComment {
 
 What will change:
 $($actions -join "`n")
+
+_Updated in place on each review event — see PR timeline for full history._
 "@
     $safeBody = Remove-Credentials $body
 
     if ($DryRun) {
-        Write-Host "[DryRun] gh pr comment $PRNumber --repo $Repo --body-file <temp-file>"
+        Write-Host "[DryRun] Upsert squad-pr-review-gate comment on PR $PRNumber (repo $Repo)"
         return
+    }
+
+    # Look for existing gate comment to update in place (prevents email noise on re-runs)
+    $existingId = $null
+    try {
+        $commentsJson = & gh api "repos/$Repo/issues/$PRNumber/comments" --paginate 2> $null
+        if ($LASTEXITCODE -eq 0 -and $commentsJson) {
+            $existing = $commentsJson | ConvertFrom-Json
+            $match = @($existing | Where-Object { $_.body -and $_.body.Contains($marker) } | Select-Object -First 1)
+            if ($match.Count -gt 0) {
+                $existingId = [string]$match[0].id
+            }
+        }
+    } catch {
+        Write-Verbose "Could not list existing comments, will post new: $_"
     }
 
     $bodyFilePath = New-RepoTempFile -Prefix 'pr-review-comment'
@@ -587,7 +606,11 @@ $($actions -join "`n")
     try {
         Set-Content -Path $bodyFilePath -Value $safeBody -Encoding utf8
         for ($attempt = 0; $attempt -lt $maxRetries; $attempt++) {
-            & gh pr comment $PRNumber --repo $Repo --body-file $bodyFilePath 1> $null 2> $stderrPath
+            if ($existingId) {
+                & gh api --method PATCH "repos/$Repo/issues/comments/$existingId" -F "body=@$bodyFilePath" 1> $null 2> $stderrPath
+            } else {
+                & gh pr comment $PRNumber --repo $Repo --body-file $bodyFilePath 1> $null 2> $stderrPath
+            }
             $exitCode = 0
             $exitCodeVar = Get-Variable -Name LASTEXITCODE -Scope Global -ErrorAction SilentlyContinue
             if ($exitCodeVar) {


### PR DESCRIPTION
Closes part of #113.

## What changes

**1. Upsert-in-place PR gate summary comment**

`modules/shared/Invoke-PRReviewGate.ps1` `Post-PRSummaryComment` now:
- Prepends a `<!-- squad-pr-review-gate -->` marker to the body.
- Lists existing PR comments via `gh api repos/{owner}/{repo}/issues/{num}/comments --paginate`.
- If a marker-tagged comment exists: `PATCH repos/{owner}/{repo}/issues/comments/{id}` to rewrite in place.
- If not: falls back to the existing `gh pr comment` POST path.

Before: every review event posted a new summary comment, so reviewers got an email per run.
After: one stable comment, updated silently on re-runs.

**2. Draft PR default in spawn templates**

`.squad/templates/issue-lifecycle.md` now instructs agents to `gh pr create --draft` and flip to ready-for-review only after CI is green and self-review is complete. Cuts the email blast during iteration.

## Tests

`Invoke-Pester -Path .\tests -CI` → **392/392 green**.

## Docs

CHANGELOG.md entry added under Unreleased > Changed.