### PR TITLE
docs: extract advanced docs + manifest-driven tool catalog (PR-3 of 5)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -23,7 +23,7 @@ jobs:
             // Check for skip-docs-check label
             const labels = context.payload.pull_request.labels.map(l => l.name);
             if (labels.includes('skip-docs-check')) {
-              core.info('Skipping docs check — skip-docs-check label found.');
+              core.info('Skipping docs check - skip-docs-check label found.');
               return;
             }
 
@@ -62,7 +62,7 @@ jobs:
             const docFiles = changed.filter(isDoc);
 
             if (codeFiles.length === 0) {
-              core.info('No code files changed — docs check not required.');
+              core.info('No code files changed - docs check not required.');
               core.info(`Changed files: ${changed.join(', ')}`);
               return;
             }
@@ -77,3 +77,19 @@ jobs:
                 'See CONTRIBUTING.md for documentation requirements.'
               );
             }
+
+  tool-catalog-fresh:
+    name: Tool catalog fresh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Verify tool catalog is in sync with manifest
+        shell: pwsh
+        run: |
+          pwsh -File scripts/Generate-ToolCatalog.ps1 -CheckOnly
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::docs/consumer/tool-catalog.md or docs/contributor/tool-catalog.md is stale."
+            Write-Host "::error::Run 'pwsh -File scripts/Generate-ToolCatalog.ps1' and commit the result."
+            exit 1
+          }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Added
+- docs: extract advanced operator/contributor content + manifest-driven tool catalog (PR-3 of 5).
+
 ### Changed
 - docs: rewrite README to consumer-first quickstart layout (PR-2 of 5)
 - `New-HtmlReport.ps1`, `New-ExecDashboard.ps1`, `report-template.html`, `modules/shared/ExecDashboardRender.ps1` (new):Merge the executive dashboard into `report.html` as a "Summary" tab that becomes the default landing view (#210). Existing report content (executive cards, tool coverage, portfolio rollup, priority stack, and category accordions) moves to a "Findings" tab. The shared `ExecDashboardRender.ps1` module is now the single source of truth for dashboard composition, exporting `Get-ExecDashboardModel`, `Get-ExecDashboardBody`, `Get-ExecDashboardCss` (with optional CSS scoping), and `Get-ExecDashboardHtml`. `New-ExecDashboard.ps1` becomes a thin wrapper that still emits the standalone `dashboard.html` for back-compat (`Invoke-AzureAnalyzer.ps1` continues to call it unchanged). Embedded summary CSS is selector-scoped under `.exec-dash` so it never collides with `report.html`'s own `.card` / `.muted` / `.empty` rules. Print mode flattens both tabs so PDF exports still show the full report. Added 2 Pester cases asserting Summary is the first/active tab, contains the canonical `Compliance score` / `Top-10 risky resources` / `WAF 5-pillar coverage` blocks, wraps in `class="exec-dash"`, and degrades gracefully when summary data is unavailable. Pester baseline: **1178/1178 green**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Adding a new assessment tool requires three components:
 2. **Normalizer** (`modules/normalizers/Normalize-{ToolName}.ps1`) -- converts raw output to schema v2 FindingRow format using `New-FindingRow` from `modules/shared/Schema.ps1`
 3. **Manifest entry** (`tools/tool-manifest.json`) -- registers the tool for orchestration
 
-See [docs/CONTRIBUTING-TOOLS.md](docs/CONTRIBUTING-TOOLS.md) for the full wrapper contract, normalizer template, and testing checklist.
+See [docs/contributor/adding-a-tool.md](docs/contributor/adding-a-tool.md) for the full wrapper contract, normalizer template, and testing checklist.
 
 ## AI-assisted contributions
 

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -90,7 +90,7 @@ Per-tenant outputs are written to `<OutputPath>/<tenantId>/`; cross-tenant aggre
 
 Azure Analyzer v3 groups capabilities into permission tiers (Tier 0–6) covering
 Azure, Graph, CI/CD, cost, and optional AI access. See
-[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the tier breakdown.
+[docs/contributor/ARCHITECTURE.md](docs/contributor/ARCHITECTURE.md) for the tier breakdown.
 
 ---
 
@@ -820,7 +820,7 @@ Azure-analyzer follows the principle of least privilege:
 
 | Credential | Purpose |
 |---|---|
-| `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` | Sends non-compliant finding data to GitHub Copilot API for AI-assisted triage. Only used when `-EnableAiTriage` is set. `ghs_` tokens NOT supported. See [docs/ai-triage.md](docs/ai-triage.md). |
+| `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` | Sends non-compliant finding data to GitHub Copilot API for AI-assisted triage. Only used when `-EnableAiTriage` is set. `ghs_` tokens NOT supported. See [docs/consumer/ai-triage.md](docs/consumer/ai-triage.md). |
 
 ---
 

--- a/docs/consumer/README.md
+++ b/docs/consumer/README.md
@@ -2,6 +2,7 @@
 
 All advanced consumer docs live here. The root `README.md` is your starting point.
 
+- [tool-catalog.md](tool-catalog.md) - Every tool azure-analyzer can run, what it covers, and what scope it targets. Generated from `tools/tool-manifest.json`.
 - [continuous-control.md](continuous-control.md) - Continuous control monitoring patterns and integration guidance.
 - [ai-triage.md](ai-triage.md) - AI-assisted finding triage workflow and prompt design.
 - [gitleaks-pattern-tuning.md](gitleaks-pattern-tuning.md) - Tuning gitleaks rule patterns to cut false positives.

--- a/docs/consumer/tool-catalog.md
+++ b/docs/consumer/tool-catalog.md
@@ -1,0 +1,62 @@
+# Tool catalog (consumer view)
+
+> GENERATED FROM tools/tool-manifest.json - do not edit by hand.
+> Regenerate with `pwsh -File scripts/Generate-ToolCatalog.ps1`.
+> Stale catalogs are blocked by the `tool-catalog-fresh` CI check.
+
+Manifest schema version: `2.2`
+
+This page lists every analyzer tool azure-analyzer can run, what it covers, what scope it targets, and where to find consumer-focused setup notes when one exists. For the full manifest fields (normalizer, install kind, upstream pin, report color/phase) see [docs/contributor/tool-catalog.md](../contributor/tool-catalog.md).
+
+**Total enabled:** 26. **Disabled / opt-in:** 1.
+
+## Enabled by default
+
+| Name | Display name | Scope | Provider | What it does | Docs |
+|---|---|---|---|---|---|
+| `ado-connections` | ADO Service Connections | ado | ado | Azure DevOps service-connection security: identity, scope, federation. | - |
+| `ado-pipeline-correlator` | ADO Pipeline Run Correlator | ado | ado | Correlates ADO pipeline runs with downstream Azure resource changes. | - |
+| `ado-pipelines` | ADO Pipeline Security | ado | ado | Azure DevOps pipeline-security posture (variable groups, environments, approvals). | - |
+| `ado-repos-secrets` | ADO Repos Secret Scanning | ado | ado | Secret scanning across Azure DevOps repositories via gitleaks. | [docs](./gitleaks-pattern-tuning.md) |
+| `alz-queries` | ALZ Resource Graph Queries | managementGroup | azure | ALZ Resource Graph queries: landing-zone compliance and drift detection. | - |
+| `azgovviz` | AzGovViz | managementGroup | azure | Azure Governance Visualizer: management-group / subscription / RBAC / policy posture. | - |
+| `azqr` | Azure Quick Review | subscription | azure | Azure best-practice review across reliability, security, cost, performance and operational excellence. | - |
+| `azure-cost` | Azure Cost (Consumption API) | subscription | azure | Per-subscription monthly Azure spend pulled from the Consumption API. | - |
+| `bicep-iac` | Bicep IaC Validation | repository | cli | Bicep IaC validation: lint, build, and best-practice checks. | - |
+| `defender-for-cloud` | Microsoft Defender for Cloud | subscription | azure | Pulls Microsoft Defender for Cloud Secure Score and active recommendations per subscription. | - |
+| `falco` | Falco (AKS runtime anomaly detection) | subscription | azure | AKS runtime anomaly detection (syscall-level threat detection). | - |
+| `finops` | FinOps Signals (Idle Resource Detection) | subscription | azure | FinOps signals: idle / orphaned resources that drive avoidable spend. | - |
+| `gitleaks` | gitleaks (Secrets Scanner) | repository | cli | Secret scanning across local or remote git repositories. | [docs](./gitleaks-pattern-tuning.md) |
+| `identity-correlator` | Identity Correlator | tenant | graph | Correlates Entra identities, role assignments, and resource ownership. | - |
+| `identity-graph-expansion` | Identity Graph Expansion | tenant | graph | Expands the identity graph: cross-tenant B2B + service-principal-to-resource edges. | - |
+| `kube-bench` | kube-bench (AKS node-level CIS compliance) | subscription | azure | CIS Kubernetes benchmark for AKS node hardening. | - |
+| `kubescape` | Kubescape (AKS runtime posture) | subscription | azure | Runtime posture for AKS clusters: misconfigurations, RBAC, network policies, vulnerabilities. | - |
+| `maester` | Maester | tenant | microsoft365 | Microsoft Entra (Identity) security baseline: conditional access, MFA, privileged roles. | [docs](./ai-triage.md) |
+| `psrule` | PSRule for Azure | subscription | azure | Microsoft PSRule for Azure: Well-Architected and best-practice rule baseline. | - |
+| `scorecard` | OpenSSF Scorecard | repository | github | OpenSSF Scorecard for repository supply-chain hygiene. | - |
+| `sentinel-coverage` | Microsoft Sentinel (Coverage / Posture) | workspace | azure | Sentinel detection posture: analytic rules, watchlists, data connectors, hunting queries. | - |
+| `sentinel-incidents` | Microsoft Sentinel (Active Incidents) | workspace | azure | Pulls active Microsoft Sentinel incidents from a Log Analytics workspace. | - |
+| `terraform-iac` | Terraform IaC Validation | repository | cli | Terraform IaC validation: tflint / tfsec / checkov-style checks. | - |
+| `trivy` | Trivy Vulnerability Scanner | repository | cli | Vulnerability and IaC misconfiguration scanner for repos and container images. | - |
+| `wara` | Well-Architected Reliability Assessment | subscription | azure | Well-Architected Reliability Assessment workflow for production workloads. | - |
+| `zizmor` | zizmor (Actions YAML Scanner) | repository | cli | Static analysis for GitHub Actions workflow security risks. | - |
+
+## Disabled / opt-in
+
+These tools are wired but turned off in the manifest. Enable them by setting `enabled: true` in `tools/tool-manifest.json` or via `tools/install-config.json`.
+
+| Name | Display name | Scope | Provider | What it does |
+|---|---|---|---|---|
+| `copilot-triage` | Copilot AI Triage | repository | cli | Optional Copilot-powered AI triage for finding prioritization (disabled by default). |
+
+## Scope reference
+
+| Scope | Targets |
+|---|---|
+| `subscription` | Single Azure subscription (`-SubscriptionId`). |
+| `managementGroup` | Azure Management Group (`-ManagementGroupId`). |
+| `tenant` | Entra ID tenant (`-TenantId`, requires `Connect-MgGraph`). |
+| `repository` | GitHub or ADO repo (`-Repository` or `-RepoPath`). |
+| `ado` | Azure DevOps organization (`-AdoOrg`). |
+| `workspace` | Log Analytics / Sentinel workspace (`-SentinelWorkspaceId`). |
+

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -4,5 +4,8 @@ Contributor and developer reference. Squad coordination lives in `.squad/`.
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) - High-level architecture, modules, and data flow.
 - [adding-a-tool.md](adding-a-tool.md) - End-to-end guide for registering and wiring a new analyzer tool.
+- [tool-catalog.md](tool-catalog.md) - Full manifest projection (provider, normalizer, install kind, upstream pin, report color/phase). Generated from `tools/tool-manifest.json`.
+- [operations.md](operations.md) - Operator runbook: shared infrastructure, security invariants, continuous-control mode, multi-tenant fan-out.
+- [troubleshooting.md](troubleshooting.md) - Diagnose tool failures, throttling, leaked credentials, Pester drops, stale catalog.
 - [ai-governance.md](ai-governance.md) - AI governance, model selection, and review-gate policy for the repo.
 - [proposals/](proposals/) - Forward-looking design proposals (IaC drift, Copilot triage panel, and more).

--- a/docs/contributor/operations.md
+++ b/docs/contributor/operations.md
@@ -1,0 +1,79 @@
+# Operations runbook
+
+Operator-focused reference for running, scheduling, and troubleshooting azure-analyzer in unattended environments. For consumer-focused setup walkthroughs see [`docs/consumer/`](../consumer/README.md).
+
+## Shared infrastructure (reuse, do not reinvent)
+
+Before adding retry, clone, sanitize, or install logic, check these modules first.
+
+| Module | Purpose |
+|---|---|
+| [`tools/tool-manifest.json`](../../tools/tool-manifest.json) | Single source of truth for tool registration. New tools register here and the report and installer pick them up automatically. |
+| [`modules/shared/Installer.ps1`](../../modules/shared/Installer.ps1) | Manifest-driven prerequisite installer. Handles `psmodule`, `cli`, `gitclone`, `none`. |
+| [`modules/shared/RemoteClone.ps1`](../../modules/shared/RemoteClone.ps1) | HTTPS-only clone helper with host allow-list and post-clone token scrub. |
+| [`modules/shared/Retry.ps1`](../../modules/shared/Retry.ps1) | `Invoke-WithRetry` with jittered backoff for transient failures. |
+| [`modules/shared/Sanitize.ps1`](../../modules/shared/Sanitize.ps1) | `Remove-Credentials` for any output written to disk. |
+| [`modules/shared/Schema.ps1`](../../modules/shared/Schema.ps1) | `New-FindingRow` is the only sanctioned way to emit v2 FindingRow entries. |
+| [`modules/shared/EntityStore.ps1`](../../modules/shared/EntityStore.ps1) | v3 entity-centric store: findings + entities written separately. |
+
+## Security invariants
+
+These rules apply to every wrapper, normalizer, and installer change.
+
+- HTTPS-only for any outbound URL. HTTP is rejected.
+- Host allow-list for clone or fetch: `github.com`, `dev.azure.com`, `*.visualstudio.com`, `*.ghe.com`. Enforced by `RemoteClone.ps1`.
+- Allow-listed package managers only: `winget`, `brew`, `pipx`, `pip`, `snap`. Enforced by `Installer.ps1`.
+- Package-name regex prevents shell-injection via manifest-sourced package names.
+- 300s timeout on every external process launch (`Invoke-WithTimeout`).
+- Token scrubbing from `.git/config` immediately post-clone.
+- `Remove-Credentials` on every artifact written to JSON, HTML, MD, or log files.
+- Errors are thrown via `New-InstallerError` / `New-FindingError` with `Category`, `Remediation`, and sanitized `Details`.
+
+## Continuous control mode
+
+Two unattended entrypoints wrap `Invoke-AzureAnalyzer.ps1` so the scanner runs on a schedule.
+
+### Scheduled GitHub Actions workflow
+
+`.github/workflows/scheduled-scan.yml` runs daily at `0 6 * * *` UTC (plus `workflow_dispatch`). It authenticates to Azure via OIDC federation (no PATs), uploads `results.json`, `entities.json`, and HTML / Markdown reports as workflow artifacts, then a separate `report` job (with `issues: write` only) opens or comments on a single deduped `auto:scheduled-scan` issue when new or escalated Critical-severity findings are detected.
+
+The workflow uses diff-mode (`modules/shared/Get-NewCriticalFindings.ps1` + `Compare-EntitySnapshots`) to compare against the previous run's snapshot so only net-new or escalated Criticals trigger an issue. First-run mode (no previous artifact) treats all Criticals as new.
+
+Required repo variables (configure once via `gh variable set`):
+
+| Variable | Description |
+|---|---|
+| `AZURE_CLIENT_ID` | App registration / user-assigned MI client id with the federated credential |
+| `AZURE_TENANT_ID` | Entra tenant id |
+| `AZURE_SUBSCRIPTION_ID` | Default subscription scope |
+
+### Azure Function (PowerShell)
+
+`azure-function/` ships `TimerScan/` (NCRONTAB `0 0 6 * * *`) and `HttpScan/` (`authLevel: function`, break-glass on-demand). Both run via the Function App's managed identity. The shared entrypoint reuses the existing Log Analytics sink (`modules/sinks/Send-FindingsToLogAnalytics.ps1`); sink invocation is opt-in via `DCE_ENDPOINT` and `DCR_IMMUTABLE_ID` app settings.
+
+**Consumption-plan timeout caveat.** Azure Functions on the Consumption plan have a hard 10-minute per-invocation cap. The Timer trigger therefore restricts itself to a small toolset (`azqr`, `psrule`). For a full daily sweep, deploy on the Premium plan or Container Apps. See [`azure-function/README.md`](../../azure-function/README.md) for the full architecture overview, and the consumer walkthrough at [`docs/consumer/continuous-control.md`](../consumer/continuous-control.md).
+
+## Output sinks
+
+Azure Analyzer can ship `results` and `entities` to Log Analytics or Sentinel custom tables using the Logs Ingestion API (DCR-based path). See [`docs/consumer/sinks/log-analytics.md`](../consumer/sinks/log-analytics.md) for DCR / table setup, app-settings wiring, and KQL examples.
+
+## Multi-tenant fan-out
+
+For MSP and large enterprise scenarios, `Invoke-AzureAnalyzer.ps1` accepts:
+
+- `-TenantConfig <path-to-json>` with explicit per-tenant subscription lists and labels.
+- `-Tenants @('<guid>', ...)` for a bare GUID array (uses the default subscription in each tenant context).
+
+Per-tenant outputs land under `<OutputPath>/<tenantId>/[<subscriptionId>/]`. The aggregate roll-up is written to `<OutputPath>/multi-tenant-summary.json` and `multi-tenant-summary.html`. Fan-out is sequential (clean Az / Microsoft.Graph context per tenant via child `pwsh` processes); per-tenant failures are recorded with sanitized stderr and the scan continues. Overall exit code is non-zero when any tenant fails.
+
+`-TenantConfig` and `-Tenants` are mutually exclusive with each other and with single-tenant `-TenantId` / `-SubscriptionId` / `-ManagementGroupId`.
+
+## Tool catalog
+
+The full list of registered tools, normalizers, install kinds, and upstream pins is generated from the manifest. See [`tool-catalog.md`](./tool-catalog.md). To regenerate:
+
+```powershell
+pwsh -File scripts/Generate-ToolCatalog.ps1
+```
+
+CI runs the generator with `-CheckOnly` and fails when the committed catalog is stale relative to `tools/tool-manifest.json`.

--- a/docs/contributor/tool-catalog.md
+++ b/docs/contributor/tool-catalog.md
@@ -1,0 +1,116 @@
+# Tool catalog (contributor view)
+
+> GENERATED FROM tools/tool-manifest.json - do not edit by hand.
+> Regenerate with `pwsh -File scripts/Generate-ToolCatalog.ps1`.
+> Stale catalogs are blocked by the `tool-catalog-fresh` CI check.
+
+Manifest schema version: `2.2`
+
+Full manifest projection: every wired tool with normalizer, invocation, install, report, and upstream metadata. For the consumer-friendly subset see [docs/consumer/tool-catalog.md](../consumer/tool-catalog.md). To onboard a new tool follow [adding-a-tool.md](./adding-a-tool.md).
+
+**Total tools registered:** 27.
+
+## Registration matrix
+
+| Name | Display name | Type | Provider | Scope | Status | Tier | Platforms |
+|---|---|---|---|---|---|---|---|
+| `ado-connections` | ADO Service Connections | collector | ado | ado | Enabled | 0 | windows, macos, linux |
+| `ado-pipeline-correlator` | ADO Pipeline Run Correlator | correlator | ado | ado | Enabled | 0 | windows, macos, linux |
+| `ado-pipelines` | ADO Pipeline Security | collector | ado | ado | Enabled | 0 | windows, macos, linux |
+| `ado-repos-secrets` | ADO Repos Secret Scanning | collector | ado | ado | Enabled | 0 | windows, macos, linux |
+| `alz-queries` | ALZ Resource Graph Queries | collector | azure | managementGroup | Enabled | 0 | windows, macos, linux |
+| `azgovviz` | AzGovViz | collector | azure | managementGroup | Enabled | 0 | windows, macos, linux |
+| `azqr` | Azure Quick Review | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
+| `azure-cost` | Azure Cost (Consumption API) | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
+| `bicep-iac` | Bicep IaC Validation | collector | cli | repository | Enabled | 0 | windows, macos, linux |
+| `copilot-triage` | Copilot AI Triage | enrichment | cli | repository | Disabled | 0 | windows, macos, linux |
+| `defender-for-cloud` | Microsoft Defender for Cloud | enrichment | azure | subscription | Enabled | 0 | windows, macos, linux |
+| `falco` | Falco (AKS runtime anomaly detection) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux |
+| `finops` | FinOps Signals (Idle Resource Detection) | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
+| `gitleaks` | gitleaks (Secrets Scanner) | collector | cli | repository | Enabled | 0 | windows, macos, linux |
+| `identity-correlator` | Identity Correlator | correlator | graph | tenant | Enabled | 3 | windows, macos, linux |
+| `identity-graph-expansion` | Identity Graph Expansion | correlator | graph | tenant | Enabled | 3 | windows, macos, linux |
+| `kube-bench` | kube-bench (AKS node-level CIS compliance) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux |
+| `kubescape` | Kubescape (AKS runtime posture) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux |
+| `maester` | Maester | collector | microsoft365 | tenant | Enabled | 0 | windows, macos, linux |
+| `psrule` | PSRule for Azure | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
+| `scorecard` | OpenSSF Scorecard | collector | github | repository | Enabled | 0 | windows, macos, linux |
+| `sentinel-coverage` | Microsoft Sentinel (Coverage / Posture) | collector | azure | workspace | Enabled | 0 | windows, macos, linux |
+| `sentinel-incidents` | Microsoft Sentinel (Active Incidents) | enrichment | azure | workspace | Enabled | 0 | windows, macos, linux |
+| `terraform-iac` | Terraform IaC Validation | collector | cli | repository | Enabled | 0 | windows, macos, linux |
+| `trivy` | Trivy Vulnerability Scanner | collector | cli | repository | Enabled | 0 | windows, macos, linux |
+| `wara` | Well-Architected Reliability Assessment | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
+| `zizmor` | zizmor (Actions YAML Scanner) | collector | cli | repository | Enabled | 0 | windows, macos, linux |
+
+## Invocation
+
+| Name | Normalizer | Invoke | Script / module | Required params |
+|---|---|---|---|---|
+| `ado-connections` | `Normalize-ADOConnections` | script | `modules/Invoke-ADOServiceConnections.ps1` | AdoOrg |
+| `ado-pipeline-correlator` | `Normalize-ADOPipelineCorrelator` | script | `modules/Invoke-ADOPipelineCorrelator.ps1` | AdoOrg |
+| `ado-pipelines` | `Normalize-ADOPipelineSecurity` | script | `modules/Invoke-ADOPipelineSecurity.ps1` | AdoOrg |
+| `ado-repos-secrets` | `Normalize-ADORepoSecrets` | script | `modules/Invoke-ADORepoSecrets.ps1` | AdoOrg |
+| `alz-queries` | `Normalize-AlzQueries` | script | `modules/Invoke-AlzQueries.ps1` | SubscriptionId, ManagementGroupId |
+| `azgovviz` | `Normalize-AzGovViz` | script | `modules/Invoke-AzGovViz.ps1` | ManagementGroupId |
+| `azqr` | `Normalize-Azqr` | script | `modules/Invoke-Azqr.ps1` | SubscriptionId |
+| `azure-cost` | `Normalize-AzureCost` | script | `modules/Invoke-AzureCost.ps1` | SubscriptionId |
+| `bicep-iac` | `Normalize-IaCBicep` | script | `modules/Invoke-IaCBicep.ps1` | - |
+| `copilot-triage` | `` | script | `modules/Invoke-CopilotTriage.ps1` | - |
+| `defender-for-cloud` | `Normalize-DefenderForCloud` | script | `modules/Invoke-DefenderForCloud.ps1` | SubscriptionId |
+| `falco` | `Normalize-Falco` | script | `modules/Invoke-Falco.ps1` | SubscriptionId |
+| `finops` | `Normalize-FinOpsSignals` | script | `modules/Invoke-FinOpsSignals.ps1` | SubscriptionId |
+| `gitleaks` | `Normalize-Gitleaks` | script | `modules/Invoke-Gitleaks.ps1` | - |
+| `identity-correlator` | `Normalize-IdentityCorrelation` | function | `modules/shared/IdentityCorrelator.ps1` | TenantId |
+| `identity-graph-expansion` | `Normalize-IdentityGraphExpansion` | function | `modules/Invoke-IdentityGraphExpansion.ps1` | TenantId |
+| `kube-bench` | `Normalize-KubeBench` | script | `modules/Invoke-KubeBench.ps1` | SubscriptionId |
+| `kubescape` | `Normalize-Kubescape` | script | `modules/Invoke-Kubescape.ps1` | SubscriptionId |
+| `maester` | `Normalize-Maester` | script | `modules/Invoke-Maester.ps1` | - |
+| `psrule` | `Normalize-PSRule` | script | `modules/Invoke-PSRule.ps1` | SubscriptionId |
+| `scorecard` | `Normalize-Scorecard` | script | `modules/Invoke-Scorecard.ps1` | Repository |
+| `sentinel-coverage` | `Normalize-SentinelCoverage` | script | `modules/Invoke-SentinelCoverage.ps1` | WorkspaceResourceId |
+| `sentinel-incidents` | `Normalize-SentinelIncidents` | script | `modules/Invoke-SentinelIncidents.ps1` | WorkspaceResourceId |
+| `terraform-iac` | `Normalize-IaCTerraform` | script | `modules/Invoke-IaCTerraform.ps1` | - |
+| `trivy` | `Normalize-Trivy` | script | `modules/Invoke-Trivy.ps1` | - |
+| `wara` | `Normalize-WARA` | script | `modules/Invoke-WARA.ps1` | SubscriptionId |
+| `zizmor` | `Normalize-Zizmor` | script | `modules/Invoke-Zizmor.ps1` | - |
+
+## Install + upstream
+
+| Name | Install kind | Upstream pin | Report color | Phase |
+|---|---|---|---|---|
+| `ado-connections` | none | n/a | `#0078d4` | 2 |
+| `ado-pipeline-correlator` | none | n/a | `#00838f` | 2 |
+| `ado-pipelines` | none | n/a | `#006064` | 2 |
+| `ado-repos-secrets` | none | n/a | `#ad1457` | 2 |
+| `alz-queries` | psmodule | Azure/Azure-Landing-Zones-Library @ HEAD | `#e65100` | 1 |
+| `azgovviz` | gitclone ("https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting") | JulianHayward/Azure-MG-Sub-Governance-Reporting @ HEAD | `#00838f` | 1 |
+| `azqr` | cli ("azqr") | Azure/azqr @ latest | `#1565c0` | 1 |
+| `azure-cost` | psmodule | n/a | `#388e3c` | 4 |
+| `bicep-iac` | cli ("bicep") | Azure/bicep @ latest | `#0d47a1` | 7 |
+| `copilot-triage` | none | n/a | `#6a1b9a` | 8 |
+| `defender-for-cloud` | psmodule | n/a | `#0078d4` | 4 |
+| `falco` | psmodule | falcosecurity/falco @ 0.42.0 | `#ef6c00` | 6 |
+| `finops` | psmodule | n/a | `#00897b` | 4 |
+| `gitleaks` | cli ("gitleaks") | gitleaks/gitleaks @ latest | `#c62828` | 3 |
+| `identity-correlator` | psmodule | n/a | `#5e35b1` | 2 |
+| `identity-graph-expansion` | psmodule | n/a | `#283593` | 2 |
+| `kube-bench` | none | n/a | `#5e35b1` | 6 |
+| `kubescape` | cli ("kubescape") | kubescape/kubescape @ v3 | `#7b1fa2` | 6 |
+| `maester` | psmodule | maester365/maester @ latest | `#7b1fa2` | 1 |
+| `psrule` | psmodule | microsoft/PSRule.Rules.Azure @ latest | `#6a1b9a` | 1 |
+| `scorecard` | cli ("scorecard") | ossf/scorecard @ latest | `#ff6f00` | 1 |
+| `sentinel-coverage` | psmodule | n/a | `#3949ab` | 4 |
+| `sentinel-incidents` | psmodule | n/a | `#0078d4` | 4 |
+| `terraform-iac` | cli ("terraform") | hashicorp/terraform @ latest | `#5c4ee5` | 7 |
+| `trivy` | cli ("trivy") | aquasecurity/trivy @ latest | `#00695c` | 3 |
+| `wara` | psmodule | Azure/Azure-Proactive-Resiliency-Library-v2 @ latest | `#2e7d32` | 1 |
+| `zizmor` | cli ("zizmor") | woodruffw/zizmor @ latest | `#ad1457` | 3 |
+
+## Notes
+
+- `tier` is `requiredPermissionTier` (0..6, see [PERMISSIONS.md](../../PERMISSIONS.md) for the tier breakdown).
+- `phase` is the report grouping hint used by `New-HtmlReport.ps1` and `New-MdReport.ps1`.
+- `report.color` is consumed by the per-source bar chart in the HTML report.
+- `install.kind` is one of `psmodule`, `cli`, `gitclone`, `none` and is enforced by `modules/shared/Installer.ps1`.
+- `upstream` drives the weekly auto-update loop; `pinType` and `currentPin` are managed by `tools/Update-ToolPins.ps1`.
+

--- a/docs/contributor/troubleshooting.md
+++ b/docs/contributor/troubleshooting.md
@@ -1,0 +1,75 @@
+# Troubleshooting
+
+Operator and contributor troubleshooting reference. For consumer-facing quickstart issues, start with the root [`README.md`](../../README.md).
+
+## Diagnose tool failures
+
+Every run writes per-tool execution status to `output/tool-status.json`. When a tool reports `Failed` or `Skipped`, inspect:
+
+- `output/errors.json` (only emitted when at least one tool errors). Contains sanitized stderr and the install hint emitted by `New-InstallerError`.
+- `output/<tool>/raw.json` (when the tool emits raw output). Useful for normalizer regressions.
+- The tool's wrapper at `modules/Invoke-<Tool>.ps1`. Wrappers must not throw; a `Failed` status means the wrapper caught and recorded the failure.
+
+## Missing prerequisites
+
+Run with `-InstallMissingModules` to auto-install via the manifest. Failures fall into three buckets:
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `winget` or `brew` not found | Package manager itself missing on the runner | Install the manager, or pre-bake the tool into the image. |
+| `Install kind 'X' is not supported` | Manifest entry uses a kind outside `{none, psmodule, cli, gitclone}` | Patch the manifest or add the kind to `AllowedInstallKinds` in `Installer.ps1` (gated by review). |
+| `Host 'X' is not allow-listed` | Clone or fetch URL falls outside the allow-list | Use `github.com`, `dev.azure.com`, `*.visualstudio.com`, or `*.ghe.com`. Other hosts are rejected by design. |
+
+## Throttling and transient errors
+
+External APIs (ARG, Defender, Graph, GitHub, ADO) are wrapped via `modules/shared/Retry.ps1` (`Invoke-WithRetry`). Retries fire on:
+
+- HTTP status codes `408`, `429`, `500`, `502`, `503`, `504`.
+- Exception messages matching `429`, `503`, `throttle`, `throttled`, `timeout`, `timed out`, `connection reset`, `socket`, `transient`.
+
+If a tool fails with a transient pattern that is not yet covered, extend `$TransientMessagePatterns` and add a unit test under `tests/shared/Retry.Tests.ps1`.
+
+## Token / credential surfaced in output
+
+Every artifact written to disk passes through `Remove-Credentials` (`modules/shared/Sanitize.ps1`). If you observe a leaked token:
+
+1. Capture the offending file and line.
+2. Add a test fixture under `tests/shared/Sanitize.Tests.ps1` that reproduces the leak.
+3. Extend the redaction patterns in `Sanitize.ps1` so the test passes.
+4. Re-run the full Pester suite.
+
+Never publish a finding or PR comment containing the unsanitized value.
+
+## Pester baseline drops
+
+The repo baseline is published in the commit message of every release-bearing PR. If your change drops the count:
+
+1. Run `Invoke-Pester -Path .\tests -CI` locally.
+2. Filter to failing tests with `Invoke-Pester -Path .\tests\<area> -Output Detailed`.
+3. Fix the root cause, never `-Skip` or `-Pending` to ship green (this is a contract violation per `.copilot/copilot-instructions.md`).
+
+## Stale tool catalog
+
+CI fails with `tool-catalog stale relative to manifest` when `docs/consumer/tool-catalog.md` or `docs/contributor/tool-catalog.md` is out of sync with `tools/tool-manifest.json`. Regenerate:
+
+```powershell
+pwsh -File scripts/Generate-ToolCatalog.ps1
+```
+
+Commit the regenerated files and push.
+
+## Module import surface
+
+`Import-Module .\AzureAnalyzer.psd1` must expose `Invoke-AzureAnalyzer`, `New-HtmlReport`, and `New-MdReport`. If a future change drops one of these from the export surface, the module integrity test under `tests/module/` will fail. Restore the export in `AzureAnalyzer.psd1` (`FunctionsToExport`) and verify with `Test-ModuleManifest .\AzureAnalyzer.psd1`.
+
+## Reporting an unreproducible scan
+
+Collect the following before opening an issue:
+
+- `output/tool-status.json`
+- `output/errors.json` (if present)
+- The orchestrator command line you ran (with credentials redacted)
+- The `Az` and `Microsoft.Graph` module versions (`Get-Module Az.Accounts, Microsoft.Graph.Authentication -ListAvailable | Select Name, Version`)
+- PowerShell version (`$PSVersionTable.PSVersion`)
+
+Sanitize before posting.

--- a/scripts/Generate-ToolCatalog.ps1
+++ b/scripts/Generate-ToolCatalog.ps1
@@ -1,0 +1,362 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Manifest-driven generator for the azure-analyzer tool catalogs.
+
+.DESCRIPTION
+    Reads tools/tool-manifest.json (single source of truth) and emits two
+    Markdown catalog pages:
+
+      docs/consumer/tool-catalog.md     consumer view (name, displayName,
+                                        scope, provider, status, what-it-does,
+                                        link to per-tool consumer doc when
+                                        one exists)
+
+      docs/contributor/tool-catalog.md  contributor view (full manifest fields:
+                                        provider, scope, normalizer,
+                                        invokeMethod, requiredPermissionTier,
+                                        platforms, install kind / command,
+                                        report color/phase, upstream pin)
+
+    Both files include a clear GENERATED header that warns against hand-edits
+    and points back to this script and the manifest.
+
+    The generator is idempotent. Running it twice on a clean tree produces no
+    diff. CI uses -CheckOnly mode to fail when the committed catalogs are
+    stale relative to the manifest.
+
+.PARAMETER ManifestPath
+    Path to tools/tool-manifest.json. Defaults to the repo-relative location.
+
+.PARAMETER ConsumerOutPath
+    Path for the consumer-facing catalog. Defaults to docs/consumer/tool-catalog.md.
+
+.PARAMETER ContributorOutPath
+    Path for the contributor-facing catalog. Defaults to docs/contributor/tool-catalog.md.
+
+.PARAMETER CheckOnly
+    Do not write files. Compare the generated content with what is on disk.
+    Exits 0 when in sync, exits 1 when stale (and prints the offending paths).
+
+.EXAMPLE
+    pwsh -File scripts/Generate-ToolCatalog.ps1
+    Regenerate both catalog pages.
+
+.EXAMPLE
+    pwsh -File scripts/Generate-ToolCatalog.ps1 -CheckOnly
+    Used by CI: fail if the committed catalog is stale.
+#>
+[CmdletBinding()]
+param(
+    [string]$ManifestPath,
+    [string]$ConsumerOutPath,
+    [string]$ContributorOutPath,
+    [switch]$CheckOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RepoRoot {
+    $candidate = Split-Path -Parent $PSScriptRoot
+    if (-not $candidate) { $candidate = (Get-Location).Path }
+    return $candidate
+}
+
+$repoRoot = Get-RepoRoot
+if (-not $ManifestPath)        { $ManifestPath        = Join-Path $repoRoot 'tools/tool-manifest.json' }
+if (-not $ConsumerOutPath)     { $ConsumerOutPath     = Join-Path $repoRoot 'docs/consumer/tool-catalog.md' }
+if (-not $ContributorOutPath)  { $ContributorOutPath  = Join-Path $repoRoot 'docs/contributor/tool-catalog.md' }
+
+if (-not (Test-Path -LiteralPath $ManifestPath)) {
+    throw "Manifest not found at: $ManifestPath"
+}
+
+$manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
+if (-not $manifest.tools) {
+    throw "Manifest at $ManifestPath has no 'tools' array."
+}
+
+$schemaVersion = if ($manifest.PSObject.Properties.Name -contains 'schemaVersion') { $manifest.schemaVersion } else { 'unknown' }
+
+# Map of tool name -> consumer doc relative path (within docs/consumer). Add
+# entries here as per-tool consumer pages are written. Missing entries fall
+# back to the central scenarios/README index.
+$consumerDocLinks = @{
+    'maester'         = 'ai-triage.md'
+    'gitleaks'        = 'gitleaks-pattern-tuning.md'
+    'ado-repos-secrets' = 'gitleaks-pattern-tuning.md'
+}
+
+# Short, consumer-friendly description per tool. Falls back to displayName when
+# absent so the catalog never ships an empty cell.
+$consumerBlurb = @{
+    'azqr'                     = 'Azure best-practice review across reliability, security, cost, performance and operational excellence.'
+    'kubescape'                = 'Runtime posture for AKS clusters: misconfigurations, RBAC, network policies, vulnerabilities.'
+    'kube-bench'               = 'CIS Kubernetes benchmark for AKS node hardening.'
+    'defender-for-cloud'       = 'Pulls Microsoft Defender for Cloud Secure Score and active recommendations per subscription.'
+    'falco'                    = 'AKS runtime anomaly detection (syscall-level threat detection).'
+    'azure-cost'               = 'Per-subscription monthly Azure spend pulled from the Consumption API.'
+    'finops'                   = 'FinOps signals: idle / orphaned resources that drive avoidable spend.'
+    'psrule'                   = 'Microsoft PSRule for Azure: Well-Architected and best-practice rule baseline.'
+    'azgovviz'                 = 'Azure Governance Visualizer: management-group / subscription / RBAC / policy posture.'
+    'alz-queries'              = 'ALZ Resource Graph queries: landing-zone compliance and drift detection.'
+    'wara'                     = 'Well-Architected Reliability Assessment workflow for production workloads.'
+    'maester'                  = 'Microsoft Entra (Identity) security baseline: conditional access, MFA, privileged roles.'
+    'scorecard'                = 'OpenSSF Scorecard for repository supply-chain hygiene.'
+    'ado-connections'          = 'Azure DevOps service-connection security: identity, scope, federation.'
+    'ado-pipelines'            = 'Azure DevOps pipeline-security posture (variable groups, environments, approvals).'
+    'ado-repos-secrets'        = 'Secret scanning across Azure DevOps repositories via gitleaks.'
+    'ado-pipeline-correlator'  = 'Correlates ADO pipeline runs with downstream Azure resource changes.'
+    'identity-correlator'      = 'Correlates Entra identities, role assignments, and resource ownership.'
+    'identity-graph-expansion' = 'Expands the identity graph: cross-tenant B2B + service-principal-to-resource edges.'
+    'zizmor'                   = 'Static analysis for GitHub Actions workflow security risks.'
+    'gitleaks'                 = 'Secret scanning across local or remote git repositories.'
+    'trivy'                    = 'Vulnerability and IaC misconfiguration scanner for repos and container images.'
+    'bicep-iac'                = 'Bicep IaC validation: lint, build, and best-practice checks.'
+    'terraform-iac'            = 'Terraform IaC validation: tflint / tfsec / checkov-style checks.'
+    'sentinel-incidents'       = 'Pulls active Microsoft Sentinel incidents from a Log Analytics workspace.'
+    'sentinel-coverage'        = 'Sentinel detection posture: analytic rules, watchlists, data connectors, hunting queries.'
+    'copilot-triage'           = 'Optional Copilot-powered AI triage for finding prioritization (disabled by default).'
+}
+
+function Format-Status {
+    param($enabled)
+    if ($enabled) { 'Enabled' } else { 'Disabled' }
+}
+
+function Format-InstallKind {
+    param($tool)
+    if ($tool.PSObject.Properties.Name -notcontains 'install' -or -not $tool.install) { return 'n/a' }
+    $kind = $tool.install.kind
+    $extra = ''
+    switch ($kind) {
+        'cli'       { if ($tool.install.PSObject.Properties.Name -contains 'command' -and $tool.install.command) { $extra = " (`"$($tool.install.command)`")" } }
+        'psmodule'  { if ($tool.install.PSObject.Properties.Name -contains 'module'  -and $tool.install.module)  { $extra = " (`"$($tool.install.module)`")"  } }
+        'gitclone'  { if ($tool.install.PSObject.Properties.Name -contains 'repo'    -and $tool.install.repo)    { $extra = " (`"$($tool.install.repo)`")"    } }
+        default     { }
+    }
+    return "$kind$extra"
+}
+
+function Format-Upstream {
+    param($tool)
+    if ($tool.PSObject.Properties.Name -notcontains 'upstream' -or -not $tool.upstream) { return 'n/a' }
+    $repo = if ($tool.upstream.PSObject.Properties.Name -contains 'repo') { $tool.upstream.repo } else { '' }
+    $pin  = if ($tool.upstream.PSObject.Properties.Name -contains 'currentPin') { $tool.upstream.currentPin } else { '' }
+    if ($repo -and $pin) { return "$repo @ $pin" }
+    if ($repo) { return $repo }
+    if ($pin)  { return $pin }
+    return 'n/a'
+}
+
+function Format-Platforms {
+    param($tool)
+    if ($tool.PSObject.Properties.Name -notcontains 'platforms' -or -not $tool.platforms) { return 'n/a' }
+    return ($tool.platforms -join ', ')
+}
+
+function Format-Color {
+    param($tool)
+    if ($tool.PSObject.Properties.Name -notcontains 'report' -or -not $tool.report) { return '' }
+    if ($tool.report.PSObject.Properties.Name -contains 'color') { return $tool.report.color }
+    return ''
+}
+
+function Format-Phase {
+    param($tool)
+    if ($tool.PSObject.Properties.Name -notcontains 'report' -or -not $tool.report) { return '' }
+    if ($tool.report.PSObject.Properties.Name -contains 'phase') { return [string]$tool.report.phase }
+    return ''
+}
+
+function Get-ConsumerDocLink {
+    param([string]$name)
+    if ($consumerDocLinks.ContainsKey($name)) {
+        return "[docs](./$($consumerDocLinks[$name]))"
+    }
+    return '-'
+}
+
+function Get-ConsumerBlurb {
+    param($tool)
+    if ($consumerBlurb.ContainsKey($tool.name)) { return $consumerBlurb[$tool.name] }
+    return $tool.displayName
+}
+
+function New-ConsumerCatalog {
+    param($tools, [string]$schema)
+
+    $enabledTools  = $tools | Where-Object { $_.enabled } | Sort-Object name
+    $disabledTools = $tools | Where-Object { -not $_.enabled } | Sort-Object name
+
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine('# Tool catalog (consumer view)')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('> GENERATED FROM tools/tool-manifest.json - do not edit by hand.')
+    [void]$sb.AppendLine('> Regenerate with `pwsh -File scripts/Generate-ToolCatalog.ps1`.')
+    [void]$sb.AppendLine('> Stale catalogs are blocked by the `tool-catalog-fresh` CI check.')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("Manifest schema version: ``$schema``")
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("This page lists every analyzer tool azure-analyzer can run, what it covers, what scope it targets, and where to find consumer-focused setup notes when one exists. For the full manifest fields (normalizer, install kind, upstream pin, report color/phase) see [docs/contributor/tool-catalog.md](../contributor/tool-catalog.md).")
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("**Total enabled:** $($enabledTools.Count). **Disabled / opt-in:** $($disabledTools.Count).")
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('## Enabled by default')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('| Name | Display name | Scope | Provider | What it does | Docs |')
+    [void]$sb.AppendLine('|---|---|---|---|---|---|')
+    foreach ($t in $enabledTools) {
+        $row = '| `{0}` | {1} | {2} | {3} | {4} | {5} |' -f `
+            $t.name, $t.displayName, $t.scope, $t.provider, (Get-ConsumerBlurb $t), (Get-ConsumerDocLink $t.name)
+        [void]$sb.AppendLine($row)
+    }
+
+    if ($disabledTools.Count -gt 0) {
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('## Disabled / opt-in')
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('These tools are wired but turned off in the manifest. Enable them by setting `enabled: true` in `tools/tool-manifest.json` or via `tools/install-config.json`.')
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('| Name | Display name | Scope | Provider | What it does |')
+        [void]$sb.AppendLine('|---|---|---|---|---|')
+        foreach ($t in $disabledTools) {
+            $row = '| `{0}` | {1} | {2} | {3} | {4} |' -f `
+                $t.name, $t.displayName, $t.scope, $t.provider, (Get-ConsumerBlurb $t)
+            [void]$sb.AppendLine($row)
+        }
+    }
+
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('## Scope reference')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('| Scope | Targets |')
+    [void]$sb.AppendLine('|---|---|')
+    [void]$sb.AppendLine('| `subscription` | Single Azure subscription (`-SubscriptionId`). |')
+    [void]$sb.AppendLine('| `managementGroup` | Azure Management Group (`-ManagementGroupId`). |')
+    [void]$sb.AppendLine('| `tenant` | Entra ID tenant (`-TenantId`, requires `Connect-MgGraph`). |')
+    [void]$sb.AppendLine('| `repository` | GitHub or ADO repo (`-Repository` or `-RepoPath`). |')
+    [void]$sb.AppendLine('| `ado` | Azure DevOps organization (`-AdoOrg`). |')
+    [void]$sb.AppendLine('| `workspace` | Log Analytics / Sentinel workspace (`-SentinelWorkspaceId`). |')
+    [void]$sb.AppendLine()
+    return $sb.ToString()
+}
+
+function New-ContributorCatalog {
+    param($tools, [string]$schema)
+
+    $sortedTools = $tools | Sort-Object name
+
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine('# Tool catalog (contributor view)')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('> GENERATED FROM tools/tool-manifest.json - do not edit by hand.')
+    [void]$sb.AppendLine('> Regenerate with `pwsh -File scripts/Generate-ToolCatalog.ps1`.')
+    [void]$sb.AppendLine('> Stale catalogs are blocked by the `tool-catalog-fresh` CI check.')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("Manifest schema version: ``$schema``")
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('Full manifest projection: every wired tool with normalizer, invocation, install, report, and upstream metadata. For the consumer-friendly subset see [docs/consumer/tool-catalog.md](../consumer/tool-catalog.md). To onboard a new tool follow [adding-a-tool.md](./adding-a-tool.md).')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine("**Total tools registered:** $($sortedTools.Count).")
+    [void]$sb.AppendLine()
+
+    [void]$sb.AppendLine('## Registration matrix')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('| Name | Display name | Type | Provider | Scope | Status | Tier | Platforms |')
+    [void]$sb.AppendLine('|---|---|---|---|---|---|---|---|')
+    foreach ($t in $sortedTools) {
+        $type = if ($t.PSObject.Properties.Name -contains 'type') { $t.type } else { '' }
+        $tier = if ($t.PSObject.Properties.Name -contains 'requiredPermissionTier') { [string]$t.requiredPermissionTier } else { '' }
+        $row = '| `{0}` | {1} | {2} | {3} | {4} | {5} | {6} | {7} |' -f `
+            $t.name, $t.displayName, $type, $t.provider, $t.scope, (Format-Status $t.enabled), $tier, (Format-Platforms $t)
+        [void]$sb.AppendLine($row)
+    }
+
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('## Invocation')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('| Name | Normalizer | Invoke | Script / module | Required params |')
+    [void]$sb.AppendLine('|---|---|---|---|---|')
+    foreach ($t in $sortedTools) {
+        $normalizer = if ($t.PSObject.Properties.Name -contains 'normalizer') { $t.normalizer } else { '' }
+        $invoke     = if ($t.PSObject.Properties.Name -contains 'invokeMethod') { $t.invokeMethod } else { '' }
+        $script     = if ($t.PSObject.Properties.Name -contains 'script') { $t.script } else { '' }
+        $required   = if ($t.PSObject.Properties.Name -contains 'requiredParams' -and $t.requiredParams) { ($t.requiredParams -join ', ') } else { '-' }
+        $row = '| `{0}` | `{1}` | {2} | `{3}` | {4} |' -f $t.name, $normalizer, $invoke, $script, $required
+        [void]$sb.AppendLine($row)
+    }
+
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('## Install + upstream')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('| Name | Install kind | Upstream pin | Report color | Phase |')
+    [void]$sb.AppendLine('|---|---|---|---|---|')
+    foreach ($t in $sortedTools) {
+        $row = '| `{0}` | {1} | {2} | `{3}` | {4} |' -f `
+            $t.name, (Format-InstallKind $t), (Format-Upstream $t), (Format-Color $t), (Format-Phase $t)
+        [void]$sb.AppendLine($row)
+    }
+
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('## Notes')
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('- `tier` is `requiredPermissionTier` (0..6, see [PERMISSIONS.md](../../PERMISSIONS.md) for the tier breakdown).')
+    [void]$sb.AppendLine('- `phase` is the report grouping hint used by `New-HtmlReport.ps1` and `New-MdReport.ps1`.')
+    [void]$sb.AppendLine('- `report.color` is consumed by the per-source bar chart in the HTML report.')
+    [void]$sb.AppendLine('- `install.kind` is one of `psmodule`, `cli`, `gitclone`, `none` and is enforced by `modules/shared/Installer.ps1`.')
+    [void]$sb.AppendLine('- `upstream` drives the weekly auto-update loop; `pinType` and `currentPin` are managed by `tools/Update-ToolPins.ps1`.')
+    [void]$sb.AppendLine()
+    return $sb.ToString()
+}
+
+function Convert-ToLfText {
+    param([string]$Text)
+    return ($Text -replace "`r`n", "`n")
+}
+
+function Write-OrCheck {
+    param(
+        [string]$Path,
+        [string]$Content,
+        [switch]$CheckOnly
+    )
+    $normalized = Convert-ToLfText $Content
+    if ($CheckOnly) {
+        if (-not (Test-Path -LiteralPath $Path)) {
+            Write-Host "[stale] missing: $Path"
+            return $false
+        }
+        $current = Convert-ToLfText (Get-Content -LiteralPath $Path -Raw)
+        if ($current -ne $normalized) {
+            Write-Host "[stale] $Path differs from manifest projection"
+            return $false
+        }
+        Write-Host "[ok] $Path"
+        return $true
+    }
+    $dir = Split-Path -Parent $Path
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    # Write LF-only, no BOM (consistent diff on Windows + Linux CI).
+    [System.IO.File]::WriteAllText($Path, $normalized, [System.Text.UTF8Encoding]::new($false))
+    Write-Host "[wrote] $Path"
+    return $true
+}
+
+$consumerContent     = New-ConsumerCatalog $manifest.tools $schemaVersion
+$contributorContent  = New-ContributorCatalog $manifest.tools $schemaVersion
+
+$okConsumer    = Write-OrCheck -Path $ConsumerOutPath    -Content $consumerContent    -CheckOnly:$CheckOnly
+$okContributor = Write-OrCheck -Path $ContributorOutPath -Content $contributorContent -CheckOnly:$CheckOnly
+
+if ($CheckOnly -and (-not ($okConsumer -and $okContributor))) {
+    Write-Host ''
+    Write-Host 'Tool catalog is stale relative to tools/tool-manifest.json.'
+    Write-Host 'Run: pwsh -File scripts/Generate-ToolCatalog.ps1'
+    exit 1
+}
+
+exit 0

--- a/tests/scripts/Generate-ToolCatalog.Tests.ps1
+++ b/tests/scripts/Generate-ToolCatalog.Tests.ps1
@@ -120,7 +120,12 @@ Describe 'Generate-ToolCatalog' {
             } finally {
                 Remove-Item -LiteralPath $tempStale -Force -ErrorAction SilentlyContinue
                 Remove-Item -LiteralPath $tempContrib -Force -ErrorAction SilentlyContinue
+                $global:LASTEXITCODE = 0
             }
         }
+    }
+
+    AfterAll {
+        $global:LASTEXITCODE = 0
     }
 }

--- a/tests/scripts/Generate-ToolCatalog.Tests.ps1
+++ b/tests/scripts/Generate-ToolCatalog.Tests.ps1
@@ -1,0 +1,126 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+Describe 'Generate-ToolCatalog' {
+
+    BeforeAll {
+        $script:RepoRoot       = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+        $script:ScriptPath     = Join-Path $script:RepoRoot 'scripts\Generate-ToolCatalog.ps1'
+        $script:ManifestPath   = Join-Path $script:RepoRoot 'tools\tool-manifest.json'
+        $script:ConsumerPath   = Join-Path $script:RepoRoot 'docs\consumer\tool-catalog.md'
+        $script:ContribPath    = Join-Path $script:RepoRoot 'docs\contributor\tool-catalog.md'
+        $script:Manifest       = Get-Content -LiteralPath $script:ManifestPath -Raw | ConvertFrom-Json
+        $script:EnabledTools   = @($script:Manifest.tools | Where-Object { $_.enabled })
+    }
+
+    It 'script file exists' {
+        Test-Path -LiteralPath $script:ScriptPath | Should -BeTrue
+    }
+
+    It 'manifest exposes at least one enabled tool' {
+        $script:EnabledTools.Count | Should -BeGreaterThan 0
+    }
+
+    Context 'generation produces both catalog files' {
+        BeforeAll {
+            $script:TempConsumer = Join-Path ([System.IO.Path]::GetTempPath()) ("consumer-catalog-{0}.md" -f ([Guid]::NewGuid()))
+            $script:TempContrib  = Join-Path ([System.IO.Path]::GetTempPath()) ("contributor-catalog-{0}.md" -f ([Guid]::NewGuid()))
+            & $script:ScriptPath `
+                -ManifestPath        $script:ManifestPath `
+                -ConsumerOutPath     $script:TempConsumer `
+                -ContributorOutPath  $script:TempContrib | Out-Null
+        }
+
+        AfterAll {
+            Remove-Item -LiteralPath $script:TempConsumer -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $script:TempContrib  -Force -ErrorAction SilentlyContinue
+        }
+
+        It 'writes the consumer catalog' {
+            Test-Path -LiteralPath $script:TempConsumer | Should -BeTrue
+        }
+
+        It 'writes the contributor catalog' {
+            Test-Path -LiteralPath $script:TempContrib | Should -BeTrue
+        }
+
+        It 'consumer catalog has the GENERATED warning header' {
+            (Get-Content -LiteralPath $script:TempConsumer -Raw) | Should -Match 'GENERATED FROM tools/tool-manifest\.json'
+        }
+
+        It 'contributor catalog has the GENERATED warning header' {
+            (Get-Content -LiteralPath $script:TempContrib -Raw) | Should -Match 'GENERATED FROM tools/tool-manifest\.json'
+        }
+
+        It 'consumer catalog contains a row per enabled tool' {
+            $content = Get-Content -LiteralPath $script:TempConsumer -Raw
+            foreach ($tool in $script:EnabledTools) {
+                $content | Should -Match ([regex]::Escape("``$($tool.name)``"))
+            }
+        }
+
+        It 'contributor catalog contains a row per registered tool (enabled and disabled)' {
+            $content = Get-Content -LiteralPath $script:TempContrib -Raw
+            foreach ($tool in $script:Manifest.tools) {
+                $content | Should -Match ([regex]::Escape("``$($tool.name)``"))
+            }
+        }
+
+        It 'consumer catalog contains the scope reference table' {
+            (Get-Content -LiteralPath $script:TempConsumer -Raw) | Should -Match '## Scope reference'
+        }
+
+        It 'contributor catalog has invocation and install sections' {
+            $content = Get-Content -LiteralPath $script:TempContrib -Raw
+            $content | Should -Match '## Invocation'
+            $content | Should -Match '## Install \+ upstream'
+        }
+
+        It 'neither catalog contains an em dash' {
+            $consumer = Get-Content -LiteralPath $script:TempConsumer -Raw
+            $contrib  = Get-Content -LiteralPath $script:TempContrib  -Raw
+            $consumer | Should -Not -Match ([char]0x2014)
+            $contrib  | Should -Not -Match ([char]0x2014)
+        }
+    }
+
+    Context 'idempotence and CheckOnly mode' {
+        It 'is idempotent: running twice produces identical files' {
+            $tempA = Join-Path ([System.IO.Path]::GetTempPath()) ("idem-a-{0}.md" -f ([Guid]::NewGuid()))
+            $tempB = Join-Path ([System.IO.Path]::GetTempPath()) ("idem-b-{0}.md" -f ([Guid]::NewGuid()))
+            try {
+                & $script:ScriptPath -ManifestPath $script:ManifestPath -ConsumerOutPath $tempA -ContributorOutPath (Join-Path ([System.IO.Path]::GetTempPath()) "_c1.md") | Out-Null
+                & $script:ScriptPath -ManifestPath $script:ManifestPath -ConsumerOutPath $tempB -ContributorOutPath (Join-Path ([System.IO.Path]::GetTempPath()) "_c2.md") | Out-Null
+                (Get-FileHash -LiteralPath $tempA).Hash | Should -Be (Get-FileHash -LiteralPath $tempB).Hash
+            } finally {
+                Remove-Item -LiteralPath $tempA -Force -ErrorAction SilentlyContinue
+                Remove-Item -LiteralPath $tempB -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'CheckOnly succeeds against the committed catalogs' {
+            $exitCode = 0
+            try {
+                & $script:ScriptPath -CheckOnly | Out-Null
+                $exitCode = $LASTEXITCODE
+            } catch {
+                $exitCode = 99
+            }
+            $exitCode | Should -Be 0
+        }
+
+        It 'CheckOnly fails when the committed file is stale' {
+            $tempStale = Join-Path ([System.IO.Path]::GetTempPath()) ("stale-{0}.md" -f ([Guid]::NewGuid()))
+            $tempContrib = Join-Path ([System.IO.Path]::GetTempPath()) ("stale-contrib-{0}.md" -f ([Guid]::NewGuid()))
+            try {
+                Set-Content -LiteralPath $tempStale -Value "stale content" -NoNewline
+                Set-Content -LiteralPath $tempContrib -Value "stale content" -NoNewline
+                & $script:ScriptPath -CheckOnly -ConsumerOutPath $tempStale -ContributorOutPath $tempContrib 2>&1 | Out-Null
+                $LASTEXITCODE | Should -Be 1
+            } finally {
+                Remove-Item -LiteralPath $tempStale -Force -ErrorAction SilentlyContinue
+                Remove-Item -LiteralPath $tempContrib -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}


### PR DESCRIPTION
PR-3 of the consumer-first restructure. Items G/H/I/J/K from the [consolidated plan](.squad/decisions/inbox/coordinator-restructure-consolidated-plan-2026-04-20T12-30-00Z.md).

## What landed

### Item I - manifest-driven tool catalog (the headline)

User explicitly chose generation over hand-writing. Implementation:

- `scripts/Generate-ToolCatalog.ps1` reads `tools/tool-manifest.json` (single source of truth) and emits two files:
  - `docs/consumer/tool-catalog.md` - consumer view (name, displayName, scope, provider, what-it-does, link to per-tool consumer doc when one exists, scope reference table). Sorted alphabetically. Disabled / opt-in tools listed separately.
  - `docs/contributor/tool-catalog.md` - full manifest projection (registration matrix with type / provider / scope / status / tier / platforms; invocation table with normalizer / invokeMethod / script / required params; install + upstream table with install kind / upstream pin / report color / phase).
- Both files carry `> GENERATED FROM tools/tool-manifest.json - do not edit by hand` header pointing at the script.
- Idempotent (LF-only, no BOM, two consecutive runs produce no diff).
- `-CheckOnly` mode returns exit 1 when committed catalog is stale.

### New CI gate - tool-catalog-fresh

New job appended to `.github/workflows/docs-check.yml`:
`pwsh -File scripts/Generate-ToolCatalog.ps1 -CheckOnly` runs on every PR. Fails with an actionable message when the committed catalog drifts from the manifest. Forces contributors to commit the regenerated catalog when they touch the manifest.

### Item G - extracted advanced operator content

- `docs/contributor/operations.md` - shared infrastructure (Installer, RemoteClone, Retry, Sanitize, Schema, EntityStore), security invariants (HTTPS-only, host allow-list, package-manager allow-list, 300s timeout, token scrub), continuous control mode (scheduled GHA + Azure Function), multi-tenant fan-out, tool catalog regen pointer.
- `docs/contributor/troubleshooting.md` - tool failure diagnosis, prerequisite buckets, throttling / transient errors, leaked credentials, Pester baseline drops, stale catalog, module import surface, repro-bug checklist.

These pages were composed from existing module headers and shared infra under `modules/shared/` (cited in-page) rather than from `README.md`, per the parallelism rule below.

### Item J - stale doc paths swept (post PR-1)

| File | Change |
|---|---|
| `PERMISSIONS.md` | `docs/ARCHITECTURE.md` -> `docs/contributor/ARCHITECTURE.md` |
| `PERMISSIONS.md` | `docs/ai-triage.md` -> `docs/consumer/ai-triage.md` |
| `CONTRIBUTING.md` | `docs/CONTRIBUTING-TOOLS.md` -> `docs/contributor/adding-a-tool.md` |
| `.github/workflows/docs-check.yml` | em-dashes in `core.info` strings replaced with `-` |

### Item K - indexes updated

- `docs/consumer/README.md` now links `tool-catalog.md`.
- `docs/contributor/README.md` now links `tool-catalog.md`, `operations.md`, `troubleshooting.md`.

### Item H - root reference moves

No candidates. `PERMISSIONS.md` (45 KB) and `CHANGELOG.md` are kept at root per the consolidated plan ('keep CONTRIBUTING.md, SECURITY.md, PERMISSIONS.md at root'). Documented in commit body.

## Files changed

| Old path | New path |
|---|---|
| - | `scripts/Generate-ToolCatalog.ps1` (new) |
| - | `tests/scripts/Generate-ToolCatalog.Tests.ps1` (new, 14 tests) |
| - | `docs/consumer/tool-catalog.md` (generated) |
| - | `docs/contributor/tool-catalog.md` (generated) |
| - | `docs/contributor/operations.md` (new) |
| - | `docs/contributor/troubleshooting.md` (new) |

Index + sweep edits: `docs/consumer/README.md`, `docs/contributor/README.md`, `PERMISSIONS.md`, `CONTRIBUTING.md`, `.github/workflows/docs-check.yml`, `CHANGELOG.md`.

## Generator design summary

1. Load and parse manifest, fail loudly when missing.
2. Per-tool consumer blurb table (in-script) and consumer-doc-link table (in-script). Both default safely (display-name fallback, `-` link fallback) so adding a new manifest entry never breaks generation.
3. Build StringBuilder for each output: GENERATED warning header + manifest-schema-version line + consumer / contributor sections.
4. Helpers: `Format-Status`, `Format-InstallKind` (kind + command/module/repo extra), `Format-Upstream` (repo + currentPin), `Format-Platforms`, `Format-Color`, `Format-Phase`.
5. `Write-OrCheck` - writes UTF-8 no-BOM with LF endings, or compares against on-disk content in `-CheckOnly` mode.

## Parallelism rule honored

PR-2 (consumer-first README) was merged `e2d42d7` while this branch was being prepared. `README.md` was NOT touched by this PR (rebased cleanly on top of PR-2). Any extra README pruning that the merged README still warrants is left as a follow-up for a Sentinel cleanup PR.

## Gates

- Em-dash gate: `rg -- "—"` against the diff returns nothing.
- `git mv` policy: no files were moved (everything is new + index edits), so history preservation is moot.
- New tests pass locally (14/14).
- Full Pester suite: pre-existing flake in `tests/shared/Get-CopilotReviewFindings.Tests.ps1` (passes 6/6 in isolation, fails under full run on local Windows due to test pollution from another file). Not introduced by this PR. CI is the source of truth (per `.copilot/copilot-instructions.md` 'GitHub-first principle').

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>