### PR TITLE
chore(squad): type:roadmap label — keep improvement plans out of auto-pickup

### DIFF
--- a/.squad/templates/ralph-triage.js
+++ b/.squad/templates/ralph-triage.js
@@ -511,6 +511,9 @@ function issueHasLabel(issue, labelName) {
 function isUntriagedIssue(issue, memberLabels) {
   if (issue.pull_request) return false;
   if (!issueHasLabel(issue, 'squad')) return false;
+  // Skip roadmap / proposal issues — these are improvement plans, not actionable work.
+  // Squad members or Ralph must NOT auto-pick these up. They are framed as backlog only.
+  if (issueHasLabel(issue, 'type:roadmap')) return false;
   return !memberLabels.some((label) => issueHasLabel(issue, label));
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to azure-analyzer will be documented here.
 ## [Unreleased]
 
 ### Changed
+- **Roadmap / proposal label (prevents auto-pickup of improvement plans)**: New `type:roadmap` label marks issues that are improvement plans or phase proposals, not actionable work. `.squad/templates/ralph-triage.js` `isUntriagedIssue()` now skips any issue tagged `type:roadmap`, so the heartbeat cron and Squad coordinator will no longer pick them up for agent execution. Applied to #91–#97 (phase plans), #106, #108, #109, #110 (review-loop improvements); all `squad:{member}` labels stripped so they render as backlog only.
 - **Notification hygiene (#113)** — reduce email noise from the automation loop:
   - `modules/shared/Invoke-PRReviewGate.ps1` `Post-PRSummaryComment` now upserts a single PR summary comment via a `<!-- squad-pr-review-gate -->` marker. On re-runs, the existing comment is updated in place with `PATCH /repos/{owner}/{repo}/issues/comments/{id}` instead of creating a new comment each time. Review threads are no longer spammed with duplicate gate summaries.
   - `.squad/templates/issue-lifecycle.md` spawn prompts now instruct agents to open PRs as drafts (`gh pr create --draft`) and flip to ready-for-review only after CI is green and self-review is complete. Cuts notification traffic during iteration.


### PR DESCRIPTION
Adds a `type:roadmap` label that keeps improvement plans and phase proposals in the backlog instead of auto-picked by the Squad coordinator or Ralph's cloud heartbeat.

## What changes

**New label:** `type:roadmap` (light purple, description: *"Improvement plan or phase proposal — do NOT auto-pick; backlog framing only"*)

**Triage engine patch:** `.squad/templates/ralph-triage.js` `isUntriagedIssue()` returns `false` when `type:roadmap` is present, so the heartbeat cron at `*/15` will skip them. The Squad coordinator's in-session Ralph loop defers to this signal too.

**Applied to:**
- Phase plans: #91, #92, #93, #94, #95, #96, #97
- Review-loop improvements: #106, #108, #109, #110

For all tagged issues, `squad:{member}` labels were removed so Ralph's `assigned but unstarted` scan ignores them. The `enhancement` and `squad` labels stay — these are still backlog-visible, just not auto-actionable.

**Explicit exclusion per user directive:** #96 (Phase 10 — Defender XDR + Sentinel ingestion) will not be auto-picked.

## Why

Ralph's in-session loop is strong at executing scoped fixes (#101, #102, #103 style chores). Plan-shaped issues need human framing and sequencing first; they should not arrive in an agent's spawn queue.

## Docs

CHANGELOG.md entry under Unreleased > Changed.

Closes part of the ongoing notification-hygiene + board-discipline work from #113.
