### PR TITLE
fix(ci): harden watchdog error extraction + close stale CI-failure fires

### DIFF
--- a/.github/workflows/ci-failure-watchdog.yml
+++ b/.github/workflows/ci-failure-watchdog.yml
@@ -2,11 +2,11 @@ name: CI failure watchdog
 
 on:
   workflow_run:
-    # The workflows: key is REQUIRED — without it GitHub never parses the
+    # The workflows: key is REQUIRED -- without it GitHub never parses the
     # trigger and creates 0-job failure runs on every push (see PR #111 + #154
     # root-cause). Each entry below MUST match the `name:` field of the watched
     # workflow exactly. The `tests/workflows/WatchdogWatchlist.Tests.ps1`
-    # Pester test enforces this — keep it green.
+    # Pester test enforces this -- keep it green.
     #
     # Inclusion criteria: every workflow whose failure on `main` or on a PR
     # would silently degrade the squad pipeline. CI / CodeQL / Docs Check
@@ -87,7 +87,14 @@ jobs:
           failed_log_raw="$(gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>&1 || true)"
           failed_log_head="$(printf '%s\n' "$failed_log_raw" | head -n 500)"
 
-          first_error_line="$(printf '%s\n' "$failed_log_head" | grep -Eim1 '(error|failed|fatal):' || true)"
+          # Prefer explicit Actions annotations first, then broader fallback patterns.
+          first_error_line="$(printf '%s\n' "$failed_log_head" | grep -Eim1 '##\[error\]|::error::' || true)"
+          if [ -z "${first_error_line}" ]; then
+            first_error_line="$(printf '%s\n' "$failed_log_head" | grep -Eim1 '(^|[^[:alpha:]])(error|failed|fatal)(:|[[:space:]])' || true)"
+          fi
+          if [ -z "${first_error_line}" ]; then
+            first_error_line="$(printf '%s\n' "$failed_log_head" | grep -Eim1 '(Exception|Traceback|exit code [1-9]|exited with code)' || true)"
+          fi
           if [ -z "${first_error_line}" ]; then
             first_error_line="No explicit error line found in failed log output."
           fi
@@ -103,7 +110,7 @@ jobs:
           short_error="$(printf '%s' "$first_error_line" | tr '\r\n' ' ' | sed -E 's/[[:space:]]+/ /g' | cut -c1-120)"
           short_error="$(sanitize_text "$short_error")"
 
-          issue_title="fix: CI failure in ${WORKFLOW_NAME} — ${short_error} [${error_hash}]"
+          issue_title="fix: CI failure in ${WORKFLOW_NAME} -- ${short_error} [${error_hash}]"
           existing_issue="$(gh issue list --repo "$REPO" --label ci-failure --state open --search "[${error_hash}] in:title" --json number --jq '.[0].number // empty' 2>/dev/null || true)"
 
           gh label create ci-failure --repo "$REPO" --color B60205 --description "Automated CI failure report" --force >/dev/null 2>&1 || true
@@ -118,7 +125,7 @@ jobs:
           body_lines+="- First error line: ${first_error_line}"
 
           if [ -n "$existing_issue" ]; then
-            gh issue comment "$existing_issue" --repo "$REPO" --body "still failing — ${RUN_URL}" || true
+            gh issue comment "$existing_issue" --repo "$REPO" --body "still failing -- ${RUN_URL}" || true
           else
             if ! gh issue create \
               --repo "$REPO" \
@@ -130,7 +137,7 @@ jobs:
               --label ci-failure; then
               existing_issue="$(gh issue list --repo "$REPO" --label ci-failure --state open --search "[${error_hash}] in:title" --json number --jq '.[0].number // empty' 2>/dev/null || true)"
               if [ -n "$existing_issue" ]; then
-                gh issue comment "$existing_issue" --repo "$REPO" --body "still failing — ${RUN_URL}" || true
+                gh issue comment "$existing_issue" --repo "$REPO" --body "still failing -- ${RUN_URL}" || true
               else
                 echo "Failed to create or reconcile ci-failure issue for hash [${error_hash}]."
                 exit 1
@@ -168,18 +175,18 @@ jobs:
           since="$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)"
           # Pull the last 50 watchdog runs and find any that completed with
           # failure but recorded zero jobs (the GitHub phantom-run signature
-          # — name falls back to file path, no job ever spun up).
+          # -- name falls back to file path, no job ever spun up).
           phantom_count="$(gh api \
             "repos/${REPO}/actions/workflows/ci-failure-watchdog.yml/runs?per_page=50&created=>${since}" \
             --jq '[.workflow_runs[] | select(.conclusion == "failure" and (.name | startswith(".github/workflows/")))] | length' \
             2>/dev/null || echo 0)"
           phantom_count="${phantom_count:-0}"
           echo "phantom_count=${phantom_count}"
-          sticky_title="chore(ci): watchdog self-health — 0-job phantom failures detected"
+          sticky_title="chore(ci): watchdog self-health -- 0-job phantom failures detected"
           existing="$(gh issue list --repo "$REPO" --label ci-failure --state open \
             --search "watchdog self-health in:title" --json number --jq '.[0].number // empty' 2>/dev/null || true)"
           if [ "${phantom_count}" -gt 0 ]; then
-            body="Watchdog detected ${phantom_count} phantom (0-job) failure run(s) in the last 7 days. This signals the bug from #111 / #154 may have regressed — verify the workflows: trigger key parses cleanly and every entry matches an actual workflow name. Run search: https://github.com/${REPO}/actions/workflows/ci-failure-watchdog.yml?query=is%3Afailure"
+            body="Watchdog detected ${phantom_count} phantom (0-job) failure run(s) in the last 7 days. This signals the bug from #111 / #154 may have regressed -- verify the workflows: trigger key parses cleanly and every entry matches an actual workflow name. Run search: https://github.com/${REPO}/actions/workflows/ci-failure-watchdog.yml?query=is%3Afailure"
             if [ -n "$existing" ]; then
               gh issue comment "$existing" --repo "$REPO" --body "Still detecting phantom runs (count=${phantom_count})." || true
             else
@@ -188,7 +195,7 @@ jobs:
             fi
           else
             if [ -n "$existing" ]; then
-              gh issue close "$existing" --repo "$REPO" --comment "No phantom runs in last 7 days — closing." || true
+              gh issue close "$existing" --repo "$REPO" --comment "No phantom runs in last 7 days -- closing." || true
             fi
           fi
 

--- a/.squad/agents/forge/history.md
+++ b/.squad/agents/forge/history.md
@@ -87,3 +87,9 @@ Stored these in `tools/install-manifest.json` with `pinningNote` field per platf
 - Importing a `.psd1` should not dot-source script entry points that execute immediately. For `AzureAnalyzer.psm1`, export wrapper functions that invoke root scripts on demand, and limit import-time dot-sourcing to pure helper modules.
 - PSGallery readiness is manifest-driven: replace placeholder GUIDs before publication and populate `PrivateData.PSData` with `Tags`, `ProjectUri`, `LicenseUri`, and `ReleaseNotes` so the package page is navigable and discoverable.
 
+### 2026-04-20T15:18:09Z: CI-failure batch #260/#261/#262/#264
+
+- Triage complete: all four issues were categorized stale or transient and closed with rationale comments.
+- Root failure pattern observed: watchdog did not capture GitHub annotation lines (`##[error]`) from failed logs.
+- Hardening applied in `.github/workflows/ci-failure-watchdog.yml` to extract actionable first error lines using annotation-first matching and broader fallback patterns.
+- Validation: `Invoke-Pester -Path .\tests -CI` passed (1213 passed, 0 failed, 5 skipped).

--- a/.squad/decisions/inbox/forge-ci-failure-batch-2026-04-20T15-18-09Z.md
+++ b/.squad/decisions/inbox/forge-ci-failure-batch-2026-04-20T15-18-09Z.md
@@ -1,0 +1,19 @@
+# Forge CI failure batch triage (2026-04-20T15:18:09Z)
+
+## Scope
+Issues: #260, #261, #262, #264 (label: ci-failure, priority:p1)
+
+## Triage matrix
+
+| Issue | Workflow | Run URL | Verdict | Reasoning | Action |
+| --- | --- | --- | --- | --- | --- |
+| #260 | Docs Check | https://github.com/martinopedal/azure-analyzer/actions/runs/24672985957 | STALE (duplicate) | Exact duplicate hash of #245 ([263533c1752a]); root failure was transient actions/github-script archive fetch. Superseded by PR #256 and newer runs are green. | Closed issue as completed with superseded note. |
+| #261 | Sync Squad Labels | https://github.com/martinopedal/azure-analyzer/actions/runs/24673112802 | STALE/FLAKE | Referenced run currently concludes success and recent failures list is empty. No reproducible failure on current main. | Closed issue as completed (transient/stale). |
+| #262 | Squad Heartbeat (Ralph) | https://github.com/martinopedal/azure-analyzer/actions/runs/24673121654 | FLAKE | Failed log shows transient GitHub action fetch error for actions/github-script tarball; subsequent runs on newer SHAs are green. | Closed issue as completed (transient). |
+| #264 | Copilot Agent PR Review | https://github.com/martinopedal/azure-analyzer/actions/runs/24673239978 | STALE/FLAKE | Referenced run currently concludes success and recent failures list is empty. No current regression on main. | Closed issue as completed (transient/stale). |
+
+## Follow-up hardening
+
+- Improved `.github/workflows/ci-failure-watchdog.yml` error-line extraction to prioritize `##[error]` and `::error::`, then fallback patterns (`error/failed/fatal`, exceptions, and exit-code text).
+- Updated `CHANGELOG.md` Unreleased section with the watchdog extraction fix.
+- Validation: `Invoke-Pester -Path .\tests -CI` passed (1213 passed, 0 failed, 5 skipped).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to azure-analyzer will be documented here.
 ### Fixed
 
 - docs: update README tool count to 27 to match current manifest (closes #235)
+- ci: improved CI failure watchdog error extraction to prioritize GitHub Actions annotations (`##[error]`, `::error::`) and fall back to broader exception/exit-code patterns so ci-failure issues include actionable first error lines.
 
 ### Permissions documentation split (closes #252)
 


### PR DESCRIPTION
## Summary
- Triaged CI-failure issues #260, #261, #262, and #264 at run level.
- Closed all 4 as stale/transient after validating current workflow health on main.
- Hardened CI failure watchdog first-error extraction so issues capture actionable log lines.

## Triage matrix
| Issue | Workflow | Verdict | Reasoning |
| --- | --- | --- | --- |
| #260 | Docs Check | STALE (duplicate) | Duplicate of #245 hash [263533c1752a]; superseded by PR #256 and newer runs are green. |
| #261 | Sync Squad Labels | STALE/FLAKE | Referenced run now concludes success; no recent failures on main. |
| #262 | Squad Heartbeat (Ralph) | FLAKE | Failed log shows transient actions/github-script download error; newer runs are green. |
| #264 | Copilot Agent PR Review | STALE/FLAKE | Referenced run now concludes success; no recent failures on main. |

## Root causes found
- Primary recurring pattern was transient GitHub action-archive fetch errors in failed job setup.
- Watchdog heuristic missed explicit `##[error]...` annotations, producing "No explicit error line found".

## Fixes in this PR
- `.github/workflows/ci-failure-watchdog.yml`
  - Prefer `##[error]` and `::error::` annotation lines first.
  - Fallback to broader `error/failed/fatal`, exception, and exit-code patterns.
- `CHANGELOG.md`
  - Added Unreleased entry for watchdog extraction hardening.
- Recorded outcomes in `.squad/decisions/inbox/forge-ci-failure-batch-2026-04-20T15-18-09Z.md` and appended Forge history.

## Validation
- `Invoke-Pester -Path .\\tests -CI` -> 1213 passed, 0 failed, 5 skipped
- `Invoke-Pester -Path .\\tests\\workflows -CI` -> 102 passed, 0 failed

Refs #260
Refs #261
Refs #262
Refs #264