### PR TITLE
chore: fix module root resolution + complete PSData manifest (PR-4 of 5)

### DIFF
--- a/AzureAnalyzer.psd1
+++ b/AzureAnalyzer.psd1
@@ -1,7 +1,7 @@
 @{
     RootModule            = 'AzureAnalyzer.psm1'
     ModuleVersion         = '1.0.0'
-    GUID                  = '0e0f0e0f-0f0e-0f0e-0f0e-0f0e0f0e0f0e'
+    GUID                  = '6d44ac09-67b5-4f66-9539-43707cd767fc'
     Author                = 'Martin Opedal'
     CompanyName           = 'Azure Community'
     Description           = 'Unified Azure assessment tool bundling azqr, PSRule for Azure, AzGovViz, ALZ Resource Graph queries, WARA, Maester, and OpenSSF Scorecard. Local module for on-demand assessment runs.'
@@ -19,4 +19,14 @@
     CmdletsToExport       = @()
     VariablesToExport     = @()
     AliasesToExport       = @()
+
+    PrivateData           = @{
+        PSData = @{
+            Tags         = @('Azure', 'Assessment', 'Compliance', 'Security', 'Governance', 'PSRule', 'azqr', 'AzGovViz', 'AzureLandingZones', 'WellArchitected')
+            LicenseUri   = 'https://github.com/martinopedal/azure-analyzer/blob/main/LICENSE'
+            ProjectUri   = 'https://github.com/martinopedal/azure-analyzer'
+            ReleaseNotes = 'https://github.com/martinopedal/azure-analyzer/blob/main/CHANGELOG.md'
+            # IconUri    = ''  # Optional - leave commented; don't add an empty string (worse than absent)
+        }
+    }
 }

--- a/AzureAnalyzer.psm1
+++ b/AzureAnalyzer.psm1
@@ -1,23 +1,25 @@
 #Requires -Version 7.4
 <#
 .SYNOPSIS
-    Azure Analyzer PowerShell Module — Root module script.
+    Azure Analyzer PowerShell Module - Root module script.
 .DESCRIPTION
-    Loads all public functions from the modules/ directory and the root-level
+    Loads shared helper functions and root-level public entry scripts.
+    The public commands are exposed via wrapper functions that invoke the
     scripts (Invoke-AzureAnalyzer.ps1, New-HtmlReport.ps1, New-MdReport.ps1).
     
-    This is a local module for convenience—use after Import-Module ./AzureAnalyzer.psd1
+    This is a local module for convenience; use after Import-Module ./AzureAnalyzer.psd1
     in the cloned repository.
 #>
 
 Set-StrictMode -Version Latest
 
 # Get the module root path
-$ModuleRoot = Split-Path -Parent $PSScriptRoot
+$ModuleRoot = $PSScriptRoot
 
-# Dot-source all tool wrapper modules from modules/ directory
-# These are internal helpers and should not be exported directly
-Get-ChildItem -Path (Join-Path $ModuleRoot 'modules') -Filter '*.ps1' -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
+# Dot-source shared helper modules only
+# Wrapper/normalizer/report scripts are invoked by the orchestrator and not loaded at import time
+$sharedModulePath = Join-Path $ModuleRoot 'modules\shared'
+Get-ChildItem -Path $sharedModulePath -Filter '*.ps1' -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
     . $_.FullName
 }
 
@@ -29,11 +31,51 @@ $publicFunctions = @(
     'New-MdReport'
 )
 
-foreach ($funcName in $publicFunctions) {
-    $funcPath = Join-Path $ModuleRoot "$($funcName).ps1"
-    if (Test-Path $funcPath) {
-        . $funcPath
+function Invoke-ModuleScript {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $ScriptPath,
+
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]] $Arguments
+    )
+
+    if (-not (Test-Path $ScriptPath)) {
+        throw "Required script not found: $ScriptPath"
     }
+
+    & $ScriptPath @Arguments
+}
+
+function Invoke-AzureAnalyzer {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]] $Arguments
+    )
+
+    Invoke-ModuleScript -ScriptPath (Join-Path $ModuleRoot 'Invoke-AzureAnalyzer.ps1') @Arguments
+}
+
+function New-HtmlReport {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]] $Arguments
+    )
+
+    Invoke-ModuleScript -ScriptPath (Join-Path $ModuleRoot 'New-HtmlReport.ps1') @Arguments
+}
+
+function New-MdReport {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]] $Arguments
+    )
+
+    Invoke-ModuleScript -ScriptPath (Join-Path $ModuleRoot 'New-MdReport.ps1') @Arguments
 }
 
 # Warn if core required modules are missing

--- a/tests/module/Import-AzureAnalyzer.Tests.ps1
+++ b/tests/module/Import-AzureAnalyzer.Tests.ps1
@@ -1,0 +1,34 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    $script:Here = Split-Path $PSCommandPath -Parent
+    $script:RepoRoot = Resolve-Path (Join-Path $script:Here '..' '..')
+    $script:ManifestPath = Join-Path $script:RepoRoot 'AzureAnalyzer.psd1'
+}
+
+AfterAll {
+    Remove-Module -Name AzureAnalyzer -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'AzureAnalyzer module import and manifest integrity' {
+    It 'imports AzureAnalyzer.psd1 without errors' {
+        { Import-Module $script:ManifestPath -Force -ErrorAction Stop } | Should -Not -Throw
+    }
+
+    It 'exports expected public commands after import' {
+        Import-Module $script:ManifestPath -Force -ErrorAction Stop
+        $commands = Get-Command -Module AzureAnalyzer
+
+        $commands.Name | Should -Contain 'Invoke-AzureAnalyzer'
+        $commands.Name | Should -Contain 'New-HtmlReport'
+        $commands.Name | Should -Contain 'New-MdReport'
+    }
+
+    It 'validates AzureAnalyzer.psd1 with Test-ModuleManifest' {
+        { Test-ModuleManifest -Path $script:ManifestPath -ErrorAction Stop } | Should -Not -Throw
+        $manifest = Test-ModuleManifest -Path $script:ManifestPath -ErrorAction Stop
+        $manifest | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes PR-4 Item R from .squad/decisions/inbox/coordinator-restructure-consolidated-plan-2026-04-20T12-30-00Z.md by correcting module root resolution in AzureAnalyzer.psm1.
- Prevents import-time execution failures by exposing Invoke-AzureAnalyzer, New-HtmlReport, and New-MdReport as module wrapper functions and adding import integrity tests.
- Implements PR-4 Item Q by rotating the placeholder GUID and adding PrivateData.PSData metadata (Tags, ProjectUri, LicenseUri, ReleaseNotes) to AzureAnalyzer.psd1.

## Validation
- Invoke-Pester -Path .\tests\module\Import-AzureAnalyzer.Tests.ps1 -CI
- Invoke-Pester -Path .\tests -CI (1183 passed, 0 failed, 5 skipped)
- Test-ModuleManifest .\AzureAnalyzer.psd1
- Import-Module .\AzureAnalyzer.psd1 -Force; Get-Command -Module AzureAnalyzer
- g -- "—" AzureAnalyzer.psd1 AzureAnalyzer.psm1 tests\module\

## Plan alignment
- Implements consolidated plan PR-4 (Module integrity + manifest hygiene).
- Incorporates the 3-model rubberduck approved direction (Opus 4.7 + GPT-5.3-codex + Goldeneye) including the explicit root-path bug fix and PSGallery manifest hygiene updates.