### PR TITLE
feat(ci): add markdown link-check workflow (closes #251)

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,35 @@
+name: Markdown Link Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**/*.md'
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-link-check:
+    name: markdown-link-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check markdown links
+        id: lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        with:
+          args: --config .lychee.toml './**/*.md'
+          format: markdown
+          output: lychee/out.md
+          jobSummary: true
+
+      - name: Show report path
+        if: always()
+        run: |
+          echo "Lychee report: ${{ github.workspace }}/lychee/out.md" >> "$GITHUB_STEP_SUMMARY"

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,23 @@
+verbose = "info"
+no_progress = true
+max_concurrency = 8
+max_retries = 2
+retry_wait_time = 2
+timeout = 20
+accept = ["200..=299", "429"]
+include_fragments = false
+exclude_loopback = true
+include_mail = false
+exclude = [
+  "^http://",
+  "^https://img\\.shields\\.io/",
+  "^https://(www\\.)?linkedin\\.com/",
+  "^https://x\\.com/",
+  "^https://twitter\\.com/",
+  "^file:///.*?/\\.copilot/skills/humanizer/url$",
+  "^file:///.*?/\\.squad/templates/skills/humanizer/url$",
+]
+exclude_path = [
+  "(^|/)\\.copilot/skills/humanizer/SKILL\\.md$",
+  "(^|/)\\.squad/templates/skills/humanizer/SKILL\\.md$",
+]

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -12,15 +12,15 @@
 
 | Name | Role | Charter | Status |
 |------|------|---------|--------|
-| Lead | Team Lead | [charter](.squad/agents/lead/charter.md) | Active |
-| Atlas | Azure Resource Graph Engineer | [charter](.squad/agents/atlas/charter.md) | Active |
-| Iris | Entra ID & Microsoft Graph Engineer | [charter](.squad/agents/iris/charter.md) | Active |
-| Forge | Platform Automation & DevOps Engineer | [charter](.squad/agents/forge/charter.md) | Active |
-| Sentinel | Security Analyst & Recommendation Engine | [charter](.squad/agents/sentinel/charter.md) | Active |
-| Sage | Research & Discovery Specialist | [charter](.squad/agents/sage/charter.md) | Active |
+| Lead | Team Lead | [charter](agents/lead/charter.md) | Active |
+| Atlas | Azure Resource Graph Engineer | [charter](agents/atlas/charter.md) | Active |
+| Iris | Entra ID & Microsoft Graph Engineer | [charter](agents/iris/charter.md) | Active |
+| Forge | Platform Automation & DevOps Engineer | [charter](agents/forge/charter.md) | Active |
+| Sentinel | Security Analyst & Recommendation Engine | [charter](agents/sentinel/charter.md) | Active |
+| Sage | Research & Discovery Specialist | [charter](agents/sage/charter.md) | Active |
 
 ## Project Context
 
-- **Project:** azure-analyzer — Automated Azure assessment bundling azqr, PSRule, AzGovViz, and ALZ Resource Graph queries
+- **Project:** azure-analyzer, automated Azure assessment bundling azqr, PSRule, AzGovViz, and ALZ Resource Graph queries
 - **Stack:** Python (orchestrator), KQL/ARG queries (JSON), PowerShell, GitHub Actions
 - **Created:** 2026-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to azure-analyzer will be documented here.
 
 - Removed orphaned `report-template.html`; HTML reports are rendered directly by `New-HtmlReport.ps1`, and the unused static scaffold no longer ships in the repo (closes #249).
 
+### Added
+
+- ci: add markdown link-check workflow (advisory, weekly + PR path filter) (closes #251)
+
 ### Consumer-first documentation restructure
 
 The documentation now leads with the consumer experience, keeps advanced operator and contributor material under dedicated indexes, and leaves short redirect stubs at the old paths so existing links keep working during the transition. The same stream also made module consumption safer, generated the tool catalog from the manifest, and aligned the root README with the new consumer-first quickstart flow. This entry consolidates PRs #243, #244, #246, #247, and #253.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ These workflows support repo development and the AI squad workflow. They're not 
 |---|---|---|
 | `codeql.yml` | Push / PR / weekly | CodeQL static analysis (SHA-pinned) |
 | `docs-check.yml` | PR | Enforces docs updates with code changes (non-final stacked PR parts titled `(PR-x of y)` are skipped) |
+| `markdown-link-check.yml` | PR (`*.md` path filter) / weekly | Checks markdown links via `.lychee.toml` and reports failures in job summary |
 | `pr-review-gate.yml` | `pull_request_review` + `_comment` | Ingests review feedback, writes consensus plan to `.squad/decisions/inbox/`, posts gate summary |
 | `ci-failure-watchdog.yml` | `workflow_run` on failure | Deduplicated CI failure issue (hash = workflow + first error line) |
 | `squad-heartbeat.yml` | Cron | Automated triage and CI gate via Ralph |
@@ -51,5 +52,7 @@ These workflows support repo development and the AI squad workflow. They're not 
 | `auto-label-issues.yml` | Issue opened | Adds `squad` label |
 
 Set `SQUAD_WATCH_CI=1` to opt into the local polling helper (`tools/Watch-GithubActions.ps1`) that applies the same dedup loop outside GitHub Actions.
+
+To run markdown link checks locally: `lychee --config .lychee.toml './**/*.md'`
 
 The `.squad/` directory contains AI team infrastructure for automated triage and development. It is **not** part of the tool itself and is excluded from archive downloads.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The HTML report includes an executive Summary tab, a severity-by-resource-group 
 - **Read-only everywhere.** No write permissions on any cloud. See [PERMISSIONS.md](PERMISSIONS.md) for exact scopes.
 - **HTML + Markdown reports** with executive summary, heatmap, filtering, control-framework chips, and CSV export.
 - **Manifest-driven installer.** Run with `-InstallMissingModules` to auto-install prerequisites (PSGallery modules, allow-listed package managers, HTTPS-only git clones).
+- **Markdown link CI checks** on PRs that change `.md` files, plus a weekly scheduled link-rot sweep.
 
 The full tool catalog, parameter reference, schema, scoped-run patterns, incremental-scan modes, and report internals all live in [docs/consumer/](docs/consumer/README.md). That index is the entry point for every advanced consumer page.
 

--- a/docs/consumer/continuous-control.md
+++ b/docs/consumer/continuous-control.md
@@ -710,7 +710,7 @@ Step 4.
 
 To use the Premium Elastic plan, set `planSku = 'EP1'` in your parameters file
 before deploying. The Premium plan supports full scans without the Consumption
-timeout. See [`azure-function/README.md`](../azure-function/README.md) for
+timeout. See [`azure-function/README.md`](../../azure-function/README.md) for
 details on the timeout caveat.
 
 ---
@@ -741,7 +741,7 @@ Function App after deployment.
 
 The deployer must have **Owner** or **User Access Administrator** at subscription
 scope to create the Reader role assignment. All runtime operations use
-read-only Azure APIs. See [`PERMISSIONS.md`](../PERMISSIONS.md) for the full
+read-only Azure APIs. See [`PERMISSIONS.md`](../../PERMISSIONS.md) for the full
 permissions model.
 
 ---
@@ -779,11 +779,11 @@ After completing the above steps, confirm:
 
 ## Related Documentation
 
-- [azure-function/README.md](../azure-function/README.md) -- Function App architecture overview and app settings reference
-- [docs/consumer/permissions/_continuous-control.md](../consumer/permissions/_continuous-control.md) -- full RBAC breakdown
+- [azure-function/README.md](../../azure-function/README.md) -- Function App architecture overview and app settings reference
+- [docs/consumer/permissions/_continuous-control.md](permissions/_continuous-control.md) -- full RBAC breakdown
 - [docs/sinks/log-analytics.md](sinks/log-analytics.md) -- DCR/table setup and KQL examples
 ## Bicep template reference
 
-See [`infra/continuous-control.bicep`](../infra/continuous-control.bicep) for
+See [`infra/continuous-control.bicep`](../../infra/continuous-control.bicep) for
 all parameters, resources, and outputs.
 


### PR DESCRIPTION
## Summary
- add `.github/workflows/markdown-link-check.yml` using SHA-pinned `lycheeverse/lychee-action` (v2 commit `8646ba30535128ac92d33dfc9133794bfdd9b411`)
- add root `.lychee.toml` config for markdown scans, weekly schedule, and noisy-link exclusions
- update docs (`README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`) and fix pre-existing broken markdown links found during local validation

## Design choice
Selected `lycheeverse/lychee-action` over `github-action-markdown-link-check` because lychee-action is actively maintained and provides first-class config support (`.lychee.toml`), markdown output, and GitHub job summary integration.

## Scope
- scans `**/*.md` across repo on PRs that touch markdown files only
- runs weekly (`0 6 * * 1`) to catch link rot
- ignores flaky/non-actionable categories via `.lychee.toml`: `mailto:`, localhost/loopback, http links, known flaky external domains, and JS-fragment-heavy checks (`include_fragments = false`)

## Advisory decision
This workflow is intentionally advisory for now by branch protection policy. It runs and can fail on broken links, but it is not added as a required status check. `Analyze (actions)` remains the only required check.

## Validation
- `lychee --config .lychee.toml './**/*.md'` (pass)
- `Invoke-Pester -Path .\tests -CI` (pass, 1197 passed / 0 failed / 5 skipped)

## Broken links found and fixed
Local scan initially found 12 pre-existing broken links. This PR fixed 10 broken internal links and excluded 2 intentional placeholder-example links in humanizer skill docs.

Closes #251