### PR TITLE
docs: reconcile 5 documentation drift items

### DIFF
--- a/.copilot/copilot-instructions.md
+++ b/.copilot/copilot-instructions.md
@@ -11,7 +11,7 @@ All code changes follow this pipeline:
 3. **Fix** - address all findings from reviewers
 4. **Re-gate** - re-run review with the models that rejected, verify fixes
 5. **Final Review Gate** - if re-gate passes, proceed. If not, loop back to Fix
-6. **CI** - all GitHub Actions must pass (CodeQL, docs-check)
+6. **CI** - all GitHub Actions must pass (`Analyze (actions)`)
 7. **Merge** - squash merge to main, delete feature branch
 
 ## Automated Review Ingestion

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,7 +63,7 @@ When the GitHub coding agent (copilot-swe-agent[bot]) opens a draft PR for a `sq
    - Updated plan is itself rubber-ducked before any code change.
    - Code is implemented, then the 3-model gate re-runs on the diff (Build → Review → Fix → Re-gate → CI → Merge).
    - Every Copilot thread gets a reply: either the addressing commit SHA, or the multi-model rejection justification.
-4. Maintainers **MUST NOT** squash-merge an agent PR until **all Copilot review threads are Resolved**, the 3-model gate is green, the squad reviewer has approved, and required checks (`Analyze (actions)`, `Docs Check`) are green.
+4. Maintainers **MUST NOT** squash-merge an agent PR until **all Copilot review threads are Resolved**, the 3-model gate is green, the squad reviewer has approved, and the required `Analyze (actions)` check is green.
 5. If the agent is unresponsive for >24h, reassign the issue to a squad member or take it over locally.
 6. Stale agent draft PRs that are superseded by a direct merge MUST be closed with a `--delete-branch` to keep the branch list clean.
 
@@ -71,7 +71,7 @@ When the GitHub coding agent (copilot-swe-agent[bot]) opens a draft PR for a `sq
 
 Before adding retry/clone/sanitize/install logic, check these modules first:
 
-- **`tools/tool-manifest.json`** — single source of truth for tool registration. `name`, `displayName`, `scope` (subscription/tenant/repository/ado/cluster), `provider` (azure/entra/github/ado/cli), `enabled`, plus `install` and `report` blocks. New tools **MUST** register here. Installer + both reports read from it.
+- **`tools/tool-manifest.json`** — single source of truth for tool registration. `name`, `displayName`, `scope` (`subscription` / `managementGroup` / `tenant` / `repository` / `ado` / `workspace`), `provider` (`azure` / `microsoft365` / `graph` / `github` / `ado` / `cli`), `enabled`, plus `install` and `report` blocks. New tools **MUST** register here. Installer + both reports read from it.
 - **`modules/shared/Installer.ps1`** — manifest-driven prerequisite installer. `Install-PrerequisitesFromManifest` handles `psmodule` / `cli` / `gitclone` / `none`. Uses `Invoke-WithInstallRetry` + `Invoke-WithTimeout` (300s). Rich errors via `New-InstallerError` / `Write-InstallerError`. Entry point: `-InstallMissingModules` orchestrator flag.
 - **`modules/shared/RemoteClone.ps1`** — cloud-first HTTPS clone helper. `Invoke-RemoteRepoClone` returns `{ Path, Url, Cleanup }`. All new repo-scoped scanners MUST use this instead of rolling their own `git clone`.
 - **`modules/shared/Retry.ps1`** — `Invoke-WithRetry` with jittered backoff. Retries on `$TransientMessagePatterns` (429/503/504/throttle/timeout). Wrap any REST/ARG/external call with it.
@@ -95,7 +95,7 @@ Non-negotiable rules that apply to every new wrapper/module:
 
 ## Testing gate
 
-- `Invoke-Pester -Path .\tests -CI` — baseline is **309/309 green**. Any PR that lands must preserve or extend this.
+- `Invoke-Pester -Path .\tests -CI` — baseline is **842/842 green**. Any PR that lands must preserve or extend this.
 - Normalizer tests live under `tests/normalizers/`; wrapper tests under `tests/wrappers/`; shared-module tests under `tests/shared/`.
 - Every new tool MUST ship with a normalizer test using a realistic fixture in `tests/fixtures/`.
 - Every new shared module MUST ship with its own `tests/shared/<Module>.Tests.ps1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to azure-analyzer will be documented here.
 ## [Unreleased]
 
 ### Fixed
+- **Documentation drift cleanup**: Reconciled five doc-vs-truth mismatches surfaced by the docs audit. (1) `README.md` Source enum now lists `falco` alongside the other 20 tool sources. (2) `PERMISSIONS.md` quick-reference matrix gained `bicep-iac` and `terraform-iac` rows (no Azure/Graph permissions; remote-clone or local CLI). (3) `.github/copilot-instructions.md` line 66 dropped the stale `Docs Check` requirement — the only required status check on `main` is `Analyze (actions)` (verified via `gh api .../branches/main/protection`); `.copilot/copilot-instructions.md` line 14 updated from "CodeQL, docs-check" to match. (4) `.github/copilot-instructions.md` Pester baseline corrected from `309/309` to the actual `842/842` green from a fresh `Invoke-Pester -CI` run. (5) `.github/copilot-instructions.md` shared-infra blurb now reflects the manifest's real `scope` enum (`subscription` / `managementGroup` / `tenant` / `repository` / `ado` / `workspace`) and `provider` enum (`azure` / `microsoft365` / `graph` / `github` / `ado` / `cli`) instead of the stale `cluster`/`entra` values.
+
+### Fixed
 - **CI failure watchdog 50/50 zero-job failures (root cause)**: The `workflow_run` trigger in `ci-failure-watchdog.yml` was missing the **required** `workflows:` key. Without it, GitHub never fully parses the workflow YAML — it creates a phantom run with 0 jobs on every push, reports `conclusion: failure`, and uses the raw file path as the run name instead of the declared `name:` field. Added `workflows: ["CI", "CodeQL", "Docs Check"]` to the trigger. Prior fix attempts (PR #130 job-level `if:`, PR #153 step-level gate) addressed a secondary concern but could never take effect because the workflow was never parsed.
 
 ### Added

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -557,6 +557,8 @@ $env:COPILOT_GITHUB_TOKEN = "ghp_..."
 | **zizmor** | -- | -- | ⚡ Remote | -- | ⚡ Local fallback | -- |
 | **gitleaks** | -- | -- | ⚡ Remote | -- | ⚡ Local fallback | -- |
 | **Trivy** | -- | -- | ⚡ Remote | -- | ⚡ Local fallback | -- |
+| **bicep-iac** | -- | -- | ⚡ Remote (clone) | -- | ⚡ Local fallback (`bicep`) | -- |
+| **terraform-iac** | -- | -- | ⚡ Remote (clone) | -- | ⚡ Local fallback (`terraform`/`trivy`) | -- |
 | **Identity Correlator** | ✅ Inherited | ⚡ Optional (Graph lookup) | -- | -- | -- | -- |
 | **AI Triage** | -- | -- | ⚡ Recommended | -- | -- | ⚠️ Optional |
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ Azure Analyzer writes two JSON output files with different schemas:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `Id` | string | yes | Unique finding identifier |
-| `Source` | string | yes | `azqr`, `psrule`, `azgovviz`, `alz-queries`, `wara`, `azure-cost`, `defender-for-cloud`, `sentinel-incidents`, `kubescape`, `kube-bench`, `maester`, `scorecard`, `ado-connections`, `ado-pipelines`, `identity-correlator`, `zizmor`, `gitleaks`, `trivy`, `bicep-iac`, or `terraform-iac` |
+| `Source` | string | yes | `azqr`, `psrule`, `azgovviz`, `alz-queries`, `wara`, `azure-cost`, `defender-for-cloud`, `sentinel-incidents`, `kubescape`, `kube-bench`, `falco`, `maester`, `scorecard`, `ado-connections`, `ado-pipelines`, `identity-correlator`, `zizmor`, `gitleaks`, `trivy`, `bicep-iac`, or `terraform-iac` |
 | `Category` | string | | e.g. Security, Reliability, Networking, Compute, Storage, Identity |
 | `Title` | string | yes | Short finding title |
 | `Severity` | string | | `Critical`, `High`, `Medium`, `Low`, or `Info` |


### PR DESCRIPTION
## Summary
Reconciles 5 documentation drift items found by the docs audit.

## Fixes
1. **README.md L468** — added missing `falco` to the `results.json` Source enum (now lists all 21 manifest tools).
2. **PERMISSIONS.md L540-561** — added `bicep-iac` and `terraform-iac` rows to the quick-reference matrix (no Azure/Graph perms; remote-clone or local CLI fallback).
3. **.github/copilot-instructions.md L66** — dropped stale `Docs Check` from the required-checks list. Verified via `gh api repos/martinopedal/azure-analyzer/branches/main/protection --jq '.required_status_checks.contexts'` -> `[\"Analyze (actions)\"]`. Also updated `.copilot/copilot-instructions.md` line 14 (`CodeQL, docs-check` -> `Analyze (actions)`).
4. **.github/copilot-instructions.md L98** — Pester baseline `309/309` -> `842/842` (verified by fresh `Invoke-Pester -Path .\tests -CI -Output Minimal` run: `Tests Passed: 842, Failed: 0`).
5. **.github/copilot-instructions.md L74** — replaced stale scope/provider enums with the real values from `tools/tool-manifest.json`:
   - scope: `subscription` / `managementGroup` / `tenant` / `repository` / `ado` / `workspace`
   - provider: `azure` / `microsoft365` / `graph` / `github` / `ado` / `cli`

Bonus item 6 (samples `17 tools` prose) skipped — no such literal exists in `samples/sample-report.md` or `samples/sample-findings-v2.json`; no edit needed.

## Self-review
- ✅ Doc-only change, no code/tests touched.
- ✅ Pester `842/842` green pre-change (captured as new baseline).
- ✅ Required checks line now matches `gh api` truth.
- ✅ Manifest enums verified directly against `tools/tool-manifest.json` (21 tools, 6 scopes, 6 providers).
- ✅ CHANGELOG updated under `[Unreleased] -> Fixed`.

## Test plan
`Invoke-Pester -Path .\tests -CI` — must remain at 842/842.
