### PR TITLE
fix(ci): prevent docs-check re-fires + add watchdog hash dedupe (closes #266)

### DIFF
--- a/.github/workflows/ci-failure-watchdog.yml
+++ b/.github/workflows/ci-failure-watchdog.yml
@@ -111,7 +111,9 @@ jobs:
           short_error="$(sanitize_text "$short_error")"
 
           issue_title="fix: CI failure in ${WORKFLOW_NAME} -- ${short_error} [${error_hash}]"
-          existing_issue="$(gh issue list --repo "$REPO" --label ci-failure --state open --search "[${error_hash}] in:title" --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          existing_issue_records="$(gh issue list --repo "$REPO" --label ci-failure --state all --search "[${error_hash}] in:title" --limit 100 --json number,state,createdAt 2>/dev/null || echo '[]')"
+          existing_issue="$(printf '%s' "$existing_issue_records" | jq -r '([.[] | select(.state == "OPEN")] | sort_by(.createdAt) | .[0]) // (sort_by(.createdAt) | .[0]) | .number // empty')"
+          existing_issue_state="$(printf '%s' "$existing_issue_records" | jq -r '([.[] | select(.state == "OPEN")] | sort_by(.createdAt) | .[0]) // (sort_by(.createdAt) | .[0]) | .state // empty')"
 
           gh label create ci-failure --repo "$REPO" --color B60205 --description "Automated CI failure report" --force >/dev/null 2>&1 || true
 
@@ -125,7 +127,11 @@ jobs:
           body_lines+="- First error line: ${first_error_line}"
 
           if [ -n "$existing_issue" ]; then
-            gh issue comment "$existing_issue" --repo "$REPO" --body "still failing -- ${RUN_URL}" || true
+            if [ "$existing_issue_state" = "CLOSED" ]; then
+              gh issue comment "$existing_issue" --repo "$REPO" --body "still failing -- ${RUN_URL} (existing closed issue reused for hash [${error_hash}]; no new duplicate opened)" || true
+            else
+              gh issue comment "$existing_issue" --repo "$REPO" --body "still failing -- ${RUN_URL}" || true
+            fi
           else
             if ! gh issue create \
               --repo "$REPO" \
@@ -135,9 +141,15 @@ jobs:
               --label type:bug \
               --label priority:p1 \
               --label ci-failure; then
-              existing_issue="$(gh issue list --repo "$REPO" --label ci-failure --state open --search "[${error_hash}] in:title" --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+              existing_issue_records="$(gh issue list --repo "$REPO" --label ci-failure --state all --search "[${error_hash}] in:title" --limit 100 --json number,state,createdAt 2>/dev/null || echo '[]')"
+              existing_issue="$(printf '%s' "$existing_issue_records" | jq -r '([.[] | select(.state == "OPEN")] | sort_by(.createdAt) | .[0]) // (sort_by(.createdAt) | .[0]) | .number // empty')"
+              existing_issue_state="$(printf '%s' "$existing_issue_records" | jq -r '([.[] | select(.state == "OPEN")] | sort_by(.createdAt) | .[0]) // (sort_by(.createdAt) | .[0]) | .state // empty')"
               if [ -n "$existing_issue" ]; then
-                gh issue comment "$existing_issue" --repo "$REPO" --body "still failing -- ${RUN_URL}" || true
+                if [ "$existing_issue_state" = "CLOSED" ]; then
+                  gh issue comment "$existing_issue" --repo "$REPO" --body "still failing -- ${RUN_URL} (existing closed issue reused for hash [${error_hash}]; no new duplicate opened)" || true
+                else
+                  gh issue comment "$existing_issue" --repo "$REPO" --body "still failing -- ${RUN_URL}" || true
+                fi
               else
                 echo "Failed to create or reconcile ci-failure issue for hash [${error_hash}]."
                 exit 1

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -27,7 +27,7 @@ jobs:
               return;
             }
             const prTitle = context.payload.pull_request.title || '';
-            const stackedPrMatch = prTitle.match(/\(PR-(\d+)\s+of\s+(\d+)\)/i);
+            const stackedPrMatch = prTitle.match(/\(pr\s*[-:]?\s*(\d+)\s+of\s+(\d+)\)/i);
             if (stackedPrMatch) {
               const currentPart = Number.parseInt(stackedPrMatch[1], 10);
               const totalParts = Number.parseInt(stackedPrMatch[2], 10);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to azure-analyzer will be documented here.
 
 - docs: update README tool count to 27 to match current manifest (closes #235)
 - ci: improved CI failure watchdog error extraction to prioritize GitHub Actions annotations (`##[error]`, `::error::`) and fall back to broader exception/exit-code patterns so ci-failure issues include actionable first error lines.
+- fix(ci): prevent docs-check from re-firing + watchdog hash dedupe (closes #266)
 
 ### Permissions documentation split (closes #252)
 


### PR DESCRIPTION
## Summary
Fix recurring Docs Check watchdog noise for hash `263533c1752a` and harden stacked PR title detection.

## Root-cause investigation
| Root cause | Evidence | Fix | Validation plan |
| --- | --- | --- | --- |
| Watchdog dedupe only searched open ci-failure issues, so closed duplicates (#245, #260) were ignored and #266 was re-opened with same hash. | `.github/workflows/ci-failure-watchdog.yml` used `gh issue list --state open`; issue history shows #245/#260 closed and #266 opened with same hash/title. | Search `--state all`, prefer an open issue when present, otherwise reuse oldest closed issue and comment instead of creating a new issue. | Run hash search query for `[263533c1752a]` across all states and verify selected canonical issue behavior. |
| Stacked PR skip matcher in docs check only handled strict `(PR-x of y)` formatting. | Regex was `/\(PR-(\d+)\s+of\s+(\d+)\)/i`. | Broaden matcher to accept `PR-4`, `PR 4`, and `PR:4` forms, case-insensitive. | Title pattern match exercised by workflow logic and existing `(PR-4 of 5)` format remains covered. |
| Run 24674548710 attempt #1 failure was transient action-download setup failure, not missing docs. | `gh run view 24674548710 --attempt 1 --log-failed` shows `An action could not be found ... actions/github-script ...` then rerun attempt #2 succeeded. | No docs-check rule change needed for this failure mode; watchdog dedupe now prevents repeated duplicate issue churn on identical hash. | Monitor next watchdog trigger for same hash; it should comment existing issue instead of opening another. |

## What changed
- `.github/workflows/ci-failure-watchdog.yml`
  - Dedupes by hash across **open + closed** ci-failure issues.
  - Chooses canonical issue: first open by oldest createdAt, else oldest closed.
  - Comments canonical issue (including closed canonical issue) and skips new issue creation.
- `.github/workflows/docs-check.yml`
  - Broadened stacked-PR regex: `\(pr\s*[-:]?\s*(\d+)\s+of\s+(\d+)\)`.
- `CHANGELOG.md`
  - Added Unreleased fixed entry: `fix(ci): prevent docs-check from re-firing + watchdog hash dedupe (closes #266)`.

## Validation
- `gh run view 24674548710 --attempt 1 --log-failed`
- `gh run view 24674548710 --json databaseId,displayTitle,event,headBranch,headSha,name,number,status,conclusion,workflowName,createdAt,updatedAt,url,jobs`
- `gh run list --workflow="Docs Check" --status=failure --limit 20 --json conclusion,headBranch,event,displayTitle,createdAt`
- Dedupe simulation query over all states found existing hash matches and canonical selection.
- `Invoke-Pester -Path .\tests -CI` (pass; discovery shows 1218 tests).

## Related issue history
- #245 (first occurrence)
- #260 (stale duplicate)
- #266 (this fix)