### PR TITLE
fix: stabilize Docs Check stacked-PR handling (closes #245)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -26,6 +26,16 @@ jobs:
               core.info('Skipping docs check - skip-docs-check label found.');
               return;
             }
+            const prTitle = context.payload.pull_request.title || '';
+            const stackedPrMatch = prTitle.match(/\(PR-(\d+)\s+of\s+(\d+)\)/i);
+            if (stackedPrMatch) {
+              const currentPart = Number.parseInt(stackedPrMatch[1], 10);
+              const totalParts = Number.parseInt(stackedPrMatch[2], 10);
+              if (Number.isInteger(currentPart) && Number.isInteger(totalParts) && currentPart < totalParts) {
+                core.info(`Skipping docs check for stacked PR part ${currentPart} of ${totalParts}; enforce docs in the final stack PR.`);
+                return;
+              }
+            }
 
             // Get changed files in the PR
             const files = await github.paginate(
@@ -71,8 +81,12 @@ jobs:
             core.info(`Doc files changed: ${docFiles.join(', ')}`);
 
             if (docFiles.length === 0) {
+              core.error(`error: Missing documentation updates for code changes in PR #${context.issue.number}.`);
+              core.error(`error: Code files changed: ${codeFiles.join(', ')}`);
+              core.error('error: Add README.md, CHANGELOG.md, PERMISSIONS.md, or docs under docs/consumer/ or docs/contributor/.');
+              core.error("error: If docs are intentionally deferred, add the 'skip-docs-check' label and follow up in a later PR.");
               core.setFailed(
-                'This PR changes code files but no documentation was updated.\n' +
+                'error: This PR changes code files but no documentation was updated.\n' +
                 'Please update README.md, CHANGELOG.md, or a page under docs/consumer/ or docs/contributor/.\n' +
                 'See CONTRIBUTING.md for documentation requirements.'
               );

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The documentation now leads with the consumer experience, keeps advanced operato
 #### Fixed
 
 - `AzureAnalyzer.psm1` root-path resolution for `Import-Module .\AzureAnalyzer.psd1` consumption.
+- `docs-check.yml` now skips docs enforcement for non-final stacked PRs titled `(PR-x of y)` and emits explicit `error:` lines when docs are missing so CI-failure triage can extract the first error reliably.
 
 #### Stub deadline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ These workflows support repo development and the AI squad workflow. They're not 
 | Workflow | Trigger | Purpose |
 |---|---|---|
 | `codeql.yml` | Push / PR / weekly | CodeQL static analysis (SHA-pinned) |
-| `docs-check.yml` | PR | Enforces docs updates with code changes |
+| `docs-check.yml` | PR | Enforces docs updates with code changes (non-final stacked PR parts titled `(PR-x of y)` are skipped) |
 | `pr-review-gate.yml` | `pull_request_review` + `_comment` | Ingests review feedback, writes consensus plan to `.squad/decisions/inbox/`, posts gate summary |
 | `ci-failure-watchdog.yml` | `workflow_run` on failure | Deduplicated CI failure issue (hash = workflow + first error line) |
 | `squad-heartbeat.yml` | Cron | Automated triage and CI gate via Ralph |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Run azure-analyzer on a schedule and stream findings to Log Analytics or open is
 - [docs/contributor/README.md](docs/contributor/README.md): architecture, adding a new tool, AI governance, and forward-looking proposals.
 - [docs/contributor/ARCHITECTURE.md](docs/contributor/ARCHITECTURE.md): module layout, normalizer contract, EntityStore design.
 - [docs/contributor/adding-a-tool.md](docs/contributor/adding-a-tool.md): end-to-end guide for registering a new analyzer tool in `tools/tool-manifest.json`.
+- Docs Check note: stacked PR titles formatted as `(PR-x of y)` skip docs enforcement until the final part, while missing docs errors now emit explicit `error:` lines for CI triage.
 
 The Pester baseline must stay green: `Invoke-Pester -Path .\tests -CI`.
 


### PR DESCRIPTION
## Summary
- Root cause: Docs Check enforced doc updates on every stacked PR part, so non-final parts like `(PR-4 of 5)` failed even when docs were intended for later parts.
- Added stacked-PR detection in `docs-check.yml` to skip docs enforcement for non-final parts.
- Added explicit `error:` log lines before `core.setFailed(...)` so CI-failure triage can extract a concrete first error line.
- Updated README, CONTRIBUTING, and CHANGELOG with the new behavior.

## Verification
- `pwsh -File scripts/Generate-ToolCatalog.ps1 -CheckOnly`
- `Invoke-Pester -Path .\tests -CI` (1197 passed, 0 failed)

Closes #245