### PR TITLE
feat: Infracost wrapper for Bicep/Terraform pre-deploy cost (closes #233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to azure-analyzer will be documented here.
 
 - ci: add markdown link-check workflow (advisory, weekly + PR path filter) (closes #251)
 - feat(reports): per-category severity totals strip in Findings with click-to-filter and sticky visibility; includes Critical, High, Medium, Low, Info, and Total (closes #226)
+- feat: Infracost wrapper for Bicep/Terraform pre-deploy cost (closes #233)
 
 ### Consumer-first documentation restructure
 

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -73,6 +73,7 @@ Per-tool permission detail lives under [`docs/consumer/permissions/`](docs/consu
 |---|---|---|
 | **Bicep IaC Validation** | Repository | [`bicep-iac.md`](docs/consumer/permissions/bicep-iac.md) |
 | **gitleaks (Secrets Scanner)** | Repository | [`gitleaks.md`](docs/consumer/permissions/gitleaks.md) |
+| **Infracost IaC Cost Estimation** | Repository | [`infracost.md`](docs/consumer/permissions/infracost.md) |
 | **Terraform IaC Validation** | Repository | [`terraform-iac.md`](docs/consumer/permissions/terraform-iac.md) |
 | **Trivy Vulnerability Scanner** | Repository | [`trivy.md`](docs/consumer/permissions/trivy.md) |
 | **zizmor (Actions YAML Scanner)** | Repository | [`zizmor.md`](docs/consumer/permissions/zizmor.md) |

--- a/docs/consumer/README.md
+++ b/docs/consumer/README.md
@@ -9,3 +9,4 @@ All advanced consumer docs live here. The root `README.md` is your starting poin
 - [gitleaks-pattern-tuning.md](gitleaks-pattern-tuning.md) - Tuning gitleaks rule patterns to cut false positives.
 - [k8s-auth.md](k8s-auth.md) - Targeting Kubernetes wrappers (kubescape, falco, kube-bench) with explicit `-KubeconfigPath` / `-KubeContext` / per-tool namespace params.
 - [sinks/log-analytics.md](sinks/log-analytics.md) - Streaming azure-analyzer findings into Azure Log Analytics.
+- Cost and FinOps tools are listed in [tool-catalog.md](tool-catalog.md); permission details are in [permissions/](permissions/README.md).

--- a/docs/consumer/permissions/infracost.md
+++ b/docs/consumer/permissions/infracost.md
@@ -1,0 +1,27 @@
+# Infracost - Required Permissions
+
+**Display name:** Infracost IaC Cost Estimation
+
+**Scope:** repository | **Provider:** cli
+
+Runs `infracost breakdown --path <dir> --format json` against Terraform and Bicep source before deployment. This is static IaC analysis and does not query Azure Resource Manager.
+
+## Required permissions
+
+| Surface | Requirement |
+|---|---|
+| Azure | None |
+| Microsoft Graph | None |
+| GitHub | Token only required when cloning a private GitHub repo (`GITHUB_TOKEN` or `GH_TOKEN` with Contents: Read) |
+| ADO | `AZURE_DEVOPS_EXT_PAT` with Code: Read required only when cloning a private ADO repo |
+| Local | None for local path mode |
+
+## Local CLI requirement
+
+`infracost` must be on PATH. The wrapper is auto-installable through the manifest installer (winget on Windows, brew on macOS).
+
+## What it does NOT do
+
+- No `terraform plan`, `terraform apply`, or Bicep deployment.
+- No Azure write operations.
+- No Git writes to target repositories.

--- a/docs/consumer/tool-catalog.md
+++ b/docs/consumer/tool-catalog.md
@@ -8,7 +8,7 @@ Manifest schema version: `2.2`
 
 This page lists every analyzer tool azure-analyzer can run, what it covers, what scope it targets, and where to find consumer-focused setup notes when one exists. For the full manifest fields (normalizer, install kind, upstream pin, report color/phase) see [docs/contributor/tool-catalog.md](../contributor/tool-catalog.md).
 
-**Total enabled:** 26. **Disabled / opt-in:** 1.
+**Total enabled:** 27. **Disabled / opt-in:** 1.
 
 ## Enabled by default
 
@@ -29,6 +29,7 @@ This page lists every analyzer tool azure-analyzer can run, what it covers, what
 | `gitleaks` | gitleaks (Secrets Scanner) | repository | cli | Secret scanning across local or remote git repositories. | [docs](./gitleaks-pattern-tuning.md) |
 | `identity-correlator` | Identity Correlator | tenant | graph | Correlates Entra identities, role assignments, and resource ownership. | - |
 | `identity-graph-expansion` | Identity Graph Expansion | tenant | graph | Expands the identity graph: cross-tenant B2B + service-principal-to-resource edges. | - |
+| `infracost` | Infracost IaC Cost Estimation | repository | cli | Pre-deploy cost estimate for Terraform and Bicep resources. | - |
 | `kube-bench` | kube-bench (AKS node-level CIS compliance) | subscription | azure | CIS Kubernetes benchmark for AKS node hardening. | - |
 | `kubescape` | Kubescape (AKS runtime posture) | subscription | azure | Runtime posture for AKS clusters: misconfigurations, RBAC, network policies, vulnerabilities. | - |
 | `maester` | Maester | tenant | microsoft365 | Microsoft Entra (Identity) security baseline: conditional access, MFA, privileged roles. | [docs](./ai-triage.md) |

--- a/docs/contributor/tool-catalog.md
+++ b/docs/contributor/tool-catalog.md
@@ -8,7 +8,7 @@ Manifest schema version: `2.2`
 
 Full manifest projection: every wired tool with normalizer, invocation, install, report, and upstream metadata. For the consumer-friendly subset see [docs/consumer/tool-catalog.md](../consumer/tool-catalog.md). To onboard a new tool follow [adding-a-tool.md](./adding-a-tool.md).
 
-**Total tools registered:** 27.
+**Total tools registered:** 28.
 
 ## Registration matrix
 
@@ -30,6 +30,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | `gitleaks` | gitleaks (Secrets Scanner) | collector | cli | repository | Enabled | 0 | windows, macos, linux |
 | `identity-correlator` | Identity Correlator | correlator | graph | tenant | Enabled | 3 | windows, macos, linux |
 | `identity-graph-expansion` | Identity Graph Expansion | correlator | graph | tenant | Enabled | 3 | windows, macos, linux |
+| `infracost` | Infracost IaC Cost Estimation | collector | cli | repository | Enabled | 0 | windows, macos, linux |
 | `kube-bench` | kube-bench (AKS node-level CIS compliance) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux |
 | `kubescape` | Kubescape (AKS runtime posture) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux |
 | `maester` | Maester | collector | microsoft365 | tenant | Enabled | 0 | windows, macos, linux |
@@ -62,6 +63,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | `gitleaks` | `Normalize-Gitleaks` | script | `modules/Invoke-Gitleaks.ps1` | - |
 | `identity-correlator` | `Normalize-IdentityCorrelation` | function | `modules/shared/IdentityCorrelator.ps1` | TenantId |
 | `identity-graph-expansion` | `Normalize-IdentityGraphExpansion` | function | `modules/Invoke-IdentityGraphExpansion.ps1` | TenantId |
+| `infracost` | `Normalize-Infracost` | script | `modules/Invoke-Infracost.ps1` | - |
 | `kube-bench` | `Normalize-KubeBench` | script | `modules/Invoke-KubeBench.ps1` | SubscriptionId |
 | `kubescape` | `Normalize-Kubescape` | script | `modules/Invoke-Kubescape.ps1` | SubscriptionId |
 | `maester` | `Normalize-Maester` | script | `modules/Invoke-Maester.ps1` | - |
@@ -94,6 +96,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | `gitleaks` | cli ("gitleaks") | gitleaks/gitleaks @ latest | `#c62828` | 3 |
 | `identity-correlator` | psmodule | n/a | `#5e35b1` | 2 |
 | `identity-graph-expansion` | psmodule | n/a | `#283593` | 2 |
+| `infracost` | cli ("infracost") | infracost/infracost @ latest | `#2e7d32` | 7 |
 | `kube-bench` | none | n/a | `#5e35b1` | 6 |
 | `kubescape` | cli ("kubescape") | kubescape/kubescape @ v3 | `#7b1fa2` | 6 |
 | `maester` | psmodule | maester365/maester @ latest | `#7b1fa2` | 1 |

--- a/modules/Invoke-Infracost.ps1
+++ b/modules/Invoke-Infracost.ps1
@@ -1,0 +1,248 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+    Wrapper for Infracost CLI pre-deploy IaC cost estimation.
+.DESCRIPTION
+    Runs `infracost breakdown` against Terraform/Bicep source and emits a v1
+    wrapper envelope with one finding per resource estimate.
+
+    Cloud-first behavior:
+    - `-Repository` clones a remote repo through RemoteClone.ps1 (HTTPS-only,
+      host allow-list, token-safe cleanup).
+    - `-Path` scans a local directory (fallback mode).
+
+    Resilience and security:
+    - Infracost CLI invocation is wrapped with Invoke-WithRetry.
+    - CLI process is executed through Invoke-WithTimeout with 300s timeout.
+    - Any surfaced message is passed through Remove-Credentials.
+
+    Never throws -- designed for graceful degradation in the orchestrator.
+.PARAMETER Path
+    Local directory containing Terraform/Bicep files. Defaults to current dir.
+.PARAMETER Repository
+    Remote HTTPS repository URL to clone and scan.
+#>
+[CmdletBinding()]
+param (
+    [Alias('RepoPath')]
+    [string] $Path = '.',
+    [Alias('RemoteUrl')]
+    [string] $Repository
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$sharedDir = Join-Path (Split-Path $PSScriptRoot -Parent) 'modules' 'shared'
+if (-not $sharedDir -or -not (Test-Path $sharedDir)) {
+    $sharedDir = Join-Path $PSScriptRoot 'shared'
+}
+
+$sanitizePath = Join-Path $sharedDir 'Sanitize.ps1'
+if (Test-Path $sanitizePath) { . $sanitizePath }
+$retryPath = Join-Path $sharedDir 'Retry.ps1'
+if (Test-Path $retryPath) { . $retryPath }
+$remoteClonePath = Join-Path $sharedDir 'RemoteClone.ps1'
+if (Test-Path $remoteClonePath) { . $remoteClonePath }
+$installerPath = Join-Path $sharedDir 'Installer.ps1'
+if (-not (Get-Command Invoke-WithTimeout -ErrorAction SilentlyContinue) -and (Test-Path $installerPath)) {
+    . $installerPath
+}
+
+if (-not (Get-Command Remove-Credentials -ErrorAction SilentlyContinue)) {
+    function Remove-Credentials { param ([string]$Text) return $Text }
+}
+if (-not (Get-Command Invoke-WithRetry -ErrorAction SilentlyContinue)) {
+    function Invoke-WithRetry { param([scriptblock]$ScriptBlock, [int]$MaxAttempts = 3) & $ScriptBlock }
+}
+if (-not (Get-Command Invoke-WithTimeout -ErrorAction SilentlyContinue)) {
+    function Invoke-WithTimeout {
+        param (
+            [Parameter(Mandatory)][string]$Command,
+            [Parameter(Mandatory)][string[]]$Arguments,
+            [int]$TimeoutSec = 300
+        )
+        $output = & $Command @Arguments 2>&1 | Out-String
+        [PSCustomObject]@{
+            ExitCode = $LASTEXITCODE
+            Output   = Remove-Credentials $output
+        }
+    }
+}
+
+function Test-InfracostInstalled {
+    return $null -ne (Get-Command infracost -ErrorAction SilentlyContinue)
+}
+
+function Get-FirstJsonObjectText {
+    param([AllowNull()][string]$Text)
+    if ([string]::IsNullOrWhiteSpace($Text)) { return $null }
+    $start = $Text.IndexOf('{')
+    $end = $Text.LastIndexOf('}')
+    if ($start -lt 0 -or $end -lt $start) { return $null }
+    return $Text.Substring($start, ($end - $start) + 1)
+}
+
+if (-not (Test-InfracostInstalled)) {
+    Write-Warning "infracost CLI is not installed. Skipping Infracost scan."
+    return [PSCustomObject]@{
+        Source        = 'infracost'
+        SchemaVersion = '1.0'
+        Status        = 'Skipped'
+        Message       = 'infracost CLI not installed. Install from https://www.infracost.io/docs/'
+        Findings      = @()
+    }
+}
+
+$cloneInfo = $null
+$cleanupClone = $null
+try {
+    if ($Repository) {
+        if (-not (Get-Command Invoke-RemoteRepoClone -ErrorAction SilentlyContinue)) {
+            Write-Warning "RemoteClone helper not loaded; cannot scan remote repository."
+            return [PSCustomObject]@{
+                Source        = 'infracost'
+                SchemaVersion = '1.0'
+                Status        = 'Failed'
+                Message       = 'RemoteClone helper unavailable'
+                Findings      = @()
+            }
+        }
+        $cloneInfo = Invoke-RemoteRepoClone -RepoUrl $Repository -TimeoutSec 300
+        if (-not $cloneInfo) {
+            return [PSCustomObject]@{
+                Source        = 'infracost'
+                SchemaVersion = '1.0'
+                Status        = 'Failed'
+                Message       = "Remote clone failed or host not on allow-list: $Repository"
+                Findings      = @()
+            }
+        }
+        $cleanupClone = $cloneInfo.Cleanup
+        $Path = $cloneInfo.Path
+    }
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return [PSCustomObject]@{
+            Source        = 'infracost'
+            SchemaVersion = '1.0'
+            Status        = 'Failed'
+            Message       = "Path not found: $Path"
+            Findings      = @()
+        }
+    }
+
+    $iacFiles = @(Get-ChildItem -Path $Path -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Extension -in @('.tf', '.bicep') })
+    if ($iacFiles.Count -eq 0) {
+        return [PSCustomObject]@{
+            Source        = 'infracost'
+            SchemaVersion = '1.0'
+            Status        = 'Skipped'
+            Message       = 'No Terraform or Bicep files found under scan path.'
+            Findings      = @()
+        }
+    }
+
+    $args = @('breakdown', '--path', $Path, '--format', 'json', '--no-color')
+    $exec = Invoke-WithRetry -MaxAttempts 3 -InitialDelaySeconds 2 -MaxDelaySeconds 30 -ScriptBlock {
+        Invoke-WithTimeout -Command 'infracost' -Arguments $args -TimeoutSec 300
+    }
+
+    if (-not $exec -or $exec.ExitCode -ne 0) {
+        $safeOutput = if ($exec) { Remove-Credentials ([string]$exec.Output) } else { '' }
+        return [PSCustomObject]@{
+            Source        = 'infracost'
+            SchemaVersion = '1.0'
+            Status        = 'Failed'
+            Message       = "infracost breakdown failed (exit code $($exec.ExitCode)): $safeOutput"
+            Findings      = @()
+        }
+    }
+
+    $jsonText = Get-FirstJsonObjectText -Text ([string]$exec.Output)
+    if (-not $jsonText) {
+        return [PSCustomObject]@{
+            Source        = 'infracost'
+            SchemaVersion = '1.0'
+            Status        = 'Failed'
+            Message       = 'infracost output did not contain a JSON object.'
+            Findings      = @()
+        }
+    }
+
+    $parsed = $null
+    try {
+        $parsed = $jsonText | ConvertFrom-Json -Depth 100 -ErrorAction Stop
+    } catch {
+        return [PSCustomObject]@{
+            Source        = 'infracost'
+            SchemaVersion = '1.0'
+            Status        = 'Failed'
+            Message       = Remove-Credentials "Failed to parse infracost JSON: $($_.Exception.Message)"
+            Findings      = @()
+        }
+    }
+
+    $findings = [System.Collections.Generic.List[PSCustomObject]]::new()
+    foreach ($project in @($parsed.projects)) {
+        if (-not $project) { continue }
+        $projectName = if ($project.PSObject.Properties['name'] -and $project.name) { [string]$project.name } else { 'project' }
+        $projectPath = if ($project.PSObject.Properties['path'] -and $project.path) { [string]$project.path } else { [string]$Path }
+        $resources = @()
+        if ($project.PSObject.Properties['breakdown'] -and $project.breakdown -and
+            $project.breakdown.PSObject.Properties['resources']) {
+            $resources = @($project.breakdown.resources)
+        }
+
+        foreach ($resource in $resources) {
+            if (-not $resource) { continue }
+            $resourceName = if ($resource.PSObject.Properties['name'] -and $resource.name) { [string]$resource.name } else { 'resource' }
+            $resourceType = if ($resource.PSObject.Properties['resourceType'] -and $resource.resourceType) { [string]$resource.resourceType } else { 'unknown' }
+            $monthlyRaw = if ($resource.PSObject.Properties['monthlyCost']) { [string]$resource.monthlyCost } else { '0' }
+            $monthlyCost = 0.0
+            [void][double]::TryParse($monthlyRaw, [System.Globalization.NumberStyles]::Any, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$monthlyCost)
+
+            $findings.Add([PSCustomObject]@{
+                    Id            = [guid]::NewGuid().ToString()
+                    Category      = 'Cost'
+                    Title         = "Estimated monthly cost: $([string]::Format([System.Globalization.CultureInfo]::InvariantCulture, '{0:0.00}', $monthlyCost)) for $resourceType"
+                    Severity      = 'Info'
+                    Compliant     = $false
+                    Detail        = "Infracost estimate for $resourceName in project $projectName."
+                    Remediation   = 'Review right-sizing, SKU choice, and environment count before deployment.'
+                    ResourceId    = $projectPath
+                    LearnMoreUrl  = 'https://www.infracost.io/docs/'
+                    ResourceType  = $resourceType
+                    ResourceName  = $resourceName
+                    ProjectName   = $projectName
+                    ProjectPath   = $projectPath
+                    MonthlyCost   = [math]::Round($monthlyCost, 2)
+                    Currency      = if ($resource.PSObject.Properties['currency'] -and $resource.currency) { [string]$resource.currency } else { 'USD' }
+                })
+        }
+    }
+
+    return [PSCustomObject]@{
+        Source        = 'infracost'
+        SchemaVersion = '1.0'
+        Status        = 'Success'
+        Message       = "Parsed $($findings.Count) resource cost estimate(s)."
+        Findings      = @($findings)
+    }
+} catch {
+    Write-Warning "Infracost scan failed: $(Remove-Credentials -Text ([string]$_.Exception.Message))"
+    return [PSCustomObject]@{
+        Source        = 'infracost'
+        SchemaVersion = '1.0'
+        Status        = 'Failed'
+        Message       = Remove-Credentials -Text ([string]$_.Exception.Message)
+        Findings      = @()
+    }
+} finally {
+    if ($cleanupClone) {
+        try { & $cleanupClone } catch {
+            Write-Verbose "Infracost clone cleanup failed: $(Remove-Credentials -Text ([string]$_.Exception.Message))"
+        }
+    }
+}

--- a/modules/normalizers/Normalize-Infracost.ps1
+++ b/modules/normalizers/Normalize-Infracost.ps1
@@ -1,0 +1,129 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+    Normalizer for Infracost wrapper output.
+.DESCRIPTION
+    Converts v1 Infracost wrapper output to v2 FindingRow objects.
+
+    Design:
+    - One finding per estimated IaC resource (more actionable than one summary).
+    - EntityType is AzureResource for report consistency.
+    - Because IaC pre-deploy estimates do not have deployed ARM IDs yet, this
+      normalizer generates a deterministic synthetic ARM-style resource ID.
+    - Severity heuristic is monthly-cost based:
+        > 1000 => High
+        > 100  => Medium
+        else   => Low
+#>
+[CmdletBinding()]
+param ()
+
+. "$PSScriptRoot\..\shared\Schema.ps1"
+. "$PSScriptRoot\..\shared\Canonicalize.ps1"
+
+function ConvertTo-InfracostSlug {
+    param([string]$Value)
+    $slug = if ($Value) { $Value.ToLowerInvariant() } else { 'unknown' }
+    $slug = $slug -replace '[^a-z0-9\-]+', '-'
+    $slug = $slug.Trim('-')
+    if ([string]::IsNullOrWhiteSpace($slug)) { return 'unknown' }
+    return $slug
+}
+
+function Resolve-InfracostSeverity {
+    param([double]$MonthlyCost)
+    if ($MonthlyCost -gt 1000) { return 'High' }
+    if ($MonthlyCost -gt 100) { return 'Medium' }
+    return 'Low'
+}
+
+function Normalize-Infracost {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [PSCustomObject] $ToolResult
+    )
+
+    if ($ToolResult.Status -ne 'Success' -or -not $ToolResult.Findings) {
+        return @()
+    }
+
+    $runId = [guid]::NewGuid().ToString()
+    $normalized = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $syntheticSub = '00000000-0000-0000-0000-000000000000'
+
+    foreach ($finding in @($ToolResult.Findings)) {
+        if (-not $finding) { continue }
+
+        $findingId = if ($finding.PSObject.Properties['Id'] -and $finding.Id) {
+            [string]$finding.Id
+        } else {
+            [guid]::NewGuid().ToString()
+        }
+
+        $resourceType = if ($finding.PSObject.Properties['ResourceType'] -and $finding.ResourceType) {
+            [string]$finding.ResourceType
+        } else {
+            'unknown'
+        }
+        $resourceName = if ($finding.PSObject.Properties['ResourceName'] -and $finding.ResourceName) {
+            [string]$finding.ResourceName
+        } else {
+            $findingId
+        }
+        $projectName = if ($finding.PSObject.Properties['ProjectName'] -and $finding.ProjectName) {
+            [string]$finding.ProjectName
+        } else {
+            'project'
+        }
+
+        $monthlyCost = 0.0
+        if ($finding.PSObject.Properties['MonthlyCost'] -and $null -ne $finding.MonthlyCost) {
+            try {
+                $monthlyCost = [double]$finding.MonthlyCost
+            } catch {
+                $monthlyCost = 0.0
+            }
+        }
+        $currency = if ($finding.PSObject.Properties['Currency'] -and $finding.Currency) {
+            [string]$finding.Currency
+        } else {
+            'USD'
+        }
+
+        $resourceSlug = ConvertTo-InfracostSlug -Value "$projectName-$resourceType-$resourceName"
+        $syntheticArmId = "/subscriptions/$syntheticSub/resourceGroups/infracost-iac/providers/Microsoft.Infracost/iacResources/$resourceSlug"
+        $canonicalId = $syntheticArmId.ToLowerInvariant()
+        try {
+            $canonicalId = (ConvertTo-CanonicalEntityId -RawId $syntheticArmId -EntityType 'AzureResource').CanonicalId
+        } catch {
+            # Keep synthetic ARM id as fallback.
+        }
+
+        $severity = Resolve-InfracostSeverity -MonthlyCost $monthlyCost
+        $title = "Estimated monthly cost: $([string]::Format([System.Globalization.CultureInfo]::InvariantCulture, '{0:0.00}', $monthlyCost)) for $resourceType"
+        $detail = if ($finding.PSObject.Properties['ProjectPath'] -and $finding.ProjectPath) {
+            "Resource $resourceName from $($finding.ProjectPath). Static IaC estimate generated before deployment."
+        } else {
+            "Resource $resourceName from project $projectName. Static IaC estimate generated before deployment."
+        }
+
+        $row = New-FindingRow -Id $findingId `
+            -Source 'infracost' -EntityId $canonicalId -EntityType 'AzureResource' `
+            -Title $title -Compliant ($monthlyCost -le 100) -ProvenanceRunId $runId `
+            -Platform 'Azure' -Category 'WAF Cost Optimization' -Severity $severity `
+            -Detail $detail `
+            -Remediation 'Review right-sizing, SKU selection, and environment count before deployment.' `
+            -LearnMoreUrl 'https://www.infracost.io/docs/' `
+            -ResourceId $syntheticArmId `
+            -SubscriptionId $syntheticSub `
+            -ResourceGroup 'infracost-iac'
+        if ($null -eq $row) { continue }
+
+        $row | Add-Member -NotePropertyName MonthlyCost -NotePropertyValue ([math]::Round($monthlyCost, 2)) -Force
+        $row | Add-Member -NotePropertyName Currency -NotePropertyValue $currency -Force
+        $normalized.Add($row)
+    }
+
+    return @($normalized)
+}

--- a/scripts/Generate-ToolCatalog.ps1
+++ b/scripts/Generate-ToolCatalog.ps1
@@ -115,6 +115,7 @@ $consumerBlurb = @{
     'trivy'                    = 'Vulnerability and IaC misconfiguration scanner for repos and container images.'
     'bicep-iac'                = 'Bicep IaC validation: lint, build, and best-practice checks.'
     'terraform-iac'            = 'Terraform IaC validation: tflint / tfsec / checkov-style checks.'
+    'infracost'                = 'Pre-deploy cost estimate for Terraform and Bicep resources.'
     'sentinel-incidents'       = 'Pulls active Microsoft Sentinel incidents from a Log Analytics workspace.'
     'sentinel-coverage'        = 'Sentinel detection posture: analytic rules, watchlists, data connectors, hunting queries.'
     'copilot-triage'           = 'Optional Copilot-powered AI triage for finding prioritization (disabled by default).'

--- a/tests/fixtures/infracost/infracost-breakdown.json
+++ b/tests/fixtures/infracost/infracost-breakdown.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.10",
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "terraform-main",
+      "path": "infra/terraform",
+      "breakdown": {
+        "resources": [
+          {
+            "name": "azurerm_kubernetes_cluster.aks",
+            "resourceType": "azurerm_kubernetes_cluster",
+            "monthlyCost": "1260.75",
+            "currency": "USD"
+          },
+          {
+            "name": "azurerm_storage_account.logs",
+            "resourceType": "azurerm_storage_account",
+            "monthlyCost": "180.20",
+            "currency": "USD"
+          },
+          {
+            "name": "azurerm_resource_group.rg",
+            "resourceType": "azurerm_resource_group",
+            "monthlyCost": "12.30",
+            "currency": "USD"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/infracost/infracost-output.json
+++ b/tests/fixtures/infracost/infracost-output.json
@@ -1,0 +1,58 @@
+{
+  "Source": "infracost",
+  "Status": "Success",
+  "Message": "Parsed 3 resource cost estimate(s).",
+  "Findings": [
+    {
+      "Id": "11111111-1111-1111-1111-111111111111",
+      "Category": "Cost",
+      "Title": "Estimated monthly cost: 1260.75 for azurerm_kubernetes_cluster",
+      "Severity": "Info",
+      "Compliant": false,
+      "Detail": "Infracost estimate for azurerm_kubernetes_cluster.aks in project terraform-main.",
+      "Remediation": "Review right-sizing, SKU choice, and environment count before deployment.",
+      "ResourceId": "infra/terraform",
+      "LearnMoreUrl": "https://www.infracost.io/docs/",
+      "ResourceType": "azurerm_kubernetes_cluster",
+      "ResourceName": "azurerm_kubernetes_cluster.aks",
+      "ProjectName": "terraform-main",
+      "ProjectPath": "infra/terraform",
+      "MonthlyCost": 1260.75,
+      "Currency": "USD"
+    },
+    {
+      "Id": "22222222-2222-2222-2222-222222222222",
+      "Category": "Cost",
+      "Title": "Estimated monthly cost: 180.20 for azurerm_storage_account",
+      "Severity": "Info",
+      "Compliant": false,
+      "Detail": "Infracost estimate for azurerm_storage_account.logs in project terraform-main.",
+      "Remediation": "Review right-sizing, SKU choice, and environment count before deployment.",
+      "ResourceId": "infra/terraform",
+      "LearnMoreUrl": "https://www.infracost.io/docs/",
+      "ResourceType": "azurerm_storage_account",
+      "ResourceName": "azurerm_storage_account.logs",
+      "ProjectName": "terraform-main",
+      "ProjectPath": "infra/terraform",
+      "MonthlyCost": 180.20,
+      "Currency": "USD"
+    },
+    {
+      "Id": "33333333-3333-3333-3333-333333333333",
+      "Category": "Cost",
+      "Title": "Estimated monthly cost: 12.30 for azurerm_resource_group",
+      "Severity": "Info",
+      "Compliant": false,
+      "Detail": "Infracost estimate for azurerm_resource_group.rg in project terraform-main.",
+      "Remediation": "Review right-sizing, SKU choice, and environment count before deployment.",
+      "ResourceId": "infra/terraform",
+      "LearnMoreUrl": "https://www.infracost.io/docs/",
+      "ResourceType": "azurerm_resource_group",
+      "ResourceName": "azurerm_resource_group.rg",
+      "ProjectName": "terraform-main",
+      "ProjectPath": "infra/terraform",
+      "MonthlyCost": 12.30,
+      "Currency": "USD"
+    }
+  ]
+}

--- a/tests/normalizers/Normalize-Infracost.Tests.ps1
+++ b/tests/normalizers/Normalize-Infracost.Tests.ps1
@@ -1,0 +1,60 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+    . (Join-Path $repoRoot 'modules\shared\Canonicalize.ps1')
+    . (Join-Path $repoRoot 'modules\shared\Schema.ps1')
+    . (Join-Path $repoRoot 'modules\normalizers\Normalize-Infracost.ps1')
+}
+
+Describe 'Normalize-Infracost' {
+    BeforeAll {
+        $fixture = Get-Content (Join-Path $PSScriptRoot '..\fixtures\infracost\infracost-output.json') -Raw | ConvertFrom-Json
+        $failedFixture = Get-Content (Join-Path $PSScriptRoot '..\fixtures\failed-output.json') -Raw | ConvertFrom-Json
+    }
+
+    It 'returns one normalized row per resource finding' {
+        $rows = @(Normalize-Infracost -ToolResult $fixture)
+        $rows.Count | Should -Be 3
+    }
+
+    It 'uses v2 schema rows with AzureResource entity type' {
+        $rows = @(Normalize-Infracost -ToolResult $fixture)
+        foreach ($r in $rows) {
+            $r.SchemaVersion | Should -Be '2.0'
+            $r.Source | Should -Be 'infracost'
+            $r.EntityType | Should -Be 'AzureResource'
+            $r.Platform | Should -Be 'Azure'
+            $r.Category | Should -Be 'WAF Cost Optimization'
+        }
+    }
+
+    It 'applies severity thresholds based on monthly cost' {
+        $rows = @(Normalize-Infracost -ToolResult $fixture)
+        ($rows | Where-Object { $_.Title -match 'kubernetes_cluster' } | Select-Object -First 1).Severity | Should -Be 'High'
+        ($rows | Where-Object { $_.Title -match 'storage_account' } | Select-Object -First 1).Severity | Should -Be 'Medium'
+        ($rows | Where-Object { $_.Title -match 'resource_group' } | Select-Object -First 1).Severity | Should -Be 'Low'
+    }
+
+    It 'sets Compliant true only when monthly cost is at or below 100' {
+        $rows = @(Normalize-Infracost -ToolResult $fixture)
+        ($rows | Where-Object { $_.Severity -eq 'Low' } | Select-Object -First 1).Compliant | Should -BeTrue
+        ($rows | Where-Object { $_.Severity -eq 'High' } | Select-Object -First 1).Compliant | Should -BeFalse
+        ($rows | Where-Object { $_.Severity -eq 'Medium' } | Select-Object -First 1).Compliant | Should -BeFalse
+    }
+
+    It 'attaches MonthlyCost and Currency for EntityStore folding' {
+        $rows = @(Normalize-Infracost -ToolResult $fixture)
+        foreach ($r in $rows) {
+            $r.PSObject.Properties.Name | Should -Contain 'MonthlyCost'
+            $r.PSObject.Properties.Name | Should -Contain 'Currency'
+            $r.Currency | Should -Be 'USD'
+        }
+    }
+
+    It 'returns empty array for failed wrapper output' {
+        $rows = @(Normalize-Infracost -ToolResult $failedFixture)
+        $rows.Count | Should -Be 0
+    }
+}

--- a/tests/wrappers/Invoke-Infracost.Tests.ps1
+++ b/tests/wrappers/Invoke-Infracost.Tests.ps1
@@ -1,0 +1,41 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    $script:Here = Split-Path $PSCommandPath -Parent
+    $script:RepoRoot = Resolve-Path (Join-Path $script:Here '..' '..')
+    $script:Wrapper = Join-Path $script:RepoRoot 'modules' 'Invoke-Infracost.ps1'
+}
+
+Describe 'Invoke-Infracost: error paths' {
+    Context 'when infracost CLI is missing' {
+        BeforeAll {
+            Mock Get-Command { return $null } -ParameterFilter { $Name -eq 'infracost' }
+            $result = & $script:Wrapper
+        }
+
+        It 'returns Status = Skipped' {
+            $result.Status | Should -Be 'Skipped'
+        }
+
+        It 'returns Source = infracost' {
+            $result.Source | Should -Be 'infracost'
+        }
+
+        It 'returns SchemaVersion 1.0' {
+            $result.SchemaVersion | Should -Be '1.0'
+        }
+    }
+
+    Context 'when scan path does not exist' {
+        BeforeAll {
+            Mock Get-Command { return @{ Name = 'infracost' } } -ParameterFilter { $Name -eq 'infracost' }
+            $result = & $script:Wrapper -Path 'C:\does-not-exist\infracost'
+        }
+
+        It 'returns Status = Failed' {
+            $result.Status | Should -Be 'Failed'
+        }
+    }
+}

--- a/tests/wrappers/Wrappers-Remote.Tests.ps1
+++ b/tests/wrappers/Wrappers-Remote.Tests.ps1
@@ -52,3 +52,18 @@ Describe 'trivy wrapper: remote/local routing' {
     }
 }
 
+Describe 'infracost wrapper: remote/local routing' {
+    BeforeAll {
+        $script:wrapper = Join-Path $script:RepoRoot 'modules' 'Invoke-Infracost.ps1'
+    }
+    It 'accepts -Repository parameter' {
+        $paramInfo = (Get-Command $script:wrapper).Parameters
+        $paramInfo.ContainsKey('Repository') | Should -BeTrue
+    }
+    It 'rejects non-allow-listed remote URL' {
+        $result = & $script:wrapper -Repository 'https://evil.example.org/org/repo'
+        $result.Source | Should -Be 'infracost'
+        $result.Status | Should -Match 'Skipped|Failed'
+    }
+}
+

--- a/tools/tool-manifest.json
+++ b/tools/tool-manifest.json
@@ -834,6 +834,55 @@
       }
     },
     {
+      "name": "infracost",
+      "displayName": "Infracost IaC Cost Estimation",
+      "source": "infracost",
+      "provider": "cli",
+      "scope": "repository",
+      "normalizer": "Normalize-Infracost",
+      "invokeMethod": "script",
+      "type": "collector",
+      "script": "modules/Invoke-Infracost.ps1",
+      "requiredParams": [],
+      "optionalParams": [
+        "Path",
+        "Repository",
+        "RemoteUrl",
+        "RepoPath"
+      ],
+      "requiredPermissionTier": 0,
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
+      "enabled": true,
+      "report": {
+        "color": "#2e7d32",
+        "phase": 7
+      },
+      "install": {
+        "kind": "cli",
+        "command": "infracost",
+        "preferredManagers": ["winget", "brew"],
+        "windows": {
+          "winget": "Infracost.Infracost"
+        },
+        "macos": {
+          "brew": "infracost"
+        },
+        "linux": {
+          "url": "https://www.infracost.io/docs/"
+        }
+      },
+      "upstream": {
+        "repo": "infracost/infracost",
+        "releaseApi": "https://api.github.com/repos/infracost/infracost/releases/latest",
+        "pinType": "cli-version",
+        "currentPin": "latest"
+      }
+    },
+    {
       "name": "terraform-iac",
       "displayName": "Terraform IaC Validation",
       "source": "terraform-iac",


### PR DESCRIPTION
## Summary
- Added new `infracost` manifest entry with CLI install metadata (winget/brew) and upstream release metadata.
- Added `modules/Invoke-Infracost.ps1` wrapper with cloud-first remote clone support, local path support, and v1 envelope output.
- Added `modules/normalizers/Normalize-Infracost.ps1` using `New-FindingRow` to convert v1 output into v2 rows.
- Added fixtures and Pester tests for wrapper + normalizer.
- Added permissions page: `docs/consumer/permissions/infracost.md`.
- Regenerated manifest-driven docs (`tool-catalog` and `PERMISSIONS.md` index).

## Design choices
- Severity heuristic (monthly cost):
  - `> 1000` -> `High`
  - `> 100` -> `Medium`
  - `<= 100` -> `Low`
- Entity type: `AzureResource`.
  - Rationale: keep cost findings in Azure report groupings.
  - Since pre-deploy IaC has no deployed ARM IDs, the normalizer emits deterministic synthetic ARM-style IDs.
- Finding granularity: one finding per IaC resource estimate (more actionable than single summary finding).

## Validation
- `Invoke-Pester -Path .\tests -CI`
- `pwsh -File scripts/Generate-ToolCatalog.ps1`
- `pwsh -File scripts/Generate-PermissionsIndex.ps1`
- `pwsh -File scripts/Check-StubDeadline.ps1 -Mode Check`

## Context
Lead triage doc reference: `.squad/decisions/inbox/lead-backlog-triage-2026-04-20-aks-reports-cost-173025.md`