### PR TITLE
chore: enforce stub-deadline removal mechanism (closes #250)

### DIFF
--- a/.github/workflows/stub-deadline-check.yml
+++ b/.github/workflows/stub-deadline-check.yml
@@ -1,0 +1,23 @@
+name: Stub deadline check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-stub-deadline:
+    name: Check redirect stub deadline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate stub deadline registry against module version
+        shell: pwsh
+        run: |
+          pwsh -File scripts/Check-StubDeadline.ps1 -Mode Check

--- a/.squad/stub-deadlines.json
+++ b/.squad/stub-deadlines.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "1.0",
+  "description": "Temporary redirect stubs from docs restructure PR-1 (#243). Remove at next minor bump.",
+  "stubs": [
+    {
+      "path": "AI_GOVERNANCE.md",
+      "replacementPath": "docs/contributor/ai-governance.md",
+      "expiresAt": "1.1.0"
+    },
+    {
+      "path": "docs/ARCHITECTURE.md",
+      "replacementPath": "docs/contributor/ARCHITECTURE.md",
+      "expiresAt": "1.1.0"
+    },
+    {
+      "path": "docs/CONTRIBUTING-TOOLS.md",
+      "replacementPath": "docs/contributor/adding-a-tool.md",
+      "expiresAt": "1.1.0"
+    },
+    {
+      "path": "docs/ai-triage.md",
+      "replacementPath": "docs/consumer/ai-triage.md",
+      "expiresAt": "1.1.0"
+    },
+    {
+      "path": "docs/continuous-control.md",
+      "replacementPath": "docs/consumer/continuous-control.md",
+      "expiresAt": "1.1.0"
+    },
+    {
+      "path": "docs/future-iac-drift.md",
+      "replacementPath": "docs/contributor/proposals/iac-drift.md",
+      "expiresAt": "1.1.0"
+    },
+    {
+      "path": "docs/gitleaks-pattern-tuning.md",
+      "replacementPath": "docs/consumer/gitleaks-pattern-tuning.md",
+      "expiresAt": "1.1.0"
+    },
+    {
+      "path": "docs/proposals/copilot-triage-panel.md",
+      "replacementPath": "docs/contributor/proposals/copilot-triage-panel.md",
+      "expiresAt": "1.1.0"
+    },
+    {
+      "path": "docs/sinks/log-analytics.md",
+      "replacementPath": "docs/consumer/sinks/log-analytics.md",
+      "expiresAt": "1.1.0"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ The documentation now leads with the consumer experience, keeps advanced operato
 
 - Redirect stubs at the old paths stay in place through the `1.0.x` line and will be removed in `v1.1.0`, the next minor version bump.
 
+#### Enforcement
+
+- chore: enforce stub-deadline removal via `.squad/stub-deadlines.json` + `scripts/Check-StubDeadline.ps1` + `.github/workflows/stub-deadline-check.yml` + `tests/scripts/Check-StubDeadline.Tests.ps1` (closes #250)
+
 ## [Unreleased - earlier entries]
 
 ### Fixed (earlier)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Run azure-analyzer on a schedule and stream findings to Log Analytics or open is
 - [docs/contributor/ARCHITECTURE.md](docs/contributor/ARCHITECTURE.md): module layout, normalizer contract, EntityStore design.
 - [docs/contributor/adding-a-tool.md](docs/contributor/adding-a-tool.md): end-to-end guide for registering a new analyzer tool in `tools/tool-manifest.json`.
 - Docs Check note: stacked PR titles formatted as `(PR-x of y)` skip docs enforcement until the final part, while missing docs errors now emit explicit `error:` lines for CI triage.
+- Redirect stub deadlines are enforced by `.squad/stub-deadlines.json` + `scripts/Check-StubDeadline.ps1` (CI workflow: `stub-deadline-check.yml`).
 
 The Pester baseline must stay green: `Invoke-Pester -Path .\tests -CI`.
 

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -9,3 +9,4 @@ Contributor and developer reference. Squad coordination lives in `.squad/`.
 - [troubleshooting.md](troubleshooting.md) - Diagnose tool failures, throttling, leaked credentials, Pester drops, stale catalog.
 - [ai-governance.md](ai-governance.md) - AI governance, model selection, and review-gate policy for the repo.
 - [proposals/](proposals/) - Forward-looking design proposals (IaC drift, Copilot triage panel, and more).
+- Redirect stub deadlines are tracked in `.squad/stub-deadlines.json` and enforced by `scripts/Check-StubDeadline.ps1` (CI: `.github/workflows/stub-deadline-check.yml`).

--- a/scripts/Check-StubDeadline.ps1
+++ b/scripts/Check-StubDeadline.ps1
@@ -1,0 +1,129 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [ValidateSet('Check', 'Remove', 'Report')]
+    [string]$Mode = 'Check',
+    [string]$RepoRoot,
+    [string]$RegistryPath,
+    [string]$ModuleManifestPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RepoRoot {
+    $candidate = Split-Path -Parent $PSScriptRoot
+    if (-not $candidate) {
+        $candidate = (Get-Location).Path
+    }
+    return $candidate
+}
+
+function Resolve-DefaultPath {
+    param(
+        [string]$BasePath,
+        [string]$RelativePath,
+        [string]$ProvidedPath
+    )
+
+    if ($ProvidedPath) {
+        return $ProvidedPath
+    }
+
+    return Join-Path $BasePath $RelativePath
+}
+
+$defaultRepoRoot = Get-RepoRoot
+$basePath = if ($RepoRoot) { $RepoRoot } else { $defaultRepoRoot }
+$RegistryPath = Resolve-DefaultPath -BasePath $basePath -RelativePath '.squad\stub-deadlines.json' -ProvidedPath $RegistryPath
+$ModuleManifestPath = Resolve-DefaultPath -BasePath $basePath -RelativePath 'AzureAnalyzer.psd1' -ProvidedPath $ModuleManifestPath
+
+if (-not (Test-Path -LiteralPath $RegistryPath -PathType Leaf)) {
+    throw "Stub deadline registry not found at: $RegistryPath"
+}
+
+if (-not (Test-Path -LiteralPath $ModuleManifestPath -PathType Leaf)) {
+    throw "Module manifest not found at: $ModuleManifestPath"
+}
+
+$resolvedManifestPath = (Resolve-Path -LiteralPath $ModuleManifestPath).Path
+if ($RepoRoot) {
+    $repoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+} elseif ($PSBoundParameters.ContainsKey('ModuleManifestPath')) {
+    $repoRoot = Split-Path -Parent $resolvedManifestPath
+} else {
+    $repoRoot = $defaultRepoRoot
+}
+
+$moduleManifest = Import-PowerShellDataFile -LiteralPath $resolvedManifestPath
+if (-not $moduleManifest.ModuleVersion) {
+    throw "ModuleVersion missing from module manifest: $ModuleManifestPath"
+}
+
+[Version]$currentVersion = $moduleManifest.ModuleVersion
+$registry = Get-Content -LiteralPath $RegistryPath -Raw | ConvertFrom-Json
+$stubs = @($registry.stubs)
+
+if ($stubs.Count -eq 0) {
+    throw "No stubs declared in registry: $RegistryPath"
+}
+
+$results = foreach ($stub in $stubs) {
+    if (-not $stub.path) {
+        throw "Registry entry missing 'path': $($stub | ConvertTo-Json -Compress)"
+    }
+    if (-not $stub.expiresAt) {
+        throw "Registry entry missing 'expiresAt' for path: $($stub.path)"
+    }
+
+    [Version]$expiresAt = $stub.expiresAt
+    $stubPath = Join-Path $repoRoot $stub.path
+    $exists = Test-Path -LiteralPath $stubPath -PathType Leaf
+    $isExpired = $currentVersion -ge $expiresAt
+
+    [PSCustomObject]@{
+        Path            = $stub.path
+        ReplacementPath = $stub.replacementPath
+        ExpiresAt       = $expiresAt.ToString()
+        CurrentVersion  = $currentVersion.ToString()
+        Exists          = $exists
+        IsExpired       = $isExpired
+    }
+}
+
+$expiredPresent = @($results | Where-Object { $_.Exists -and $_.IsExpired })
+
+switch ($Mode) {
+    'Report' {
+        $results |
+            Sort-Object Path |
+            Select-Object Path, ReplacementPath, ExpiresAt, CurrentVersion, Exists, IsExpired
+        exit 0
+    }
+
+    'Check' {
+        if ($expiredPresent.Count -gt 0) {
+            Write-Host "Expired stub files detected for module version ${currentVersion}:"
+            foreach ($item in $expiredPresent | Sort-Object Path) {
+                Write-Host " - $($item.Path) -> $($item.ReplacementPath) (expired at $($item.ExpiresAt))"
+            }
+            exit 1
+        }
+
+        Write-Host "Stub deadline check passed for module version $currentVersion."
+        Write-Host "Tracked stubs: $($results.Count). Expired stubs present: 0."
+        exit 0
+    }
+
+    'Remove' {
+        foreach ($item in $expiredPresent) {
+            $absolutePath = Join-Path $repoRoot $item.Path
+            Remove-Item -LiteralPath $absolutePath -Force
+            Write-Host "Removed expired stub: $($item.Path)"
+        }
+
+        Write-Host "Stub removal complete for module version $currentVersion."
+        Write-Host "Removed stubs: $($expiredPresent.Count)."
+        exit 0
+    }
+}

--- a/tests/scripts/Check-StubDeadline.Tests.ps1
+++ b/tests/scripts/Check-StubDeadline.Tests.ps1
@@ -1,0 +1,97 @@
+#requires -Version 7.0
+#requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+Describe 'Check-StubDeadline' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+        $script:ScriptPath = Join-Path $script:RepoRoot 'scripts\Check-StubDeadline.ps1'
+        $script:NewStubFixture = {
+            param(
+                [Parameter(Mandatory)]
+                [string]$RootPath,
+                [Parameter(Mandatory)]
+                [string]$ModuleVersion,
+                [Parameter(Mandatory)]
+                [string]$ExpiresAt,
+                [bool]$CreateStub = $true
+            )
+
+            $manifestPath = Join-Path $RootPath 'AzureAnalyzer.psd1'
+            $stubPath = Join-Path $RootPath 'docs\legacy.md'
+            $stubDirectory = Split-Path -Parent $stubPath
+            $registryPath = Join-Path $RootPath '.squad\stub-deadlines.json'
+            $registryDirectory = Split-Path -Parent $registryPath
+
+            New-Item -ItemType Directory -Path $stubDirectory -Force | Out-Null
+            New-Item -ItemType Directory -Path $registryDirectory -Force | Out-Null
+
+            @"
+@{
+    ModuleVersion = '$ModuleVersion'
+}
+"@ | Set-Content -LiteralPath $manifestPath -NoNewline
+
+            if ($CreateStub) {
+                '# Moved' | Set-Content -LiteralPath $stubPath -NoNewline
+            }
+
+            @"
+{
+  "schemaVersion": "1.0",
+  "stubs": [
+    {
+      "path": "docs/legacy.md",
+      "replacementPath": "docs/new/location.md",
+      "expiresAt": "$ExpiresAt"
+    }
+  ]
+}
+"@ | Set-Content -LiteralPath $registryPath -NoNewline
+
+            return [PSCustomObject]@{
+                ManifestPath = $manifestPath
+                RegistryPath = $registryPath
+                StubPath = $stubPath
+            }
+        }
+    }
+
+    BeforeEach {
+        $global:LASTEXITCODE = 0
+    }
+
+    It 'script file exists' {
+        Test-Path -LiteralPath $script:ScriptPath | Should -BeTrue
+    }
+
+    It 'Check mode succeeds when current version is below deadline' {
+        $fixture = & $script:NewStubFixture -RootPath $TestDrive -ModuleVersion '1.0.0' -ExpiresAt '1.1.0'
+        & $script:ScriptPath -Mode Check -ModuleManifestPath $fixture.ManifestPath -RegistryPath $fixture.RegistryPath | Out-Null
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It 'Check mode fails when current version reached deadline and stub still exists' {
+        $fixture = & $script:NewStubFixture -RootPath $TestDrive -ModuleVersion '1.1.0' -ExpiresAt '1.1.0'
+        & $script:ScriptPath -Mode Check -ModuleManifestPath $fixture.ManifestPath -RegistryPath $fixture.RegistryPath 2>&1 | Out-Null
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It 'Remove mode deletes expired stubs' {
+        $fixture = & $script:NewStubFixture -RootPath $TestDrive -ModuleVersion '1.1.0' -ExpiresAt '1.1.0'
+        & $script:ScriptPath -Mode Remove -ModuleManifestPath $fixture.ManifestPath -RegistryPath $fixture.RegistryPath | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        Test-Path -LiteralPath $fixture.StubPath | Should -BeFalse
+    }
+
+    It 'Report mode returns a row for each tracked stub' {
+        $fixture = & $script:NewStubFixture -RootPath $TestDrive -ModuleVersion '1.0.0' -ExpiresAt '1.1.0'
+        $rows = & $script:ScriptPath -Mode Report -ModuleManifestPath $fixture.ManifestPath -RegistryPath $fixture.RegistryPath
+        $LASTEXITCODE | Should -Be 0
+        $rows.Count | Should -Be 1
+        $rows[0].Path | Should -Be 'docs/legacy.md'
+    }
+
+    AfterAll {
+        $global:LASTEXITCODE = 0
+    }
+}


### PR DESCRIPTION
## Summary
- Chose design **C** (registry + script + workflow + Pester) for resilient enforcement.
- Added `.squad/stub-deadlines.json` as the source of truth for 9 temporary redirect stubs.
- Added `scripts/Check-StubDeadline.ps1` with `-Mode Check|Remove|Report`.
- Added `tests/scripts/Check-StubDeadline.Tests.ps1` and `.github/workflows/stub-deadline-check.yml`.
- Updated `CHANGELOG.md`, `README.md`, and `docs/contributor/README.md`.

## Design choice and rationale
I implemented option C. A single registry file keeps deadlines explicit and reviewable. The script allows local checks and deterministic removal. CI runs the same check on PRs and pushes so a version bump past the deadline cannot slip through unnoticed.

## Deadline version
- Configured deadline: **1.1.0** (next minor bump after 1.0.x, matching issue #250 and CHANGELOG wording).

## How to override
- Edit `.squad/stub-deadlines.json` and change `expiresAt` per stub if the squad decides to move the cutoff.

## How removal works at deadline
- `Check` mode fails when `AzureAnalyzer.psd1` `ModuleVersion` is greater than or equal to `expiresAt` and a tracked stub file still exists.
- `Remove` mode deletes only expired stub files.
- CI (`stub-deadline-check.yml`) runs `Check` mode and blocks green status until expired stubs are removed.

Closes #250.

## Self-review

### Diff summary
- Added a registry file for all 9 redirect stubs with replacement path and deadline metadata.
- Implemented a new script that compares module version against stub deadlines and supports check/report/remove modes.
- Added workflow and tests so enforcement runs both locally and in CI.

### Risks considered
- False positives from relative-path resolution: mitigated by resolving repo root from explicit `-ModuleManifestPath` when provided.
- Accidental deletion of non-expired stubs: mitigated by removing only entries where `currentVersion >= expiresAt` and file exists.
- Drift between docs and enforcement behavior: mitigated by changelog and contributor-readme updates in the same PR.
- Out of scope on purpose: sticky reminder comments were not added because option C already provides a hard-fail gate in CI.

### Validation
- `pwsh -File .\\scripts\\Check-StubDeadline.ps1 -Mode Check` (passes, 9 tracked stubs, 0 expired present)
- `pwsh -File .\\scripts\\Check-StubDeadline.ps1 -Mode Report`
- `Invoke-Pester -Path .\\tests\\scripts\\Check-StubDeadline.Tests.ps1 -CI`
- `Invoke-Pester -Path .\\tests -CI` (1202 passed, 0 failed, 5 skipped)