### PR TITLE
docs: update README tool count to match manifest (closes #235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- docs: update README tool count to 27 to match current manifest (closes #235)
+
 ### Permissions documentation split (closes #252)
 
 - **docs: split PERMISSIONS.md per-tool detail to `docs/consumer/permissions/<tool>.md`**. The root `PERMISSIONS.md` is now a 116-line summary plus a manifest-driven per-tool index (down from 867 lines); detailed permission tables, sample commands, and "what it does / does not do" prose for each tool live in dedicated pages under `docs/consumer/permissions/`. Cross-cutting topics (Continuous Control OIDC + MI, multi-tenant fan-out, MG recursion, auth troubleshooting, the cross-tool matrix) were extracted to `_*.md` companion pages in the same folder. Squad automation that hardcodes the `PERMISSIONS.md` path keeps working unchanged.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CodeQL](https://github.com/martinopedal/azure-analyzer/actions/workflows/codeql.yml/badge.svg)](https://github.com/martinopedal/azure-analyzer/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**One PowerShell command, 26 read-only Azure assessment tools, one unified HTML and Markdown report.** Cloud-first by default: target remote GitHub and Azure DevOps repositories without cloning anything by hand.
+**One PowerShell command, 27 read-only Azure assessment tools, one unified HTML and Markdown report.** Cloud-first by default: target remote GitHub and Azure DevOps repositories without cloning anything by hand.
 
 ## Install
 
@@ -63,7 +63,7 @@ The HTML report includes an executive Summary tab, a severity-by-resource-group 
 
 ## What you get
 
-- **26 tools** across Azure resources, Entra ID, GitHub, and Azure DevOps.
+- **27 tools** across Azure resources, Entra ID, GitHub, and Azure DevOps.
 - **Unified v2 schema** with 5 severity levels (Critical, High, Medium, Low, Info) and 14 entity types across 4 platforms (Azure, Entra, GitHub, ADO).
 - **Read-only everywhere.** No write permissions on any cloud. See [PERMISSIONS.md](PERMISSIONS.md) for exact scopes.
 - **HTML + Markdown reports** with executive summary, heatmap, filtering, control-framework chips, and CSV export.


### PR DESCRIPTION
## Summary
Update README.md tool count from 26 to 27 to reflect the current tool manifest entry count.

## Details
- **Old count**: 26 (shown in README lines 7 and 66)
- **New count**: 27 (verified from tools/tool-manifest.json, which now includes copilot-triage)
- **Source**: Current tools/tool-manifest.json has 27 registered tools (26 enabled + 1 disabled)
- Updated CHANGELOG.md under [Unreleased] → Fixed section

## Verification
- Pester baseline: **1213 tests pass** (vs. baseline 1208+) ✅
- No em dashes in changes ✅
- Commit has proper Co-authored-by trailer ✅

Closes #235