### PR TITLE
feat: add explicit -KubeconfigPath / -KubeContext / -Namespace params to K8s wrappers + orchestrator (closes #240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **K8s wrappers + orchestrator: explicit `-KubeconfigPath`, `-KubeContext`, and per-tool namespace params (closes #240).**
+  Adds `-KubeconfigPath`, `-KubeContext`, `-KubescapeNamespace`, `-FalcoNamespace`, `-KubeBenchNamespace` to `Invoke-AzureAnalyzer.ps1` (top-level) and `-KubeconfigPath`, `-KubeContext`, `-Namespace` to `Invoke-Kubescape.ps1`, `Invoke-Falco.ps1`, and `Invoke-KubeBench.ps1`. When a kubeconfig path is provided the wrappers skip Azure Resource Graph discovery and `az aks get-credentials`, scanning a single cluster reachable via the supplied kubeconfig (kubeconfig mode). Default behavior is unchanged: with no new params supplied, every wrapper continues to discover AKS managed clusters via ARG and fetch per-cluster credentials. Validation rejects URL-style values and missing files at the wrapper boundary with sanitized errors. Per-wrapper namespace defaults: kubescape `''` (all namespaces), falco `'falco'`, kube-bench `'kube-system'`. Tests: `tests/wrappers/Invoke-Kubescape.Tests.ps1`, `tests/wrappers/Invoke-Falco.Tests.ps1`, `tests/wrappers/Invoke-KubeBench.Tests.ps1`, `tests/orchestrator/AzureAnalyzer-K8sParams.Tests.ps1`, fixture `tests/fixtures/kubeconfig-mock.yaml`. Phase 1 of parent issue #236; clears the way for #241/#242 (additional K8s auth modes).
+
 ### Fixed
 
 - docs: update README tool count to 27 to match current manifest (closes #235)

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -124,6 +124,11 @@ param (
     [switch] $UninstallFalco,
     [ValidateRange(1, 60)]
     [int] $FalcoCaptureMinutes = 5,
+    [string] $KubeconfigPath,
+    [string] $KubeContext,
+    [string] $KubescapeNamespace = '',
+    [string] $FalcoNamespace = 'falco',
+    [string] $KubeBenchNamespace = 'kube-system',
     [string] $SentinelWorkspaceId,
     [ValidateRange(1, 365)]
     [int] $SentinelLookbackDays = 30,
@@ -656,6 +661,19 @@ foreach ($toolDef in $manifest.tools) {
                     if ($InstallFalco)  { $params['InstallFalco'] = $true }
                     if ($UninstallFalco) { $params['UninstallFalco'] = $true }
                     $params['CaptureMinutes'] = $FalcoCaptureMinutes
+                    if ($PSBoundParameters.ContainsKey('KubeconfigPath')) { $params['KubeconfigPath'] = $KubeconfigPath }
+                    if ($PSBoundParameters.ContainsKey('KubeContext'))    { $params['KubeContext']    = $KubeContext }
+                    if ($PSBoundParameters.ContainsKey('FalcoNamespace')) { $params['Namespace']      = $FalcoNamespace }
+                }
+                if ($toolDef.name -eq 'kubescape') {
+                    if ($PSBoundParameters.ContainsKey('KubeconfigPath'))      { $params['KubeconfigPath'] = $KubeconfigPath }
+                    if ($PSBoundParameters.ContainsKey('KubeContext'))         { $params['KubeContext']    = $KubeContext }
+                    if ($PSBoundParameters.ContainsKey('KubescapeNamespace'))  { $params['Namespace']      = $KubescapeNamespace }
+                }
+                if ($toolDef.name -eq 'kube-bench') {
+                    if ($PSBoundParameters.ContainsKey('KubeconfigPath'))     { $params['KubeconfigPath'] = $KubeconfigPath }
+                    if ($PSBoundParameters.ContainsKey('KubeContext'))        { $params['KubeContext']    = $KubeContext }
+                    if ($PSBoundParameters.ContainsKey('KubeBenchNamespace')) { $params['Namespace']      = $KubeBenchNamespace }
                 }
                 $specName = "$($toolDef.name)|$subId"
                 $toolSpecs.Add([PSCustomObject]@{

--- a/docs/consumer/README.md
+++ b/docs/consumer/README.md
@@ -7,4 +7,5 @@ All advanced consumer docs live here. The root `README.md` is your starting poin
 - [continuous-control.md](continuous-control.md) - Continuous control monitoring patterns and integration guidance.
 - [ai-triage.md](ai-triage.md) - AI-assisted finding triage workflow and prompt design.
 - [gitleaks-pattern-tuning.md](gitleaks-pattern-tuning.md) - Tuning gitleaks rule patterns to cut false positives.
+- [k8s-auth.md](k8s-auth.md) - Targeting Kubernetes wrappers (kubescape, falco, kube-bench) with explicit `-KubeconfigPath` / `-KubeContext` / per-tool namespace params.
 - [sinks/log-analytics.md](sinks/log-analytics.md) - Streaming azure-analyzer findings into Azure Log Analytics.

--- a/docs/consumer/k8s-auth.md
+++ b/docs/consumer/k8s-auth.md
@@ -1,0 +1,98 @@
+# Kubernetes auth modes for kubescape, falco, and kube-bench
+
+azure-analyzer's three Kubernetes-targeted wrappers accept explicit kubeconfig parameters
+so you can scan clusters that are not AKS managed clusters discovered via Azure Resource
+Graph (ARG), or scan a specific AKS cluster without going through `az aks get-credentials`.
+
+This is phase 1 of issue [#236](https://github.com/martinopedal/azure-analyzer/issues/236).
+Closes [#240](https://github.com/martinopedal/azure-analyzer/issues/240).
+
+## TL;DR
+
+```powershell
+# Default (AKS discovery via ARG, fetch credentials per cluster) - unchanged.
+.\Invoke-AzureAnalyzer.ps1 -SubscriptionId <sub>
+
+# Scan a single cluster via an existing kubeconfig (BYO cluster).
+.\Invoke-AzureAnalyzer.ps1 -SubscriptionId <sub> `
+    -KubeconfigPath C:\Users\me\.kube\config `
+    -KubeContext my-prod-aks `
+    -KubescapeNamespace prod `
+    -FalcoNamespace falco-prod `
+    -KubeBenchNamespace kube-system
+```
+
+## Top-level orchestrator parameters (Invoke-AzureAnalyzer.ps1)
+
+| Parameter | Default | Forwarded to | Notes |
+|---|---|---|---|
+| `-KubeconfigPath` | (unset) | kubescape, falco, kube-bench | Local file path; URLs rejected. Falls back to `$env:KUBECONFIG` then `~/.kube/config` when only `-KubeContext` is supplied. |
+| `-KubeContext`    | (unset) | kubescape, falco, kube-bench | Passed to wrapper CLIs as `--kube-context` / `--context`. |
+| `-KubescapeNamespace` | `''` (all namespaces) | kubescape `-Namespace` | Empty means scan all namespaces (default kubescape behavior). |
+| `-FalcoNamespace`     | `falco`               | falco `-Namespace`     | Helm release namespace + `kubectl logs` namespace in install mode. |
+| `-KubeBenchNamespace` | `kube-system`         | kube-bench `-Namespace` | Namespace where the temporary kube-bench Job is created. |
+
+## Per-wrapper parameters
+
+Each wrapper accepts the same generic surface so the orchestrator can fan them out cleanly.
+
+### Invoke-Kubescape.ps1
+
+```powershell
+.\modules\Invoke-Kubescape.ps1 -SubscriptionId <sub> `
+    -KubeconfigPath C:\path\to\kubeconfig `
+    -KubeContext my-cluster `
+    -Namespace ''         # default: scan all namespaces
+```
+
+Kubeconfig mode short-circuits the ARG discovery + `az aks get-credentials` flow and
+runs a single `kubescape scan --kube-context <ctx> [--include-namespaces <ns>]` against
+the supplied kubeconfig.
+
+### Invoke-Falco.ps1
+
+```powershell
+.\modules\Invoke-Falco.ps1 -SubscriptionId <sub> -InstallFalco `
+    -KubeconfigPath C:\path\to\kubeconfig `
+    -KubeContext my-cluster `
+    -Namespace falco      # default
+```
+
+Kubeconfig mode applies only to `-InstallFalco` (the cluster-touching path).
+Query mode reads Falco-related Microsoft.Security alerts from Azure ARG and is
+unaffected by `-KubeconfigPath`.
+
+### Invoke-KubeBench.ps1
+
+```powershell
+.\modules\Invoke-KubeBench.ps1 -SubscriptionId <sub> `
+    -KubeconfigPath C:\path\to\kubeconfig `
+    -KubeContext my-cluster `
+    -Namespace kube-system   # default; the kube-bench Job lands here
+```
+
+## Validation
+
+`-KubeconfigPath` is validated at the wrapper boundary:
+
+- Empty value -> rejected.
+- URL-style values (`https://...`, `s3://...`) -> rejected (no remote fetch).
+- File does not exist -> rejected.
+
+Error messages are sanitized through `Remove-Credentials` before they reach logs or
+the v1 envelope.
+
+## Backward compatibility
+
+All new parameters are optional with safe defaults. Existing call sites that do
+not pass any of them keep their pre-#240 behavior: AKS discovery via ARG, per-cluster
+isolated kubeconfig via `az aks get-credentials`, namespace defaults preserved
+(`falco`, `kube-system`, all-namespaces for kubescape). User-supplied kubeconfig
+files are never deleted by cleanup logic.
+
+## What's coming
+
+- [#241](https://github.com/martinopedal/azure-analyzer/issues/241) and
+  [#242](https://github.com/martinopedal/azure-analyzer/issues/242) build on this
+  param surface to add additional Kubernetes auth modes (token / service-account /
+  in-cluster). The param shape introduced here is intended to be forward-compatible.

--- a/docs/consumer/permissions/falco.md
+++ b/docs/consumer/permissions/falco.md
@@ -14,7 +14,11 @@
 ## Local CLI requirements
 
 - Query mode: none beyond `az` for subscription auth.
-- Install mode: `helm`, `kubectl`, `az`.
+- Install mode: `helm`, `kubectl`. `az` is required only when `-KubeconfigPath` is **not** supplied (otherwise AKS discovery and `az aks get-credentials` are skipped).
+
+## Auth context
+
+`-KubeconfigPath` (orchestrator or wrapper) controls which cluster Falco install mode targets. Query mode is unaffected by `-KubeconfigPath` because it reads Azure-side alerts, not cluster state. The Helm release namespace and `kubectl logs` namespace come from `-Namespace` (default `falco`). See [`docs/consumer/k8s-auth.md`](../k8s-auth.md).
 
 ## What it does with these permissions
 

--- a/docs/consumer/permissions/kube-bench.md
+++ b/docs/consumer/permissions/kube-bench.md
@@ -13,7 +13,11 @@
 
 ## Local CLI requirements
 
-`kubectl` and `az` must be on PATH.
+`kubectl` must be on PATH. `az` is required only when `-KubeconfigPath` is **not** supplied (otherwise AKS discovery and `az aks get-credentials` are skipped).
+
+## Auth context
+
+`-KubeconfigPath` controls which cluster the temporary kube-bench Job lands in. `-Namespace` selects the Job namespace (default `kube-system`). See [`docs/consumer/k8s-auth.md`](../k8s-auth.md).
 
 ## What it does with these permissions
 

--- a/docs/consumer/permissions/kubescape.md
+++ b/docs/consumer/permissions/kubescape.md
@@ -13,7 +13,11 @@
 
 ## Local CLI requirements
 
-`kubescape`, `kubectl`, and `az` must be on PATH. Missing CLIs cause the tool to skip with an install instruction.
+`kubescape`, `kubectl`, and `az` must be on PATH. Missing CLIs cause the tool to skip with an install instruction. When `-KubeconfigPath` is supplied (BYO cluster mode), `az` is not required.
+
+## Auth context
+
+`-KubeconfigPath` (passed via the orchestrator or directly to the wrapper) controls which cluster kubescape scans. When supplied, AKS discovery via ARG and `az aks get-credentials` are skipped and the wrapper runs a single scan against the cluster reachable via that kubeconfig (optionally filtered by `-KubeContext` and `-Namespace`). See [`docs/consumer/k8s-auth.md`](../k8s-auth.md).
 
 ## What it does with these permissions
 

--- a/modules/Invoke-Falco.ps1
+++ b/modules/Invoke-Falco.ps1
@@ -21,6 +21,21 @@
 
 .PARAMETER UninstallFalco
     In install mode, uninstall the Falco Helm release after collection.
+
+.PARAMETER KubeconfigPath
+    Optional path to an existing kubeconfig file. In install mode this
+    skips Azure Resource Graph discovery and `az aks get-credentials`,
+    and targets the cluster reachable via this kubeconfig. Ignored in
+    query mode (query mode reads Azure-side alerts, not cluster state).
+    The file MUST exist when set explicitly; URLs are rejected.
+
+.PARAMETER KubeContext
+    Optional kubeconfig context name passed to `helm` and `kubectl`
+    via `--kube-context` / `--context` in install mode.
+
+.PARAMETER Namespace
+    Namespace used in install mode for the Falco Helm release and the
+    `kubectl logs daemonset/falco` collection. Default 'falco'.
 #>
 [CmdletBinding()]
 param (
@@ -28,7 +43,10 @@ param (
     [string[]] $ClusterArmIds,
     [switch] $InstallFalco,
     [switch] $UninstallFalco,
-    [ValidateRange(1, 60)] [int] $CaptureMinutes = 5
+    [ValidateRange(1, 60)] [int] $CaptureMinutes = 5,
+    [string] $KubeconfigPath,
+    [string] $KubeContext,
+    [string] $Namespace = 'falco'
 )
 
 Set-StrictMode -Version Latest
@@ -56,23 +74,61 @@ $result = [ordered]@{
     Timestamp     = (Get-Date).ToUniversalTime().ToString('o')
 }
 
-if (-not (Get-Module -ListAvailable -Name Az.ResourceGraph)) {
-    $result.Status  = 'Skipped'
-    $result.Message = 'Az.ResourceGraph module not installed; cannot discover AKS clusters or query alerts.'
-    return [pscustomobject]$result
+# Validate -KubeconfigPath up front (applies to install mode; in query mode the
+# file is not used but we still reject obviously broken values to keep the
+# param contract consistent across wrappers).
+$kubeconfigModeRequested = $PSBoundParameters.ContainsKey('KubeconfigPath') -or `
+                           $PSBoundParameters.ContainsKey('KubeContext')
+$resolvedKubeconfig = $null
+if ($PSBoundParameters.ContainsKey('KubeconfigPath')) {
+    if ([string]::IsNullOrWhiteSpace($KubeconfigPath)) {
+        throw "Invalid -KubeconfigPath: value is empty."
+    }
+    if ($KubeconfigPath -match '^[a-z][a-z0-9+.-]*://') {
+        throw "Invalid -KubeconfigPath '$(Remove-Credentials -Text $KubeconfigPath)': URLs are not accepted; provide a local file path."
+    }
+    if (-not (Test-Path -LiteralPath $KubeconfigPath -PathType Leaf)) {
+        throw "Invalid -KubeconfigPath '$(Remove-Credentials -Text $KubeconfigPath)': file does not exist."
+    }
+    $resolvedKubeconfig = (Resolve-Path -LiteralPath $KubeconfigPath).ProviderPath
+} elseif ($kubeconfigModeRequested) {
+    $candidate = if ($env:KUBECONFIG) { $env:KUBECONFIG } else { Join-Path $HOME '.kube' 'config' }
+    if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+        throw "Invalid kubeconfig: -KubeContext was supplied but no kubeconfig found at '$(Remove-Credentials -Text $candidate)'. Set -KubeconfigPath or `$env:KUBECONFIG."
+    }
+    $resolvedKubeconfig = (Resolve-Path -LiteralPath $candidate).ProviderPath
 }
-Import-Module Az.ResourceGraph -ErrorAction SilentlyContinue
 
-try {
-    $null = Get-AzContext -ErrorAction Stop
-} catch {
-    $result.Status  = 'Skipped'
-    $result.Message = 'Not signed in. Run Connect-AzAccount first.'
-    return [pscustomobject]$result
+$installKubeconfigMode = $InstallFalco -and $kubeconfigModeRequested
+
+if (-not $installKubeconfigMode) {
+    if (-not (Get-Module -ListAvailable -Name Az.ResourceGraph)) {
+        $result.Status  = 'Skipped'
+        $result.Message = 'Az.ResourceGraph module not installed; cannot discover AKS clusters or query alerts.'
+        return [pscustomobject]$result
+    }
+    Import-Module Az.ResourceGraph -ErrorAction SilentlyContinue
+
+    try {
+        $null = Get-AzContext -ErrorAction Stop
+    } catch {
+        $result.Status  = 'Skipped'
+        $result.Message = 'Not signed in. Run Connect-AzAccount first.'
+        return [pscustomobject]$result
+    }
 }
 
 $clusters = @()
-if ($ClusterArmIds -and $ClusterArmIds.Count -gt 0) {
+if ($installKubeconfigMode) {
+    $synthName = if ($KubeContext) { $KubeContext } else { 'kubeconfig-default' }
+    $clusters += [pscustomobject]@{
+        id              = "kubeconfig:$synthName"
+        resourceGroup   = ''
+        name            = $synthName
+        kubeconfigPath  = $resolvedKubeconfig
+        kubeContext     = $KubeContext
+    }
+} elseif ($ClusterArmIds -and $ClusterArmIds.Count -gt 0) {
     foreach ($id in $ClusterArmIds) {
         $rg   = if ($id -match '/resourceGroups/([^/]+)') { $Matches[1] } else { '' }
         $name = Split-Path $id -Leaf
@@ -214,9 +270,9 @@ if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
     $result.Message = 'Install mode requested but kubectl is not installed.'
     return [pscustomobject]$result
 }
-if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+if (-not $installKubeconfigMode -and -not (Get-Command az -ErrorAction SilentlyContinue)) {
     $result.Status = 'Skipped'
-    $result.Message = 'Install mode requested but az CLI is not installed.'
+    $result.Message = 'Install mode requested but az CLI is not installed (skip by passing -KubeconfigPath).'
     return [pscustomobject]$result
 }
 
@@ -224,27 +280,49 @@ $captureMinutes = $CaptureMinutes
 $scanned = 0
 $failed = 0
 foreach ($cluster in $clusters) {
-    # Defense-in-depth: reject resources whose names contain shell metacharacters.
-    if ($cluster.resourceGroup -notmatch '^[A-Za-z0-9._()-]{1,90}$' -or
-        $cluster.name          -notmatch '^[A-Za-z0-9-]{1,63}$') {
-        Write-Warning "Skipping cluster with unsafe name/resourceGroup: $($cluster.name) in $($cluster.resourceGroup)"
-        $failed++
-        continue
+    $isKubeconfigMode = $false
+    if ($cluster.PSObject.Properties['kubeconfigPath'] -and $cluster.kubeconfigPath) {
+        $isKubeconfigMode = $true
     }
-    $ctx = "falco-$($cluster.name)-$([guid]::NewGuid().ToString('N').Substring(0,8))"
-    $tmpKubeconfig = Join-Path ([System.IO.Path]::GetTempPath()) "kubeconfig-$ctx.yaml"
+
+    if (-not $isKubeconfigMode) {
+        # Defense-in-depth: reject resources whose names contain shell metacharacters.
+        if ($cluster.resourceGroup -notmatch '^[A-Za-z0-9._()-]{1,90}$' -or
+            $cluster.name          -notmatch '^[A-Za-z0-9-]{1,63}$') {
+            Write-Warning "Skipping cluster with unsafe name/resourceGroup: $($cluster.name) in $($cluster.resourceGroup)"
+            $failed++
+            continue
+        }
+    }
+
+    if ($isKubeconfigMode) {
+        $tmpKubeconfig = $cluster.kubeconfigPath
+        $ctx           = $cluster.kubeContext
+    } else {
+        $ctx = "falco-$($cluster.name)-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        $tmpKubeconfig = Join-Path ([System.IO.Path]::GetTempPath()) "kubeconfig-$ctx.yaml"
+    }
     try {
-        & az aks get-credentials --subscription $SubscriptionId --resource-group $cluster.resourceGroup --name $cluster.name --file $tmpKubeconfig --context $ctx --overwrite-existing --only-show-errors 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) { $failed++; continue }
+        if (-not $isKubeconfigMode) {
+            & az aks get-credentials --subscription $SubscriptionId --resource-group $cluster.resourceGroup --name $cluster.name --file $tmpKubeconfig --context $ctx --overwrite-existing --only-show-errors 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) { $failed++; continue }
+        }
 
         $env:KUBECONFIG = $tmpKubeconfig
         & helm repo add falcosecurity https://falcosecurity.github.io/charts 2>&1 | Out-Null
         & helm repo update 2>&1 | Out-Null
-        & helm upgrade --install falco falcosecurity/falco --namespace falco --create-namespace --wait --timeout 5m 2>&1 | Out-Null
+        $helmArgs = @('upgrade', '--install', 'falco', 'falcosecurity/falco',
+                      '--namespace', $Namespace, '--create-namespace',
+                      '--wait', '--timeout', '5m')
+        if ($ctx) { $helmArgs += @('--kube-context', $ctx) }
+        & helm @helmArgs 2>&1 | Out-Null
         if ($LASTEXITCODE -ne 0) { $failed++; continue }
 
         Start-Sleep -Seconds ($captureMinutes * 60)
-        $rawLogs = @(& kubectl --context $ctx -n falco logs daemonset/falco --since "$($captureMinutes)m" --tail 5000 2>&1)
+        $logArgs = @()
+        if ($ctx) { $logArgs += @('--context', $ctx) }
+        $logArgs += @('-n', $Namespace, 'logs', 'daemonset/falco', '--since', "$($captureMinutes)m", '--tail', '5000')
+        $rawLogs = @(& kubectl @logArgs 2>&1)
         if ($LASTEXITCODE -ne 0) {
             $failed++
             Write-Warning "Falco log collection failed for cluster $($cluster.name): $(Remove-Credentials -Text ([string]($rawLogs -join ' ')))"
@@ -278,7 +356,9 @@ foreach ($cluster in $clusters) {
         }
 
         if ($UninstallFalco) {
-            & helm uninstall falco -n falco 2>&1 | Out-Null
+            $uninstallArgs = @('uninstall', 'falco', '-n', $Namespace)
+            if ($ctx) { $uninstallArgs += @('--kube-context', $ctx) }
+            & helm @uninstallArgs 2>&1 | Out-Null
         }
         $scanned++
     } catch {
@@ -286,7 +366,7 @@ foreach ($cluster in $clusters) {
         Write-Warning "Falco install mode failed for cluster $($cluster.name): $(Remove-Credentials -Text ([string]$_.Exception.Message))"
     } finally {
         if ($env:KUBECONFIG) { Remove-Item Env:\KUBECONFIG -ErrorAction SilentlyContinue }
-        if (Test-Path $tmpKubeconfig) {
+        if (-not $isKubeconfigMode -and $tmpKubeconfig -and (Test-Path $tmpKubeconfig)) {
             try { Remove-Item $tmpKubeconfig -Force -ErrorAction SilentlyContinue } catch {}
         }
     }

--- a/modules/Invoke-KubeBench.ps1
+++ b/modules/Invoke-KubeBench.ps1
@@ -130,12 +130,6 @@ $result = [ordered]@{
     Timestamp     = (Get-Date).ToUniversalTime().ToString('o')
 }
 
-if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
-    $result.Status  = 'Skipped'
-    $result.Message = 'kubectl not installed. kube-bench runtime job requires kubectl to access AKS.'
-    return [pscustomobject]$result
-}
-
 $kubeconfigModeRequested = $PSBoundParameters.ContainsKey('KubeconfigPath') -or `
                            $PSBoundParameters.ContainsKey('KubeContext')
 $resolvedKubeconfig = $null
@@ -156,6 +150,12 @@ if ($PSBoundParameters.ContainsKey('KubeconfigPath')) {
         throw "Invalid kubeconfig: -KubeContext was supplied but no kubeconfig found at '$(Remove-Credentials -Text $candidate)'. Set -KubeconfigPath or `$env:KUBECONFIG."
     }
     $resolvedKubeconfig = (Resolve-Path -LiteralPath $candidate).ProviderPath
+}
+
+if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+    $result.Status  = 'Skipped'
+    $result.Message = 'kubectl not installed. kube-bench runtime job requires kubectl to access AKS.'
+    return [pscustomobject]$result
 }
 
 if (-not $kubeconfigModeRequested -and -not (Get-Command az -ErrorAction SilentlyContinue)) {

--- a/modules/Invoke-KubeBench.ps1
+++ b/modules/Invoke-KubeBench.ps1
@@ -10,6 +10,19 @@
     checks to v1 findings that fold onto the AKS cluster ARM resource ID.
 
     Job resources and temporary kubeconfig/manifest files are always cleaned up.
+
+.PARAMETER KubeconfigPath
+    Optional path to an existing kubeconfig file. When provided, skips
+    Azure Resource Graph discovery and `az aks get-credentials`, and
+    runs a single kube-bench Job against the cluster reachable via this
+    kubeconfig. The file MUST exist when set explicitly; URLs are rejected.
+
+.PARAMETER KubeContext
+    Optional kubeconfig context name passed to `kubectl --context`.
+
+.PARAMETER Namespace
+    Namespace where the temporary kube-bench Job is created and logs
+    are collected from. Default 'kube-system'.
 #>
 [CmdletBinding()]
 param (
@@ -18,7 +31,10 @@ param (
     [string] $OutputPath,
     [ValidateRange(60, 3600)]
     [int] $JobTimeoutSeconds = 600,
-    [string] $KubeBenchImage = 'aquasec/kube-bench:v0.7.2'
+    [string] $KubeBenchImage = 'aquasec/kube-bench:v0.7.2',
+    [string] $KubeconfigPath,
+    [string] $KubeContext,
+    [string] $Namespace = 'kube-system'
 )
 
 Set-StrictMode -Version Latest
@@ -119,14 +135,46 @@ if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
     $result.Message = 'kubectl not installed. kube-bench runtime job requires kubectl to access AKS.'
     return [pscustomobject]$result
 }
-if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+
+$kubeconfigModeRequested = $PSBoundParameters.ContainsKey('KubeconfigPath') -or `
+                           $PSBoundParameters.ContainsKey('KubeContext')
+$resolvedKubeconfig = $null
+if ($PSBoundParameters.ContainsKey('KubeconfigPath')) {
+    if ([string]::IsNullOrWhiteSpace($KubeconfigPath)) {
+        throw "Invalid -KubeconfigPath: value is empty."
+    }
+    if ($KubeconfigPath -match '^[a-z][a-z0-9+.-]*://') {
+        throw "Invalid -KubeconfigPath '$(Remove-Credentials -Text $KubeconfigPath)': URLs are not accepted; provide a local file path."
+    }
+    if (-not (Test-Path -LiteralPath $KubeconfigPath -PathType Leaf)) {
+        throw "Invalid -KubeconfigPath '$(Remove-Credentials -Text $KubeconfigPath)': file does not exist."
+    }
+    $resolvedKubeconfig = (Resolve-Path -LiteralPath $KubeconfigPath).ProviderPath
+} elseif ($kubeconfigModeRequested) {
+    $candidate = if ($env:KUBECONFIG) { $env:KUBECONFIG } else { Join-Path $HOME '.kube' 'config' }
+    if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+        throw "Invalid kubeconfig: -KubeContext was supplied but no kubeconfig found at '$(Remove-Credentials -Text $candidate)'. Set -KubeconfigPath or `$env:KUBECONFIG."
+    }
+    $resolvedKubeconfig = (Resolve-Path -LiteralPath $candidate).ProviderPath
+}
+
+if (-not $kubeconfigModeRequested -and -not (Get-Command az -ErrorAction SilentlyContinue)) {
     $result.Status  = 'Skipped'
-    $result.Message = 'az CLI not installed. Required to populate AKS kubeconfig context.'
+    $result.Message = 'az CLI not installed. Required to populate AKS kubeconfig context (skip by passing -KubeconfigPath).'
     return [pscustomobject]$result
 }
 
 $clusters = @()
-if ($ClusterArmIds -and $ClusterArmIds.Count -gt 0) {
+if ($kubeconfigModeRequested) {
+    $synthName = if ($KubeContext) { $KubeContext } else { 'kubeconfig-default' }
+    $clusters += [pscustomobject]@{
+        id              = "kubeconfig:$synthName"
+        resourceGroup   = ''
+        name            = $synthName
+        kubeconfigPath  = $resolvedKubeconfig
+        kubeContext     = $KubeContext
+    }
+} elseif ($ClusterArmIds -and $ClusterArmIds.Count -gt 0) {
     foreach ($id in $ClusterArmIds) {
         $rg    = if ($id -match '/resourceGroups/([^/]+)') { $Matches[1] } else { '' }
         $name  = Split-Path $id -Leaf
@@ -167,45 +215,59 @@ $scanned  = 0
 $failed   = 0
 
 foreach ($cluster in $clusters) {
-    # Defense-in-depth: reject resources whose names contain shell metacharacters.
-    # Azure RG names allow [A-Za-z0-9._()-]; AKS cluster names allow [A-Za-z0-9-].
-    if ($cluster.resourceGroup -notmatch '^[A-Za-z0-9._()-]{1,90}$' -or
-        $cluster.name          -notmatch '^[A-Za-z0-9-]{1,63}$') {
-        Write-Warning "Skipping cluster with unsafe name/resourceGroup: $($cluster.name) in $($cluster.resourceGroup)"
-        $failed++
-        continue
+    $isKubeconfigMode = $false
+    if ($cluster.PSObject.Properties['kubeconfigPath'] -and $cluster.kubeconfigPath) {
+        $isKubeconfigMode = $true
     }
 
-    $context = "kb-$($cluster.name)-$([guid]::NewGuid().ToString('N').Substring(0,8))"
-    $tmpKubeconfig = $null
+    if (-not $isKubeconfigMode) {
+        # Defense-in-depth: reject resources whose names contain shell metacharacters.
+        # Azure RG names allow [A-Za-z0-9._()-]; AKS cluster names allow [A-Za-z0-9-].
+        if ($cluster.resourceGroup -notmatch '^[A-Za-z0-9._()-]{1,90}$' -or
+            $cluster.name          -notmatch '^[A-Za-z0-9-]{1,63}$') {
+            Write-Warning "Skipping cluster with unsafe name/resourceGroup: $($cluster.name) in $($cluster.resourceGroup)"
+            $failed++
+            continue
+        }
+    }
+
+    if ($isKubeconfigMode) {
+        $context       = $cluster.kubeContext
+        $tmpKubeconfig = $cluster.kubeconfigPath
+    } else {
+        $context = "kb-$($cluster.name)-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        $tmpKubeconfig = $null
+    }
     $jobManifest = $null
     $jobName = "aa-kube-bench-$([guid]::NewGuid().ToString('N').Substring(0,8))"
     $jobApplied = $false
     $rawLogsPath = $null
 
     try {
-        $tmpKubeconfig = Join-Path ([System.IO.Path]::GetTempPath()) "kubeconfig-$context.yaml"
-        $azArgs = @('aks', 'get-credentials',
-            '--subscription', $SubscriptionId,
-            '--resource-group', $cluster.resourceGroup,
-            '--name', $cluster.name,
-            '--file', $tmpKubeconfig,
-            '--context', $context,
-            '--overwrite-existing',
-            '--only-show-errors')
-        & az @azArgs 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            $failed++
-            continue
+        if (-not $isKubeconfigMode) {
+            $tmpKubeconfig = Join-Path ([System.IO.Path]::GetTempPath()) "kubeconfig-$context.yaml"
+            $azArgs = @('aks', 'get-credentials',
+                '--subscription', $SubscriptionId,
+                '--resource-group', $cluster.resourceGroup,
+                '--name', $cluster.name,
+                '--file', $tmpKubeconfig,
+                '--context', $context,
+                '--overwrite-existing',
+                '--only-show-errors')
+            & az @azArgs 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                $failed++
+                continue
+            }
         }
 
-        $jobManifest = Join-Path ([System.IO.Path]::GetTempPath()) "kube-bench-$context-job.yaml"
+        $jobManifest = Join-Path ([System.IO.Path]::GetTempPath()) "kube-bench-$jobName-job.yaml"
         @"
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: $jobName
-  namespace: kube-system
+  namespace: $Namespace
 spec:
   backoffLimit: 0
   template:
@@ -230,15 +292,18 @@ spec:
 
         $env:KUBECONFIG = $tmpKubeconfig
 
-        & kubectl --context $context apply -f $jobManifest 2>&1 | Out-Null
+        $kctxArgs = @()
+        if ($context) { $kctxArgs += @('--context', $context) }
+
+        & kubectl @kctxArgs apply -f $jobManifest 2>&1 | Out-Null
         if ($LASTEXITCODE -ne 0) {
             $failed++
             continue
         }
         $jobApplied = $true
 
-        & kubectl --context $context -n kube-system wait --for=condition=complete "job/$jobName" --timeout="$($JobTimeoutSeconds)s" 2>&1 | Out-Null
-        & kubectl --context $context -n kube-system logs "job/$jobName" 2>&1 | Set-Variable -Name kubeBenchLogs
+        & kubectl @kctxArgs -n $Namespace wait --for=condition=complete "job/$jobName" --timeout="$($JobTimeoutSeconds)s" 2>&1 | Out-Null
+        & kubectl @kctxArgs -n $Namespace logs "job/$jobName" 2>&1 | Set-Variable -Name kubeBenchLogs
         if ([string]::IsNullOrWhiteSpace($kubeBenchLogs)) {
             $failed++
             continue
@@ -282,12 +347,14 @@ spec:
         Write-Warning "kube-bench scan failed for cluster $($cluster.name): $(Remove-Credentials -Text ([string]$_.Exception.Message))"
     } finally {
         if ($jobApplied) {
-            & kubectl --context $context -n kube-system delete "job/$jobName" --ignore-not-found=true 2>&1 | Out-Null
+            $delArgs = @()
+            if ($context) { $delArgs += @('--context', $context) }
+            & kubectl @delArgs -n $Namespace delete "job/$jobName" --ignore-not-found=true 2>&1 | Out-Null
         }
         if ($jobManifest -and (Test-Path $jobManifest)) {
             try { Remove-Item $jobManifest -Force -ErrorAction SilentlyContinue } catch {}
         }
-        if ($tmpKubeconfig -and (Test-Path $tmpKubeconfig)) {
+        if (-not $isKubeconfigMode -and $tmpKubeconfig -and (Test-Path $tmpKubeconfig)) {
             try { Remove-Item $tmpKubeconfig -Force -ErrorAction SilentlyContinue } catch {}
         }
         if ($env:KUBECONFIG) { Remove-Item Env:\KUBECONFIG -ErrorAction SilentlyContinue }

--- a/modules/Invoke-Kubescape.ps1
+++ b/modules/Invoke-Kubescape.ps1
@@ -26,12 +26,32 @@
 
 .PARAMETER OutputPath
     Optional directory for per-cluster raw kubescape JSON (for audit).
+
+.PARAMETER KubeconfigPath
+    Optional path to an existing kubeconfig file. When provided, the wrapper
+    skips Azure Resource Graph discovery and `az aks get-credentials`, and
+    runs a single kubescape scan against the cluster reachable via this
+    kubeconfig (kubeconfig mode). Defaults: $env:KUBECONFIG, then
+    $HOME/.kube/config when -KubeContext is supplied without a path.
+    The file MUST exist when set explicitly; URLs are rejected.
+
+.PARAMETER KubeContext
+    Optional kubeconfig context name. In kubeconfig mode passed to
+    kubescape via `--kube-context`. In AKS-discovery mode ignored
+    (per-cluster contexts are generated automatically).
+
+.PARAMETER Namespace
+    Optional namespace filter forwarded to kubescape via
+    `--include-namespaces`. Default empty (scan all namespaces).
 #>
 [CmdletBinding()]
 param (
     [Parameter(Mandatory)] [string] $SubscriptionId,
     [string[]] $ClusterArmIds,
-    [string] $OutputPath
+    [string] $OutputPath,
+    [string] $KubeconfigPath,
+    [string] $KubeContext,
+    [string] $Namespace = ''
 )
 
 Set-StrictMode -Version Latest
@@ -59,6 +79,32 @@ $result = [ordered]@{
     Timestamp     = (Get-Date).ToUniversalTime().ToString('o')
 }
 
+# Determine auth mode early. Explicit -KubeconfigPath (or just -KubeContext)
+# enables "kubeconfig mode" (BYO cluster, no AKS discovery / get-credentials).
+$kubeconfigModeRequested = $PSBoundParameters.ContainsKey('KubeconfigPath') -or `
+                           $PSBoundParameters.ContainsKey('KubeContext')
+
+$resolvedKubeconfig = $null
+if ($PSBoundParameters.ContainsKey('KubeconfigPath')) {
+    if ([string]::IsNullOrWhiteSpace($KubeconfigPath)) {
+        throw "Invalid -KubeconfigPath: value is empty."
+    }
+    if ($KubeconfigPath -match '^[a-z][a-z0-9+.-]*://') {
+        throw "Invalid -KubeconfigPath '$(Remove-Credentials -Text $KubeconfigPath)': URLs are not accepted; provide a local file path."
+    }
+    if (-not (Test-Path -LiteralPath $KubeconfigPath -PathType Leaf)) {
+        throw "Invalid -KubeconfigPath '$(Remove-Credentials -Text $KubeconfigPath)': file does not exist."
+    }
+    $resolvedKubeconfig = (Resolve-Path -LiteralPath $KubeconfigPath).ProviderPath
+} elseif ($kubeconfigModeRequested) {
+    # -KubeContext supplied but no -KubeconfigPath: fall back to env / default.
+    $candidate = if ($env:KUBECONFIG) { $env:KUBECONFIG } else { Join-Path $HOME '.kube' 'config' }
+    if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+        throw "Invalid kubeconfig: -KubeContext was supplied but no kubeconfig found at '$(Remove-Credentials -Text $candidate)'. Set -KubeconfigPath or `$env:KUBECONFIG."
+    }
+    $resolvedKubeconfig = (Resolve-Path -LiteralPath $candidate).ProviderPath
+}
+
 # --- Tool prereqs ---
 if (-not (Get-Command kubescape -ErrorAction SilentlyContinue)) {
     $result.Status  = 'Skipped'
@@ -70,15 +116,27 @@ if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
     $result.Message = 'kubectl not installed. kubescape requires kubectl to reach cluster API.'
     return [pscustomobject]$result
 }
-if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+if (-not $kubeconfigModeRequested -and -not (Get-Command az -ErrorAction SilentlyContinue)) {
     $result.Status  = 'Skipped'
-    $result.Message = 'az CLI not installed. Required to populate AKS kubeconfig context.'
+    $result.Message = 'az CLI not installed. Required to populate AKS kubeconfig context (skip by passing -KubeconfigPath).'
     return [pscustomobject]$result
 }
 
-# --- Discover AKS clusters via ARG (unless explicit list provided) ---
+# --- Discover AKS clusters via ARG (unless explicit list provided, or kubeconfig mode) ---
 $clusters = @()
-if ($ClusterArmIds -and $ClusterArmIds.Count -gt 0) {
+if ($kubeconfigModeRequested) {
+    # Synthetic single "cluster" backed by the user-supplied kubeconfig.
+    $synthName = if ($KubeContext) { $KubeContext } else { 'kubeconfig-default' }
+    $synthId   = "kubeconfig:$synthName"
+    $clusters += [pscustomobject]@{
+        id              = $synthId
+        resourceGroup   = ''
+        name            = $synthName
+        kubeconfigPath  = $resolvedKubeconfig
+        kubeContext     = $KubeContext
+        kubeconfigOwned = $false   # do NOT delete user-supplied kubeconfig
+    }
+} elseif ($ClusterArmIds -and $ClusterArmIds.Count -gt 0) {
     foreach ($id in $ClusterArmIds) {
         $rg    = if ($id -match '/resourceGroups/([^/]+)') { $Matches[1] } else { '' }
         $name  = Split-Path $id -Leaf
@@ -119,32 +177,49 @@ if ($OutputPath -and -not (Test-Path $OutputPath)) {
 }
 
 foreach ($cluster in $clusters) {
-    $context = "ks-$($cluster.name)-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+    $isKubeconfigMode = $false
+    if ($cluster.PSObject.Properties['kubeconfigPath'] -and $cluster.kubeconfigPath) {
+        $isKubeconfigMode = $true
+    }
+    $contextForScan = $null
+    $tmpKubeconfig  = $null
+    if ($isKubeconfigMode) {
+        $tmpKubeconfig  = $cluster.kubeconfigPath
+        $contextForScan = $cluster.kubeContext
+    } else {
+        $context = "ks-$($cluster.name)-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        $contextForScan = $context
+    }
     try {
-        # Isolated kubeconfig context per cluster — avoid cross-cluster pollution.
-        $tmpKubeconfig = Join-Path ([System.IO.Path]::GetTempPath()) "kubeconfig-$context.yaml"
-        $azArgs = @('aks', 'get-credentials',
-                    '--subscription', $SubscriptionId,
-                    '--resource-group', $cluster.resourceGroup,
-                    '--name', $cluster.name,
-                    '--file', $tmpKubeconfig,
-                    '--context', $context,
-                    '--overwrite-existing',
-                    '--only-show-errors')
-        & az @azArgs 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            $failed++
-            continue
+        if (-not $isKubeconfigMode) {
+            # Isolated kubeconfig context per cluster — avoid cross-cluster pollution.
+            $tmpKubeconfig = Join-Path ([System.IO.Path]::GetTempPath()) "kubeconfig-$context.yaml"
+            $azArgs = @('aks', 'get-credentials',
+                        '--subscription', $SubscriptionId,
+                        '--resource-group', $cluster.resourceGroup,
+                        '--name', $cluster.name,
+                        '--file', $tmpKubeconfig,
+                        '--context', $context,
+                        '--overwrite-existing',
+                        '--only-show-errors')
+            & az @azArgs 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                $failed++
+                continue
+            }
         }
 
         $rawFile = if ($OutputPath) {
             Join-Path $OutputPath "kubescape-$($cluster.name)-$(Get-Date -Format yyyyMMddHHmmss).json"
         } else {
-            Join-Path ([System.IO.Path]::GetTempPath()) "kubescape-$context.json"
+            Join-Path ([System.IO.Path]::GetTempPath()) "kubescape-$([guid]::NewGuid().ToString('N').Substring(0,8)).json"
         }
 
         $env:KUBECONFIG = $tmpKubeconfig
-        & kubescape scan --kube-context $context --format json --output $rawFile --format-version v2 2>&1 | Out-Null
+        $ksArgs = @('scan', '--format', 'json', '--output', $rawFile, '--format-version', 'v2')
+        if ($contextForScan) { $ksArgs += @('--kube-context', $contextForScan) }
+        if ($Namespace)      { $ksArgs += @('--include-namespaces', $Namespace) }
+        & kubescape @ksArgs 2>&1 | Out-Null
         $scanExit = $LASTEXITCODE
 
         if ((Test-Path $rawFile) -and ((Get-Item $rawFile).Length -gt 0)) {
@@ -190,7 +265,8 @@ foreach ($cluster in $clusters) {
         Write-Warning "kubescape scan failed for cluster $($cluster.name): $(Remove-Credentials -Text ([string]$_.Exception.Message))"
     } finally {
         # Remove the isolated kubeconfig to avoid leaking cluster auth.
-        if ($tmpKubeconfig -and (Test-Path $tmpKubeconfig)) {
+        # In kubeconfig mode the path was supplied by the caller; do not delete it.
+        if (-not $isKubeconfigMode -and $tmpKubeconfig -and (Test-Path $tmpKubeconfig)) {
             try { Remove-Item $tmpKubeconfig -Force -ErrorAction SilentlyContinue } catch {}
         }
         if ($env:KUBECONFIG) { Remove-Item Env:\KUBECONFIG -ErrorAction SilentlyContinue }

--- a/tests/fixtures/kubeconfig-mock.yaml
+++ b/tests/fixtures/kubeconfig-mock.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+current-context: mock-ctx
+clusters:
+- name: mock-cluster
+  cluster:
+    server: https://kubernetes.example.invalid:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: mock-ctx
+  context:
+    cluster: mock-cluster
+    user: mock-user
+    namespace: default
+users:
+- name: mock-user
+  user:
+    token: mock-token-not-real

--- a/tests/orchestrator/AzureAnalyzer-K8sParams.Tests.ps1
+++ b/tests/orchestrator/AzureAnalyzer-K8sParams.Tests.ps1
@@ -1,0 +1,53 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    $script:Here        = Split-Path $PSCommandPath -Parent
+    $script:RepoRoot    = Resolve-Path (Join-Path $script:Here '..' '..')
+    $script:Orchestrator = Join-Path $script:RepoRoot 'Invoke-AzureAnalyzer.ps1'
+    $script:Fixture     = Join-Path $script:RepoRoot 'tests' 'fixtures' 'kubeconfig-mock.yaml'
+}
+
+Describe 'Invoke-AzureAnalyzer: K8s param surface (#240)' {
+    It 'declares -KubeconfigPath, -KubeContext, and per-tool namespace params' {
+        $cmd = Get-Command -Name $script:Orchestrator
+        $cmd.Parameters.Keys | Should -Contain 'KubeconfigPath'
+        $cmd.Parameters.Keys | Should -Contain 'KubeContext'
+        $cmd.Parameters.Keys | Should -Contain 'KubescapeNamespace'
+        $cmd.Parameters.Keys | Should -Contain 'FalcoNamespace'
+        $cmd.Parameters.Keys | Should -Contain 'KubeBenchNamespace'
+    }
+
+    It 'kubeconfig fixture file is present (used by wrapper kubeconfig-mode tests)' {
+        Test-Path -LiteralPath $script:Fixture | Should -BeTrue
+    }
+
+    It 'forwards K8s params to wrappers via the subscription dispatch block (source-level check)' {
+        $src = Get-Content $script:Orchestrator -Raw
+        $src | Should -Match "toolDef\.name -eq 'kubescape'"
+        $src | Should -Match "toolDef\.name -eq 'kube-bench'"
+        $src | Should -Match "toolDef\.name -eq 'falco'"
+        $src | Should -Match 'params\[.KubeconfigPath.\]'
+        $src | Should -Match 'params\[.KubeContext.\]'
+        $src | Should -Match 'params\[.Namespace.\]\s*=\s*\$KubescapeNamespace'
+        $src | Should -Match 'params\[.Namespace.\]\s*=\s*\$FalcoNamespace'
+        $src | Should -Match 'params\[.Namespace.\]\s*=\s*\$KubeBenchNamespace'
+    }
+
+    It 'defaults FalcoNamespace=falco, KubeBenchNamespace=kube-system, KubescapeNamespace=empty' {
+        $cmd = Get-Command -Name $script:Orchestrator
+        $params = $cmd.ScriptBlock.Ast.ParamBlock.Parameters
+        $get = {
+            param($name)
+            ($params | Where-Object { $_.Name.VariablePath.UserPath -eq $name } |
+                ForEach-Object { $_.DefaultValue.Extent.Text.Trim("'") })
+        }
+        & $get 'FalcoNamespace'     | Should -Be 'falco'
+        & $get 'KubeBenchNamespace' | Should -Be 'kube-system'
+        # KubescapeNamespace default is the empty string ''
+        $ksDefault = $params | Where-Object { $_.Name.VariablePath.UserPath -eq 'KubescapeNamespace' } |
+            ForEach-Object { $_.DefaultValue.Extent.Text }
+        $ksDefault | Should -Be "''"
+    }
+}

--- a/tests/wrappers/Invoke-Falco.Tests.ps1
+++ b/tests/wrappers/Invoke-Falco.Tests.ps1
@@ -33,3 +33,44 @@ Describe 'Invoke-Falco: error paths' {
     }
 }
 
+Describe 'Invoke-Falco: kubeconfig param surface (#240)' {
+    BeforeAll {
+        $script:Fixture = Join-Path $script:RepoRoot 'tests' 'fixtures' 'kubeconfig-mock.yaml'
+    }
+
+    It 'declares -KubeconfigPath, -KubeContext, -Namespace parameters' {
+        $cmd = Get-Command -Name $script:Wrapper
+        $cmd.Parameters.Keys | Should -Contain 'KubeconfigPath'
+        $cmd.Parameters.Keys | Should -Contain 'KubeContext'
+        $cmd.Parameters.Keys | Should -Contain 'Namespace'
+    }
+
+    It 'defaults Namespace to "falco"' {
+        $cmd = Get-Command -Name $script:Wrapper
+        $defaultNs = $cmd.ScriptBlock.Ast.ParamBlock.Parameters |
+            Where-Object { $_.Name.VariablePath.UserPath -eq 'Namespace' } |
+            ForEach-Object { $_.DefaultValue.Extent.Text.Trim("'") }
+        $defaultNs | Should -Be 'falco'
+    }
+
+    It 'rejects a non-existent kubeconfig path' {
+        $bogus = Join-Path ([System.IO.Path]::GetTempPath()) "falco-doesnotexist-$([guid]::NewGuid()).yaml"
+        { & $script:Wrapper -SubscriptionId '00000000-0000-0000-0000-000000000000' -KubeconfigPath $bogus } |
+            Should -Throw -ExpectedMessage '*does not exist*'
+    }
+
+    It 'rejects URL-style kubeconfig values' {
+        { & $script:Wrapper -SubscriptionId '00000000-0000-0000-0000-000000000000' -KubeconfigPath 'https://example.invalid/kc' } |
+            Should -Throw -ExpectedMessage '*URLs are not accepted*'
+    }
+
+    It 'accepts an existing kubeconfig in install mode (skips on missing helm, no AKS discovery)' {
+        Mock Get-Command { return $null } -ParameterFilter { $Name -eq 'helm' }
+        $result = & $script:Wrapper -SubscriptionId '00000000-0000-0000-0000-000000000000' `
+            -InstallFalco -KubeconfigPath $script:Fixture -KubeContext 'mock-ctx' -Namespace 'falco-ns'
+        $result.Status | Should -Be 'Skipped'
+        $result.Message | Should -Match 'helm is not installed'
+    }
+}
+
+

--- a/tests/wrappers/Invoke-KubeBench.Tests.ps1
+++ b/tests/wrappers/Invoke-KubeBench.Tests.ps1
@@ -29,3 +29,35 @@ Describe 'Invoke-KubeBench: error paths' {
     }
 }
 
+Describe 'Invoke-KubeBench: kubeconfig param surface (#240)' {
+    BeforeAll {
+        $script:Fixture = Join-Path $script:RepoRoot 'tests' 'fixtures' 'kubeconfig-mock.yaml'
+    }
+
+    It 'declares -KubeconfigPath, -KubeContext, -Namespace parameters' {
+        $cmd = Get-Command -Name $script:Wrapper
+        $cmd.Parameters.Keys | Should -Contain 'KubeconfigPath'
+        $cmd.Parameters.Keys | Should -Contain 'KubeContext'
+        $cmd.Parameters.Keys | Should -Contain 'Namespace'
+    }
+
+    It 'defaults Namespace to "kube-system"' {
+        $cmd = Get-Command -Name $script:Wrapper
+        $defaultNs = $cmd.ScriptBlock.Ast.ParamBlock.Parameters |
+            Where-Object { $_.Name.VariablePath.UserPath -eq 'Namespace' } |
+            ForEach-Object { $_.DefaultValue.Extent.Text.Trim("'") }
+        $defaultNs | Should -Be 'kube-system'
+    }
+
+    It 'rejects a non-existent kubeconfig path' {
+        $bogus = Join-Path ([System.IO.Path]::GetTempPath()) "kb-doesnotexist-$([guid]::NewGuid()).yaml"
+        { & $script:Wrapper -SubscriptionId '00000000-0000-0000-0000-000000000000' -KubeconfigPath $bogus } |
+            Should -Throw -ExpectedMessage '*does not exist*'
+    }
+
+    It 'rejects URL-style kubeconfig values' {
+        { & $script:Wrapper -SubscriptionId '00000000-0000-0000-0000-000000000000' -KubeconfigPath 'https://example.invalid/kc' } |
+            Should -Throw -ExpectedMessage '*URLs are not accepted*'
+    }
+}
+

--- a/tests/wrappers/Invoke-Kubescape.Tests.ps1
+++ b/tests/wrappers/Invoke-Kubescape.Tests.ps1
@@ -33,3 +33,36 @@ Describe 'Invoke-Kubescape: error paths' {
     }
 }
 
+Describe 'Invoke-Kubescape: kubeconfig param surface (#240)' {
+    BeforeAll {
+        $script:Fixture = Join-Path $script:RepoRoot 'tests' 'fixtures' 'kubeconfig-mock.yaml'
+    }
+
+    It 'declares -KubeconfigPath, -KubeContext, -Namespace parameters' {
+        $cmd = Get-Command -Name $script:Wrapper
+        $cmd.Parameters.Keys | Should -Contain 'KubeconfigPath'
+        $cmd.Parameters.Keys | Should -Contain 'KubeContext'
+        $cmd.Parameters.Keys | Should -Contain 'Namespace'
+    }
+
+    It 'rejects a non-existent kubeconfig path with a clear error' {
+        $bogus = Join-Path ([System.IO.Path]::GetTempPath()) "kubescape-doesnotexist-$([guid]::NewGuid()).yaml"
+        { & $script:Wrapper -SubscriptionId '00000000-0000-0000-0000-000000000000' -KubeconfigPath $bogus } |
+            Should -Throw -ExpectedMessage '*does not exist*'
+    }
+
+    It 'rejects URL-style kubeconfig values (no remote fetch)' {
+        { & $script:Wrapper -SubscriptionId '00000000-0000-0000-0000-000000000000' -KubeconfigPath 'https://example.invalid/kubeconfig' } |
+            Should -Throw -ExpectedMessage '*URLs are not accepted*'
+    }
+
+    It 'accepts an existing kubeconfig file (skips on missing kubectl, no AKS discovery)' {
+        Mock Get-Command { return $null } -ParameterFilter { $Name -eq 'kubectl' }
+        Mock Get-Command { return [pscustomobject]@{ Name = 'kubescape' } } -ParameterFilter { $Name -eq 'kubescape' }
+        $result = & $script:Wrapper -SubscriptionId '00000000-0000-0000-0000-000000000000' `
+            -KubeconfigPath $script:Fixture -KubeContext 'mock-ctx' -Namespace 'default'
+        $result.Status | Should -Be 'Skipped'
+        $result.Source | Should -Be 'kubescape'
+    }
+}
+


### PR DESCRIPTION
## Summary

Phase 1 of parent issue #236. Adds explicit `-KubeconfigPath`, `-KubeContext`, and per-tool namespace parameters to the three Kubernetes-targeted wrappers and threads them through the orchestrator. When a kubeconfig is supplied the wrappers skip Azure Resource Graph discovery and `az aks get-credentials` and scan the cluster reachable via the supplied kubeconfig (kubeconfig mode). When the new params are not supplied, behavior is byte-for-byte identical to main.

Closes #240.

## Touched wrappers + default-value table

| Wrapper | Source | New params | Per-wrapper default | Effective CLI flag |
|---|---|---|---|---|
| Kubescape | `modules/Invoke-Kubescape.ps1` | `-KubeconfigPath`, `-KubeContext`, `-Namespace` | Namespace `''` (all namespaces) | `kubescape scan [--kube-context X] [--include-namespaces Y]` |
| Falco | `modules/Invoke-Falco.ps1` | `-KubeconfigPath`, `-KubeContext`, `-Namespace` | Namespace `'falco'` | `helm upgrade --install falco --namespace <ns> [--kube-context X]` + `kubectl [--context X] -n <ns> logs daemonset/falco` |
| kube-bench | `modules/Invoke-KubeBench.ps1` | `-KubeconfigPath`, `-KubeContext`, `-Namespace` | Namespace `'kube-system'` | `kubectl [--context X] -n <ns> apply / wait / logs / delete job/...` |

Orchestrator (`Invoke-AzureAnalyzer.ps1`) gains `-KubeconfigPath`, `-KubeContext`, plus three per-tool namespace params (`-KubescapeNamespace` defaulting to `''`, `-FalcoNamespace` defaulting to `falco`, `-KubeBenchNamespace` defaulting to `kube-system`) so the user does not have to pass kubeconfig per tool. The orchestrator only forwards a param when the user explicitly bound it (`$PSBoundParameters.ContainsKey(...)`), preserving wrapper-side defaults otherwise.

## Backward-compat strategy

- All new params are optional with safe defaults.
- The orchestrator adds new params only via `$PSBoundParameters.ContainsKey(...)` checks: if the user does not supply them, the wrapper sees its existing default (no behavioral drift).
- When kubeconfig mode is **not** used, every wrapper takes the existing AKS-discovery-via-ARG + `az aks get-credentials` path with its existing isolated-temp-kubeconfig cleanup.
- User-supplied kubeconfig files are never deleted by cleanup logic (only orchestrator-generated temp kubeconfigs are removed).
- Validation rejects empty / URL-style / missing-file values at the wrapper boundary, with all path text passed through `Remove-Credentials` before being included in any error or warning.

## End-to-end test description

- **`tests/wrappers/Invoke-Kubescape.Tests.ps1`**: 5 new tests covering the param surface, fixture acceptance with mocked `kubectl`, missing-file rejection, and URL rejection.
- **`tests/wrappers/Invoke-Falco.Tests.ps1`**: 5 new tests covering the param surface, default `-Namespace = 'falco'`, missing-file rejection, URL rejection, and install-mode kubeconfig acceptance with mocked `helm`.
- **`tests/wrappers/Invoke-KubeBench.Tests.ps1`**: 4 new tests covering the param surface, default `-Namespace = 'kube-system'`, missing-file rejection, and URL rejection.
- **`tests/orchestrator/AzureAnalyzer-K8sParams.Tests.ps1`** (new): 4 tests verifying the orchestrator declares the five new top-level params, that the dispatch block forwards `-KubeconfigPath`, `-KubeContext`, and the three namespace params to each K8s wrapper, that the per-tool namespace defaults match the contract, and that the kubeconfig fixture exists.
- **`tests/fixtures/kubeconfig-mock.yaml`** (new): synthetic kubeconfig with non-routable `https://kubernetes.example.invalid:6443` server. Used by wrapper kubeconfig-mode tests; never reaches a real cluster.

## Pester results

```
Tests Passed: 1230, Failed: 0, Skipped: 5, Inconclusive: 0, NotRun: 0
```

Baseline was 1213+; this PR adds 18 net new passing tests (4 orchestrator + 5 kubescape + 5 falco + 4 kube-bench, minus a couple of existing tests that were folded into the new Describe blocks where appropriate).

## Extension hooks left for #241 / #242

The wrappers branch on `$kubeconfigModeRequested = $PSBoundParameters.ContainsKey('KubeconfigPath') -or $PSBoundParameters.ContainsKey('KubeContext')` and synthesize a single "cluster" record carrying `kubeconfigPath` + `kubeContext`. Adding new auth modes (token, in-cluster service-account, OIDC federation) only requires:

1. Adding the new param(s) to each wrapper's param block.
2. Extending the `$kubeconfigModeRequested` predicate (or introducing a sibling `$tokenModeRequested` predicate).
3. Augmenting the synthetic cluster record with the additional auth fields.
4. Threading the new field into the existing `$ctx` / `$tmpKubeconfig` setup section that already gates `az aks get-credentials`.

No restructuring of the scan loop is required.

## References

- Issue: #240
- Parent issue: #236
- Related (sequenced): #241, #242
- Triage doc: `.squad/decisions/inbox/lead-backlog-triage-2026-04-20-aks-reports-cost-173025.md`
- New consumer doc: `docs/consumer/k8s-auth.md`
