### PR TITLE
fix: resolve leftover merge conflict markers (main hotfix)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,3 +29,4 @@ jobs:
       - uses: github/codeql-action/analyze@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
         with:
           category: "/language:${{matrix.language}}"
+# trigger: hotfix-216 20260420-125025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+- `Invoke-AzureAnalyzer.ps1`: Resolve leftover merge conflict markers in the param block and DOC block left over from the PR #204/#206 squash-merge cascade. Both `-GitleaksConfigPath` (#198) and `-AdoOrganizationUrl`/`-AdoServerUrl` (#197) coexist as intended; the orchestrator now parses again and the IdentityGraphExpansion integration suite goes from 5/7 to 7/7.
+
 ### Changed
 - `report-template.html`, `New-HtmlReport.ps1`: Fix Critical/High severity conflation — `SeverityClass()` was mapping `Critical → sev-high`, making Critical and High findings look identical. Critical now renders as a distinct dark-red badge and row border (`#7f1d1d`) separate from High (`#dc2626`).
 - `report-template.html`, `New-HtmlReport.ps1`: Add global interactive filter bar — sticky bar with severity chips (multi-select), platform (Azure/Entra/GitHub/ADO), tool, compliance status, and free-text search filter all finding rows simultaneously across every table with no page reload.

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -38,17 +38,14 @@
 .PARAMETER AdoPat
     Azure DevOps PAT passed to ADO-scoped wrappers. Optional; wrappers also read
     ADO_PAT_TOKEN, AZURE_DEVOPS_EXT_PAT, and AZ_DEVOPS_PAT.
-<<<<<<< HEAD
 .PARAMETER GitleaksConfigPath
     Optional local path to a gitleaks TOML config file. Forwarded to gitleaks and
     ado-repos-secrets wrappers for org-level or repo-level pattern tuning.
-=======
 .PARAMETER AdoOrganizationUrl
     Optional Azure DevOps organization URL for ADO repo secret scanning.
     Supports cloud URLs (dev.azure.com / *.visualstudio.com) and on-prem collection URLs.
 .PARAMETER AdoServerUrl
     Optional Azure DevOps Server collection URL (on-prem) for ADO repo secret scanning.
->>>>>>> dd07808 (feat(ado): ADO Server/on-prem support for repo secret scanning (#197))
 .PARAMETER SentinelWorkspaceId
     Full ARM resource ID of the Log Analytics workspace linked to Microsoft Sentinel.
     When provided, the sentinel-incidents tool queries active incidents via KQL.
@@ -105,12 +102,9 @@ param (
     [string] $AdoProject,
     [Alias('AdoPatToken')]
     [string] $AdoPat,
-<<<<<<< HEAD
     [string] $GitleaksConfigPath,
-=======
     [string] $AdoOrganizationUrl,
     [string] $AdoServerUrl,
->>>>>>> dd07808 (feat(ado): ADO Server/on-prem support for repo secret scanning (#197))
     [string] $AdoRepoUrl,
     [ValidateRange(0, 10)]
     [int] $ScorecardThreshold = 7,


### PR DESCRIPTION
## Hotfix

Main is broken — PR #204 squash-merge brought through unresolved `<<<<<<< HEAD` / `=======` / `>>>>>>>` markers in `Invoke-AzureAnalyzer.ps1` (param block + DOC block). The auto-merger reached the green-required check (`Analyze (actions)`) but the optional Pester jobs were red.

**Fix:** Both feature params coexist (`-GitleaksConfigPath` from #198 + `-AdoOrganizationUrl`/`-AdoServerUrl` from #197). Just dropped the conflict markers and kept both halves.

**Verified:**
`tests/Invoke-AzureAnalyzer.IdentityGraphExpansion.Integration.Tests.ps1` 5/7 → **7/7 passing**.

Closes the post-#204 main red CI.