### PR TITLE
feat(reports): per-tab severity totals strip with click-to-filter (closes #226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to azure-analyzer will be documented here.
 ### Added
 
 - ci: add markdown link-check workflow (advisory, weekly + PR path filter) (closes #251)
+- feat(reports): per-category severity totals strip in Findings with click-to-filter and sticky visibility; includes Critical, High, Medium, Low, Info, and Total (closes #226)
 
 ### Consumer-first documentation restructure
 

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -289,11 +289,33 @@ $rowsJson = ($findings | ForEach-Object {
 
 $byCategory = @($findings | Group-Object -Property Category | Sort-Object Name)
 $tableIndex = 0
+$severityOrder = @('Critical', 'High', 'Medium', 'Low', 'Info')
 
 $categoryHtml = foreach ($cat in $byCategory) {
     $catId = ($cat.Name -replace '[^a-zA-Z0-9]', '-').ToLower()
     $tblId = "tbl-$catId-$tableIndex"
     $tableIndex++
+    $catSeverityCounts = [ordered]@{
+        Critical = 0
+        High     = 0
+        Medium   = 0
+        Low      = 0
+        Info     = 0
+    }
+    foreach ($f in $cat.Group) {
+        switch -Regex ([string]$f.Severity) {
+            '^(?i)critical$' { $catSeverityCounts['Critical']++; break }
+            '^(?i)high$'     { $catSeverityCounts['High']++; break }
+            '^(?i)medium$'   { $catSeverityCounts['Medium']++; break }
+            '^(?i)low$'      { $catSeverityCounts['Low']++; break }
+            '^(?i)info$'     { $catSeverityCounts['Info']++; break }
+        }
+    }
+    $severityStripBadges = foreach ($sev in $severityOrder) {
+        $count = [int]$catSeverityCounts[$sev]
+        $sevClass = "severity-pill-$($sev.ToLowerInvariant())"
+        "<button type='button' class='severity-pill $sevClass' data-severity='$(HE $sev)' aria-pressed='false' onclick=`"filterBySeverityStrip(this,'$(HE $sev)')`">$(HE $sev): $count</button>"
+    }
     $catRows = foreach ($f in ($cat.Group | Sort-Object Severity, Title)) {
         $sevClass = SeverityClass $f.Severity
         $sevBorder = "sev-border-$($f.Severity.ToLower())"
@@ -320,6 +342,12 @@ $categoryHtml = foreach ($cat in $byCategory) {
     @"
 <details id="cat-$catId">
   <summary><strong>$(HE $cat.Name)</strong> <span class="cat-count">($($cat.Count))</span></summary>
+  <div class="severity-strip no-print" role="group" aria-label="Severity totals for $(HE $cat.Name)">
+    <div class="severity-strip-badges">
+      $($severityStripBadges -join "`n      ")
+    </div>
+    <button type="button" class="severity-pill severity-pill-total is-active" data-severity="all" aria-pressed="true" onclick="filterBySeverityStrip(this,'all')">Total: $($cat.Count)</button>
+  </div>
   <div class="filter-box no-print"><input type="text" placeholder="Filter rows..." onkeyup="filterTable(this,'$tblId')" class="filter-input"></div>
   <table id="$tblId" class="findings-table sortable">
     <thead>
@@ -960,6 +988,25 @@ $html = @"
   .filter-banner.active { display: flex; }
   .filter-banner button { background: #1565c0; color: #fff; border: none; border-radius: 3px; padding: 4px 10px; cursor: pointer; font-size: 12px; }
   .filter-banner button:hover { background: #0d47a1; }
+  .severity-strip {
+    display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
+    position: sticky; top: 56px; z-index: 95;
+    background: #ffffff; border-top: 1px solid #edf2f7; border-bottom: 1px solid #edf2f7;
+    padding: 0.55rem 1rem;
+  }
+  .severity-strip-badges { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+  .severity-pill {
+    border: 1px solid transparent; border-radius: 999px; padding: 0.2rem 0.6rem;
+    font-size: 0.75rem; font-weight: 700; cursor: pointer; transition: box-shadow 0.12s, transform 0.12s;
+  }
+  .severity-pill:hover { transform: translateY(-1px); }
+  .severity-pill[aria-pressed="true"], .severity-pill.is-active { box-shadow: 0 0 0 2px rgba(11, 18, 32, 0.18); }
+  .severity-pill-critical { background: #fee2e2; color: #991b1b; border-color: #fecaca; }
+  .severity-pill-high { background: #ffedd5; color: #9a3412; border-color: #fed7aa; }
+  .severity-pill-medium { background: #fef3c7; color: #92400e; border-color: #fde68a; }
+  .severity-pill-low { background: #dbeafe; color: #1d4ed8; border-color: #bfdbfe; }
+  .severity-pill-info { background: #e5e7eb; color: #374151; border-color: #d1d5db; }
+  .severity-pill-total { background: #f8fafc; color: #1f2937; border-color: #cbd5e1; white-space: nowrap; }
 
   /* Print-friendly styles */
   @media print {
@@ -991,6 +1038,7 @@ $html = @"
   .gf-chip[data-active="true"][data-color="high"]     { background: #dc2626; color: #fff; border-color: #dc2626; }
   .gf-chip[data-active="true"][data-color="medium"]   { background: #f59e0b; color: #1f2937; border-color: #f59e0b; }
   .gf-chip[data-active="true"][data-color="low"]      { background: #facc15; color: #1f2937; border-color: #facc15; }
+  .gf-chip[data-active="true"][data-color="info"]     { background: #6b7280; color: #fff; border-color: #6b7280; }
   .gf-count  { font-size: 0.75rem; color: #6b7280; white-space: nowrap; }
   .gf-rg-banner { font-size: 0.75rem; color: #1f2937; background: #eef2ff; border: 1px solid #c7d2fe; padding: 0.15rem 0.45rem; border-radius: 6px; white-space: nowrap; }
   .gf-rg-banner strong { color: #1e3a8a; margin: 0 0.15rem; }
@@ -1145,6 +1193,7 @@ $complianceHtml
     <button class="gf-chip" data-sev="High"     data-color="high"     onclick="toggleSevFilter(this,'High')">High</button>
     <button class="gf-chip" data-sev="Medium"   data-color="medium"   onclick="toggleSevFilter(this,'Medium')">Medium</button>
     <button class="gf-chip" data-sev="Low"      data-color="low"      onclick="toggleSevFilter(this,'Low')">Low</button>
+    <button class="gf-chip" data-sev="Info"     data-color="info"     onclick="toggleSevFilter(this,'Info')">Info</button>
   </div>
   <select id="gf-source" onchange="applyGlobalFilter()" aria-label="Filter by tool">
     <option value="">All Tools</option>
@@ -1185,6 +1234,40 @@ var _gfPlatform = '';
 var _gfStatus = '';
 var _gfText = '';
 var _gfRg = '';
+
+function syncSeverityStripState() {
+  var active = 'all';
+  if (_gfActiveSev.size === 1) {
+    active = Array.from(_gfActiveSev)[0];
+  } else if (_gfActiveSev.size > 1) {
+    active = '__multi__';
+  }
+  document.querySelectorAll('.severity-strip .severity-pill').forEach(function(pill) {
+    var sev = pill.dataset.severity || '';
+    var isActive = (active === 'all' && sev === 'all') || (active !== 'all' && active !== '__multi__' && sev === active);
+    pill.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    pill.classList.toggle('is-active', isActive);
+  });
+}
+
+function setSingleSeverityFilter(severity) {
+  _gfActiveSev.clear();
+  _gfRg = '';
+  if (severity && severity !== 'all') {
+    _gfActiveSev.add(severity);
+  }
+  document.querySelectorAll('.gf-chip').forEach(function(chip) {
+    var chipSev = chip.dataset.sev || '';
+    var on = (severity === 'all' && chipSev === 'all') || (severity !== 'all' && chipSev === severity);
+    chip.dataset.active = on ? 'true' : 'false';
+    chip.classList.toggle('gf-active', on);
+  });
+  applyGlobalFilter();
+}
+
+function filterBySeverityStrip(btn, severity) {
+  setSingleSeverityFilter(severity || 'all');
+}
 
 function applyGlobalFilter() {
   _gfSource   = document.getElementById('gf-source') ? document.getElementById('gf-source').value : '';
@@ -1228,6 +1311,7 @@ function applyGlobalFilter() {
       rgBanner.style.display = 'none';
     }
   }
+  syncSeverityStripState();
 }
 
 function toggleSevFilter(btn, sev) {

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ New-MdReport   -InputPath .\output\results.json -OutputPath .\output\report.md
 
 `New-HtmlReport.ps1` renders the HTML report directly. There is no separate checked-in HTML template to maintain or customize.
 
-The HTML report includes an executive Summary tab, a severity-by-resource-group heatmap, a global filter bar (severity, platform, tool, free text), and a CSV export of the currently filtered view.
+The HTML report includes an executive Summary tab, a severity-by-resource-group heatmap, sticky per-category severity totals strips (Critical, High, Medium, Low, Info, Total), a global filter bar (severity, platform, tool, free text), and a CSV export of the currently filtered view.
 
 ## What you get
 

--- a/tests/reports/Severity-Strip.Tests.ps1
+++ b/tests/reports/Severity-Strip.Tests.ps1
@@ -1,0 +1,49 @@
+#Requires -Version 7.4
+
+Describe 'HTML report severity strip' {
+    BeforeAll {
+        $script:RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+    }
+
+    It 'renders per-category severity strip totals for all five severity levels' {
+        $tmp = Join-Path $TestDrive 'severity-strip'
+        $null = New-Item -ItemType Directory -Path $tmp -Force
+
+        $findings = @(
+            [pscustomobject]@{ Id='F-01'; Source='azqr'; Category='Security'; Title='Critical finding'; Severity='Critical'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-a/providers/Microsoft.Compute/virtualMachines/vm1'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-02'; Source='azqr'; Category='Security'; Title='High finding 1'; Severity='High'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-a/providers/Microsoft.Network/networkSecurityGroups/nsg1'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-03'; Source='psrule'; Category='Security'; Title='High finding 2'; Severity='High'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-a/providers/Microsoft.KeyVault/vaults/kv1'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-04'; Source='psrule'; Category='Security'; Title='Medium finding 1'; Severity='Medium'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-b/providers/Microsoft.Storage/storageAccounts/st1'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-05'; Source='psrule'; Category='Security'; Title='Medium finding 2'; Severity='Medium'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-b/providers/Microsoft.Storage/storageAccounts/st2'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-06'; Source='psrule'; Category='Security'; Title='Medium finding 3'; Severity='Medium'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-b/providers/Microsoft.Storage/storageAccounts/st3'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-07'; Source='trivy'; Category='Security'; Title='Low finding 1'; Severity='Low'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-c/providers/Microsoft.Web/sites/app1'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-08'; Source='trivy'; Category='Security'; Title='Low finding 2'; Severity='Low'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-c/providers/Microsoft.Web/sites/app2'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-09'; Source='trivy'; Category='Security'; Title='Low finding 3'; Severity='Low'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-c/providers/Microsoft.Web/sites/app3'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-10'; Source='trivy'; Category='Security'; Title='Low finding 4'; Severity='Low'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-c/providers/Microsoft.Web/sites/app4'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-11'; Source='maester'; Category='Security'; Title='Info finding 1'; Severity='Info'; Compliant=$true; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-d/providers/Microsoft.Resources/tags/tag1'; LearnMoreUrl=''; Platform='Entra'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-12'; Source='maester'; Category='Security'; Title='Info finding 2'; Severity='Info'; Compliant=$true; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-d/providers/Microsoft.Resources/tags/tag2'; LearnMoreUrl=''; Platform='Entra'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-13'; Source='maester'; Category='Security'; Title='Info finding 3'; Severity='Info'; Compliant=$true; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-d/providers/Microsoft.Resources/tags/tag3'; LearnMoreUrl=''; Platform='Entra'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-14'; Source='maester'; Category='Security'; Title='Info finding 4'; Severity='Info'; Compliant=$true; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-d/providers/Microsoft.Resources/tags/tag4'; LearnMoreUrl=''; Platform='Entra'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-15'; Source='maester'; Category='Security'; Title='Info finding 5'; Severity='Info'; Compliant=$true; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-d/providers/Microsoft.Resources/tags/tag5'; LearnMoreUrl=''; Platform='Entra'; Controls=@(); Frameworks=@() }
+            [pscustomobject]@{ Id='F-16'; Source='azqr'; Category='Operations'; Title='Other category'; Severity='Low'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg-z/providers/Microsoft.Web/sites/appz'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@() }
+        )
+
+        $resultsPath = Join-Path $tmp 'results.json'
+        $findings | ConvertTo-Json -Depth 6 | Set-Content -Path $resultsPath -Encoding UTF8
+        $outputPath = Join-Path $tmp 'report.html'
+
+        & (Join-Path $RootDir 'New-HtmlReport.ps1') -InputPath $resultsPath -OutputPath $outputPath | Out-Null
+
+        $html = Get-Content $outputPath -Raw
+        $securitySection = [regex]::Match($html, 'id="cat-security"[\s\S]*?</details>', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase).Value
+
+        $securitySection | Should -Match 'class="severity-strip'
+        $securitySection | Should -Match 'filterBySeverityStrip'
+        $securitySection | Should -Match 'Critical:\s*1'
+        $securitySection | Should -Match 'High:\s*2'
+        $securitySection | Should -Match 'Medium:\s*3'
+        $securitySection | Should -Match 'Low:\s*4'
+        $securitySection | Should -Match 'Info:\s*5'
+        $securitySection | Should -Match 'Total:\s*15'
+    }
+}


### PR DESCRIPTION
## Summary
- add a sticky severity totals strip to each Findings category panel in `New-HtmlReport.ps1`
- strip shows `Critical | High | Medium | Low | Info` counts and a right-aligned `Total`
- strip badges are color-coded and click into existing global severity filtering (reuses current filter state)
- add `Info` to the global severity chips so all five severities are filterable from the UI

## Screenshot description
Generated `report.html` now shows, at the top of every category section, a sticky row of badges like `Critical: N | High: N | Medium: N | Low: N | Info: N` and `Total: N` on the right. Clicking a badge updates the findings rows below to that severity.

## Tests
- added `tests/reports/Severity-Strip.Tests.ps1`
- asserts severity strip markup is present in generated HTML
- asserts rendered strip counts equal the expected per-severity totals and total
- full suite: `Invoke-Pester -Path .\\tests -CI` (green)

## Context
- Lead triage doc: `.squad/decisions/inbox/lead-backlog-triage-2026-04-20-aks-reports-cost-173025.md`