### PR TITLE
feat: Application Insights perf wrapper (slow requests + dependency failures + exception rate via KQL) (closes #237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Added
 
+- feat: Application Insights perf wrapper (slow requests + dependency failures + exception rate via KQL) (closes #237)
 - **K8s wrappers + orchestrator: explicit `-KubeconfigPath`, `-KubeContext`, and per-tool namespace params (closes #240).**
   Adds `-KubeconfigPath`, `-KubeContext`, `-KubescapeNamespace`, `-FalcoNamespace`, `-KubeBenchNamespace` to `Invoke-AzureAnalyzer.ps1` (top-level) and `-KubeconfigPath`, `-KubeContext`, `-Namespace` to `Invoke-Kubescape.ps1`, `Invoke-Falco.ps1`, and `Invoke-KubeBench.ps1`. When a kubeconfig path is provided the wrappers skip Azure Resource Graph discovery and `az aks get-credentials`, scanning a single cluster reachable via the supplied kubeconfig (kubeconfig mode). Default behavior is unchanged: with no new params supplied, every wrapper continues to discover AKS managed clusters via ARG and fetch per-cluster credentials. Validation rejects URL-style values and missing files at the wrapper boundary with sanitized errors. Per-wrapper namespace defaults: kubescape `''` (all namespaces), falco `'falco'`, kube-bench `'kube-system'`. Tests: `tests/wrappers/Invoke-Kubescape.Tests.ps1`, `tests/wrappers/Invoke-Falco.Tests.ps1`, `tests/wrappers/Invoke-KubeBench.Tests.ps1`, `tests/orchestrator/AzureAnalyzer-K8sParams.Tests.ps1`, fixture `tests/fixtures/kubeconfig-mock.yaml`. Phase 1 of parent issue #236; clears the way for #241/#242 (additional K8s auth modes).
 

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -26,6 +26,7 @@ Per-tool permission detail lives under [`docs/consumer/permissions/`](docs/consu
 | Tool | Scope | Detail |
 |---|---|---|
 | **ALZ Resource Graph Queries** | Management Group | [`alz-queries.md`](docs/consumer/permissions/alz-queries.md) |
+| **Application Insights Performance Signals** | Subscription | [`appinsights.md`](docs/consumer/permissions/appinsights.md) |
 | **AzGovViz** | Management Group | [`azgovviz.md`](docs/consumer/permissions/azgovviz.md) |
 | **Azure Quick Review** | Subscription | [`azqr.md`](docs/consumer/permissions/azqr.md) |
 | **Azure Cost (Consumption API)** | Subscription | [`azure-cost.md`](docs/consumer/permissions/azure-cost.md) |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CodeQL](https://github.com/martinopedal/azure-analyzer/actions/workflows/codeql.yml/badge.svg)](https://github.com/martinopedal/azure-analyzer/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**One PowerShell command, 28 read-only Azure assessment tools, one unified HTML and Markdown report.** Cloud-first by default: target remote GitHub and Azure DevOps repositories without cloning anything by hand.
+**One PowerShell command, 29 read-only Azure assessment tools, one unified HTML and Markdown report.** Cloud-first by default: target remote GitHub and Azure DevOps repositories without cloning anything by hand.
 
 ## Install
 
@@ -34,7 +34,7 @@ Connect-AzAccount -TenantId "<tenant-id>"
 Invoke-AzureAnalyzer -SubscriptionId "<subscription-id>"
 ```
 
-Runs every tool whose prerequisites are present (azqr, PSRule for Azure, AzGovViz, ALZ Resource Graph queries, WARA, Azure Cost, FinOps Signals, Azure Load Testing, Defender for Cloud) and writes findings to `output\` plus `report.html` and `report.md`.
+Runs every tool whose prerequisites are present (azqr, PSRule for Azure, AzGovViz, ALZ Resource Graph queries, WARA, Azure Cost, FinOps Signals, Application Insights, Azure Load Testing, Defender for Cloud) and writes findings to `output\` plus `report.html` and `report.md`.
 
 ### 2. Scan a remote GitHub repository for CI/CD and secret hygiene
 
@@ -63,7 +63,7 @@ The HTML report includes an executive Summary tab, a severity-by-resource-group 
 
 ## What you get
 
-- **28 tools** across Azure resources, Entra ID, GitHub, and Azure DevOps.
+- **29 tools** across Azure resources, Entra ID, GitHub, and Azure DevOps.
 - **Unified v2 schema** with 5 severity levels (Critical, High, Medium, Low, Info) and 14 entity types across 4 platforms (Azure, Entra, GitHub, ADO).
 - **Read-only everywhere.** No write permissions on any cloud. See [PERMISSIONS.md](PERMISSIONS.md) for exact scopes.
 - **HTML + Markdown reports** with executive summary, heatmap, filtering, control-framework chips, and CSV export.
@@ -80,6 +80,7 @@ The three quickstart scenarios above are the common path. The consumer index in 
 - GitHub Enterprise (GHEC-DR / GHES) targeting
 - Azure DevOps Services and Azure DevOps Server pipeline, service-connection, and repo-secret posture
 - Sentinel coverage and active incidents
+- Application Insights performance signals (slow requests, dependency failures, exception clusters)
 - Azure Load Testing failed and regressed runs
 - AKS runtime posture (kubescape, falco, kube-bench)
 - Multi-tenant fan-out for MSPs and large enterprises
@@ -92,7 +93,7 @@ All tools run **read-only**. Most common scopes:
 
 | Scope | Used by |
 |-------|---------|
-| Azure **Reader** | azqr, PSRule, AzGovViz, ALZ Queries, WARA, Azure Cost, FinOps Signals, Defender for Cloud |
+| Azure **Reader** | azqr, PSRule, AzGovViz, ALZ Queries, WARA, Azure Cost, FinOps Signals, App Insights, Defender for Cloud |
 | **Cost Management Reader** (recommended) | FinOps Signals, Azure Cost |
 | Microsoft **Graph** (read) | Maester (Entra ID) |
 | **GitHub PAT** (optional) | Scorecard, remote repo scans |

--- a/docs/consumer/README.md
+++ b/docs/consumer/README.md
@@ -8,6 +8,7 @@ All advanced consumer docs live here. The root `README.md` is your starting poin
 - [ai-triage.md](ai-triage.md) - AI-assisted finding triage workflow and prompt design.
 - [gitleaks-pattern-tuning.md](gitleaks-pattern-tuning.md) - Tuning gitleaks rule patterns to cut false positives.
 - [k8s-auth.md](k8s-auth.md) - Targeting Kubernetes wrappers (kubescape, falco, kube-bench) with explicit `-KubeconfigPath` / `-KubeContext` / per-tool namespace params.
+- [permissions/appinsights.md](permissions/appinsights.md) - Application Insights performance KQL signals (slow requests, dependency failures, exception clusters).
 - [permissions/loadtesting.md](permissions/loadtesting.md) - Azure Load Testing failed-run and regression permissions and usage.
 - [sinks/log-analytics.md](sinks/log-analytics.md) - Streaming azure-analyzer findings into Azure Log Analytics.
 - Cost and FinOps tools are listed in [tool-catalog.md](tool-catalog.md); permission details are in [permissions/](permissions/README.md).

--- a/docs/consumer/permissions/appinsights.md
+++ b/docs/consumer/permissions/appinsights.md
@@ -1,0 +1,49 @@
+# Application Insights Performance Signals - Required Permissions
+
+**Display name:** Application Insights Performance Signals
+
+**Scope:** subscription | **Provider:** azure
+
+The Application Insights wrapper discovers `Microsoft.Insights/components` resources and runs read-only KQL against telemetry tables (`requests`, `dependencies`, `exceptions`) to detect slow endpoints, dependency failures, and high-volume exception clusters.
+
+## Required roles
+
+| Token / scope | Why |
+|---|---|
+| **Reader** on the Application Insights component, resource group, or subscription | Required to discover App Insights resources and read resource metadata |
+| **Log Analytics Reader** (workspace-based components) | Required to query telemetry when the component is linked to a workspace |
+
+Reader plus Log Analytics Reader is sufficient for this wrapper. It performs no write actions.
+
+## API and query surfaces used (read-only)
+
+- ARM discovery: `Microsoft.Insights/components` (list/get)
+- App Insights query APIs via Az cmdlets:
+  - `Invoke-AzApplicationInsightsQuery`
+  - `Invoke-AzOperationalInsightsQuery` fallback (workspace-backed)
+- Telemetry tables: `requests`, `dependencies`, `exceptions`
+
+## Parameters
+
+- `-SubscriptionId <guid>` (required)
+- `-ResourceGroup <name>` (optional filter)
+- `-AppInsightsName <name>` (optional filter)
+- `-TimeRangeHours <int>` (default `24`)
+
+## Sample command
+
+```powershell
+.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "<sub-guid>" -IncludeTools 'appinsights'
+```
+
+## What it scans
+
+- Slow requests where duration exceeds 5 seconds and volume is above threshold.
+- Dependency failures where failed call count is above threshold.
+- Exception clusters where problemId count is above threshold.
+
+## What it does NOT do
+
+- No telemetry mutation.
+- No component/workspace configuration changes.
+- No write actions on Azure resources.

--- a/docs/consumer/tool-catalog.md
+++ b/docs/consumer/tool-catalog.md
@@ -8,7 +8,7 @@ Manifest schema version: `2.2`
 
 This page lists every analyzer tool azure-analyzer can run, what it covers, what scope it targets, and where to find consumer-focused setup notes when one exists. For the full manifest fields (normalizer, install kind, upstream pin, report color/phase) see [docs/contributor/tool-catalog.md](../contributor/tool-catalog.md).
 
-**Total enabled:** 28. **Disabled / opt-in:** 1.
+**Total enabled:** 29. **Disabled / opt-in:** 1.
 
 ## Enabled by default
 
@@ -19,6 +19,7 @@ This page lists every analyzer tool azure-analyzer can run, what it covers, what
 | `ado-pipelines` | ADO Pipeline Security | ado | ado | Azure DevOps pipeline-security posture (variable groups, environments, approvals). | - |
 | `ado-repos-secrets` | ADO Repos Secret Scanning | ado | ado | Secret scanning across Azure DevOps repositories via gitleaks. | [docs](./gitleaks-pattern-tuning.md) |
 | `alz-queries` | ALZ Resource Graph Queries | managementGroup | azure | ALZ Resource Graph queries: landing-zone compliance and drift detection. | - |
+| `appinsights` | Application Insights Performance Signals | subscription | azure | Application Insights telemetry signals: slow requests, dependency failures, and exception clusters via KQL. | - |
 | `azgovviz` | AzGovViz | managementGroup | azure | Azure Governance Visualizer: management-group / subscription / RBAC / policy posture. | - |
 | `azqr` | Azure Quick Review | subscription | azure | Azure best-practice review across reliability, security, cost, performance and operational excellence. | - |
 | `azure-cost` | Azure Cost (Consumption API) | subscription | azure | Per-subscription monthly Azure spend pulled from the Consumption API. | - |

--- a/docs/contributor/tool-catalog.md
+++ b/docs/contributor/tool-catalog.md
@@ -8,7 +8,7 @@ Manifest schema version: `2.2`
 
 Full manifest projection: every wired tool with normalizer, invocation, install, report, and upstream metadata. For the consumer-friendly subset see [docs/consumer/tool-catalog.md](../consumer/tool-catalog.md). To onboard a new tool follow [adding-a-tool.md](./adding-a-tool.md).
 
-**Total tools registered:** 29.
+**Total tools registered:** 30.
 
 ## Registration matrix
 
@@ -19,6 +19,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | `ado-pipelines` | ADO Pipeline Security | collector | ado | ado | Enabled | 0 | windows, macos, linux |
 | `ado-repos-secrets` | ADO Repos Secret Scanning | collector | ado | ado | Enabled | 0 | windows, macos, linux |
 | `alz-queries` | ALZ Resource Graph Queries | collector | azure | managementGroup | Enabled | 0 | windows, macos, linux |
+| `appinsights` | Application Insights Performance Signals | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
 | `azgovviz` | AzGovViz | collector | azure | managementGroup | Enabled | 0 | windows, macos, linux |
 | `azqr` | Azure Quick Review | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
 | `azure-cost` | Azure Cost (Consumption API) | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
@@ -53,6 +54,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | `ado-pipelines` | `Normalize-ADOPipelineSecurity` | script | `modules/Invoke-ADOPipelineSecurity.ps1` | AdoOrg |
 | `ado-repos-secrets` | `Normalize-ADORepoSecrets` | script | `modules/Invoke-ADORepoSecrets.ps1` | AdoOrg |
 | `alz-queries` | `Normalize-AlzQueries` | script | `modules/Invoke-AlzQueries.ps1` | SubscriptionId, ManagementGroupId |
+| `appinsights` | `Normalize-AppInsights` | script | `modules/Invoke-AppInsights.ps1` | SubscriptionId |
 | `azgovviz` | `Normalize-AzGovViz` | script | `modules/Invoke-AzGovViz.ps1` | ManagementGroupId |
 | `azqr` | `Normalize-Azqr` | script | `modules/Invoke-Azqr.ps1` | SubscriptionId |
 | `azure-cost` | `Normalize-AzureCost` | script | `modules/Invoke-AzureCost.ps1` | SubscriptionId |
@@ -87,6 +89,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | `ado-pipelines` | none | n/a | `#006064` | 2 |
 | `ado-repos-secrets` | none | n/a | `#ad1457` | 2 |
 | `alz-queries` | psmodule | Azure/Azure-Landing-Zones-Library @ HEAD | `#e65100` | 1 |
+| `appinsights` | psmodule | n/a | `#00838f` | 4 |
 | `azgovviz` | gitclone ("https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting") | JulianHayward/Azure-MG-Sub-Governance-Reporting @ HEAD | `#00838f` | 1 |
 | `azqr` | cli ("azqr") | Azure/azqr @ latest | `#1565c0` | 1 |
 | `azure-cost` | psmodule | n/a | `#388e3c` | 4 |

--- a/modules/Invoke-AppInsights.ps1
+++ b/modules/Invoke-AppInsights.ps1
@@ -1,0 +1,365 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Wrapper for Application Insights performance and reliability KQL signals.
+
+.DESCRIPTION
+    Discovers Microsoft.Insights/components resources and queries telemetry for:
+      - Slow requests
+      - Dependency failures
+      - Exception clusters
+
+    Query calls are wrapped with Invoke-WithRetry and Invoke-WithTimeout (300s).
+    Optional disk output is sanitized via Remove-Credentials before writing.
+#>
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)] [string] $SubscriptionId,
+    [string] $ResourceGroup,
+    [string] $AppInsightsName,
+    [ValidateRange(1, 168)] [int] $TimeRangeHours = 24,
+    [string] $OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$retryPath = Join-Path $PSScriptRoot 'shared' 'Retry.ps1'
+if (Test-Path $retryPath) { . $retryPath }
+if (-not (Get-Command Invoke-WithRetry -ErrorAction SilentlyContinue)) {
+    function Invoke-WithRetry { param([scriptblock]$ScriptBlock, [int]$MaxAttempts = 3) & $ScriptBlock }
+}
+
+$sanitizePath = Join-Path $PSScriptRoot 'shared' 'Sanitize.ps1'
+if (Test-Path $sanitizePath) { . $sanitizePath }
+if (-not (Get-Command Remove-Credentials -ErrorAction SilentlyContinue)) {
+    function Remove-Credentials { param([string]$Text) return $Text }
+}
+
+$installerPath = Join-Path $PSScriptRoot 'shared' 'Installer.ps1'
+if (Test-Path $installerPath) { . $installerPath }
+$timeoutCmd = Get-Command Invoke-WithTimeout -ErrorAction SilentlyContinue
+if (-not $timeoutCmd -or -not $timeoutCmd.Parameters.ContainsKey('ScriptBlock')) {
+    function Invoke-WithTimeout {
+        param(
+            [Parameter(Mandatory)] [scriptblock] $ScriptBlock,
+            [int] $TimeoutSec = 300
+        )
+        return & $ScriptBlock
+    }
+}
+
+$result = [ordered]@{
+    SchemaVersion = '1.0'
+    Source        = 'appinsights'
+    Status        = 'Success'
+    Message       = ''
+    Findings      = @()
+    Subscription  = $SubscriptionId
+    Timestamp     = (Get-Date).ToUniversalTime().ToString('o')
+}
+
+if (-not (Get-Module -ListAvailable -Name Az.Accounts)) {
+    $result.Status = 'Skipped'
+    $result.Message = 'Az.Accounts module not installed. Run: Install-Module Az.Accounts -Scope CurrentUser'
+    return [PSCustomObject]$result
+}
+
+try {
+    Import-Module Az.Accounts -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+    Import-Module Az.ApplicationInsights -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+    Import-Module Az.Monitor -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+} catch {
+    Write-Verbose "App Insights module import warning: $(Remove-Credentials -Text ([string]$_.Exception.Message))"
+}
+
+try {
+    $ctx = Get-AzContext -ErrorAction Stop
+    if (-not $ctx) { throw 'No Az context' }
+} catch {
+    $result.Status = 'Skipped'
+    $result.Message = 'Not signed in. Run Connect-AzAccount first.'
+    return [PSCustomObject]$result
+}
+
+function Get-QueryCommandName {
+    if (Get-Command Invoke-AzApplicationInsightsQuery -ErrorAction SilentlyContinue) {
+        return 'Invoke-AzApplicationInsightsQuery'
+    }
+    if (Get-Command Invoke-AzOperationalInsightsQuery -ErrorAction SilentlyContinue) {
+        return 'Invoke-AzOperationalInsightsQuery'
+    }
+    return ''
+}
+
+function Convert-AppInsightsQueryResults {
+    param([object] $QueryResult)
+
+    if ($null -eq $QueryResult) { return @() }
+    if ($QueryResult.PSObject.Properties['Results'] -and $QueryResult.Results) {
+        return @($QueryResult.Results)
+    }
+    if ($QueryResult.PSObject.Properties['value'] -and $QueryResult.value) {
+        return @($QueryResult.value)
+    }
+    if ($QueryResult.PSObject.Properties['Tables'] -and $QueryResult.Tables -and $QueryResult.Tables.Count -gt 0) {
+        $table = $QueryResult.Tables[0]
+        $columns = @($table.Columns | ForEach-Object { [string]$_.Name })
+        $rows = [System.Collections.Generic.List[object]]::new()
+        foreach ($r in @($table.Rows)) {
+            $obj = [ordered]@{}
+            for ($i = 0; $i -lt $columns.Count; $i++) {
+                $obj[$columns[$i]] = $r[$i]
+            }
+            $rows.Add([pscustomobject]$obj) | Out-Null
+        }
+        return @($rows)
+    }
+    return @()
+}
+
+function ConvertTo-DurationSeconds {
+    param([object] $Value)
+
+    if ($null -eq $Value) { return 0.0 }
+    if ($Value -is [timespan]) { return [math]::Round($Value.TotalSeconds, 3) }
+    if ($Value -is [double] -or $Value -is [single] -or $Value -is [int] -or $Value -is [long]) {
+        return [math]::Round([double]$Value, 3)
+    }
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text)) { return 0.0 }
+    $ts = [timespan]::Zero
+    if ([timespan]::TryParse($text, [ref]$ts)) {
+        return [math]::Round($ts.TotalSeconds, 3)
+    }
+    $seconds = 0.0
+    if ([double]::TryParse($text, [ref]$seconds)) {
+        return [math]::Round($seconds, 3)
+    }
+    return 0.0
+}
+
+function Invoke-AppInsightsQuery {
+    param(
+        [Parameter(Mandatory)] [string] $CommandName,
+        [Parameter(Mandatory)] [pscustomobject] $Resource,
+        [Parameter(Mandatory)] [string] $QueryText,
+        [Parameter(Mandatory)] [timespan] $QueryTimeSpan
+    )
+
+    return Invoke-WithRetry -MaxAttempts 4 -InitialDelaySeconds 2 -MaxDelaySeconds 30 -ScriptBlock {
+        Invoke-WithTimeout -TimeoutSec 300 -ScriptBlock {
+            if ($CommandName -eq 'Invoke-AzApplicationInsightsQuery') {
+                $cmd = Get-Command Invoke-AzApplicationInsightsQuery -ErrorAction Stop
+                $splat = @{
+                    Query       = $QueryText
+                    ErrorAction = 'Stop'
+                }
+                if ($cmd.Parameters.ContainsKey('AppInsightsName')) {
+                    $splat['AppInsightsName'] = $Resource.Name
+                } elseif ($cmd.Parameters.ContainsKey('ApplicationInsightsName')) {
+                    $splat['ApplicationInsightsName'] = $Resource.Name
+                } elseif ($cmd.Parameters.ContainsKey('Name')) {
+                    $splat['Name'] = $Resource.Name
+                }
+                if ($cmd.Parameters.ContainsKey('ResourceGroupName')) {
+                    $splat['ResourceGroupName'] = $Resource.ResourceGroup
+                }
+                if ($cmd.Parameters.ContainsKey('TimeSpan')) {
+                    $splat['TimeSpan'] = $QueryTimeSpan
+                } elseif ($cmd.Parameters.ContainsKey('Timespan')) {
+                    $splat['Timespan'] = $QueryTimeSpan
+                }
+                return Invoke-AzApplicationInsightsQuery @splat
+            }
+
+            if ([string]::IsNullOrWhiteSpace([string]$Resource.WorkspaceId)) {
+                throw "Resource '$($Resource.Name)' is missing WorkspaceId for Invoke-AzOperationalInsightsQuery fallback."
+            }
+            return Invoke-AzOperationalInsightsQuery -WorkspaceId $Resource.WorkspaceId -Query $QueryText -Timespan $QueryTimeSpan -ErrorAction Stop
+        }
+    }
+}
+
+function Add-AppInsightsFinding {
+    param(
+        [System.Collections.Generic.List[object]] $Collection,
+        [string] $Id,
+        [string] $Severity,
+        [bool] $Compliant,
+        [string] $Title,
+        [string] $Detail,
+        [string] $ResourceId,
+        [string] $QueryType,
+        [hashtable] $Extras
+    )
+
+    $row = [ordered]@{
+        Id           = $Id
+        Source       = 'appinsights'
+        Category     = 'Performance'
+        Severity     = $Severity
+        Compliant    = $Compliant
+        Title        = $Title
+        Detail       = $Detail
+        Remediation  = 'Investigate telemetry trends, correlate with recent changes, and tune performance budgets and alerts.'
+        ResourceId   = $ResourceId
+        LearnMoreUrl = "https://portal.azure.com/#@/resource$ResourceId/overview"
+        QueryType    = $QueryType
+    }
+    if ($Extras) {
+        foreach ($key in $Extras.Keys) {
+            $row[$key] = $Extras[$key]
+        }
+    }
+    $Collection.Add([pscustomobject]$row) | Out-Null
+}
+
+try {
+    $commandName = Get-QueryCommandName
+    if (-not $commandName) {
+        $result.Status = 'Skipped'
+        $result.Message = 'No App Insights query cmdlet available. Install Az.ApplicationInsights or Az.Monitor.'
+        return [PSCustomObject]$result
+    }
+
+    $apiVersion = '2020-02-02'
+    $resourceUri = if ($ResourceGroup -and $AppInsightsName) {
+        "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$([System.Uri]::EscapeDataString($ResourceGroup))/providers/Microsoft.Insights/components/$([System.Uri]::EscapeDataString($AppInsightsName))?api-version=$apiVersion"
+    } elseif ($ResourceGroup) {
+        "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$([System.Uri]::EscapeDataString($ResourceGroup))/providers/Microsoft.Insights/components?api-version=$apiVersion"
+    } else {
+        "https://management.azure.com/subscriptions/$SubscriptionId/providers/Microsoft.Insights/components?api-version=$apiVersion"
+    }
+
+    $discoveryResponse = Invoke-WithRetry -MaxAttempts 4 -InitialDelaySeconds 2 -MaxDelaySeconds 30 -ScriptBlock {
+        Invoke-AzRestMethod -Method GET -Uri $resourceUri -ErrorAction Stop
+    }
+    if (-not $discoveryResponse -or $discoveryResponse.StatusCode -ge 400) {
+        throw "App Insights discovery failed (HTTP $($discoveryResponse.StatusCode)): $($discoveryResponse.Content)"
+    }
+    $payload = $discoveryResponse.Content | ConvertFrom-Json -Depth 30
+    $resourceItems = if ($payload.PSObject.Properties['value']) { @($payload.value) } else { @($payload) }
+    if ($AppInsightsName -and -not $ResourceGroup) {
+        $resourceItems = @($resourceItems | Where-Object { ([string]$_.name) -ieq $AppInsightsName })
+    }
+
+    if ($resourceItems.Count -eq 0) {
+        $result.Status = 'Skipped'
+        $result.Message = 'No Application Insights resources found in the requested scope.'
+        return [pscustomobject]$result
+    }
+
+    $querySpan = [timespan]::FromHours($TimeRangeHours)
+    $slowRequestQuery = "requests | where timestamp > ago($($TimeRangeHours)h) | where duration > 5s | summarize count(), avg(duration) by name | where count_ > 10"
+    $dependencyFailureQuery = "dependencies | where timestamp > ago($($TimeRangeHours)h) | where success == false | summarize count() by name, type | where count_ > 5"
+    $exceptionRateQuery = "exceptions | where timestamp > ago($($TimeRangeHours)h) | summarize count() by problemId | where count_ > 50"
+
+    $findings = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($item in $resourceItems) {
+        $resourceId = [string]$item.id
+        $name = [string]$item.name
+        if (-not $resourceId -or -not $name) { continue }
+        $rg = if ($resourceId -match '/resourceGroups/([^/]+)') { $Matches[1] } else { '' }
+        $workspaceId = ''
+        if ($item.PSObject.Properties['properties'] -and $item.properties) {
+            if ($item.properties.PSObject.Properties['WorkspaceResourceId']) {
+                $workspaceId = [string]$item.properties.WorkspaceResourceId
+            } elseif ($item.properties.PSObject.Properties['workspaceResourceId']) {
+                $workspaceId = [string]$item.properties.workspaceResourceId
+            }
+        }
+        $resourceRef = [pscustomobject]@{
+            Name          = $name
+            ResourceGroup = $rg
+            ResourceId    = $resourceId
+            WorkspaceId   = $workspaceId
+        }
+
+        $slowRows = @(Convert-AppInsightsQueryResults (Invoke-AppInsightsQuery -CommandName $commandName -Resource $resourceRef -QueryText $slowRequestQuery -QueryTimeSpan $querySpan))
+        foreach ($row in $slowRows) {
+            $requestName = [string]$row.name
+            if ([string]::IsNullOrWhiteSpace($requestName)) { $requestName = 'unknown-request' }
+            $count = 0
+            if ($row.PSObject.Properties['count_'] -and $row.count_ -ne $null) { $count = [int]$row.count_ }
+            if ($count -le 10) { continue }
+            $avgSeconds = ConvertTo-DurationSeconds -Value $(if ($row.PSObject.Properties['avg_duration']) { $row.avg_duration } elseif ($row.PSObject.Properties['avg_duration_']) { $row.avg_duration_ } elseif ($row.PSObject.Properties['average_duration']) { $row.average_duration } else { $null })
+            $severity = if ($avgSeconds -gt 30) { 'High' } else { 'Medium' }
+            Add-AppInsightsFinding -Collection $findings `
+                -Id "appinsights/$name/requests/$([System.Uri]::EscapeDataString($requestName))" `
+                -Severity $severity -Compliant $false `
+                -Title "Slow request signal for '$requestName'" `
+                -Detail "Request '$requestName' averaged $avgSeconds second(s) across $count call(s) in the last $TimeRangeHours hour(s)." `
+                -ResourceId $resourceId -QueryType 'requests' `
+                -Extras @{
+                    RequestName         = $requestName
+                    Count               = $count
+                    AvgDurationSeconds  = $avgSeconds
+                    TimeRangeHours      = $TimeRangeHours
+                }
+        }
+
+        $dependencyRows = @(Convert-AppInsightsQueryResults (Invoke-AppInsightsQuery -CommandName $commandName -Resource $resourceRef -QueryText $dependencyFailureQuery -QueryTimeSpan $querySpan))
+        foreach ($row in $dependencyRows) {
+            $depName = [string]$row.name
+            if ([string]::IsNullOrWhiteSpace($depName)) { $depName = 'unknown-dependency' }
+            $depType = [string]$row.type
+            if ([string]::IsNullOrWhiteSpace($depType)) { $depType = 'unknown' }
+            $count = 0
+            if ($row.PSObject.Properties['count_'] -and $row.count_ -ne $null) { $count = [int]$row.count_ }
+            if ($count -le 5) { continue }
+            Add-AppInsightsFinding -Collection $findings `
+                -Id "appinsights/$name/dependencies/$([System.Uri]::EscapeDataString($depName))/$([System.Uri]::EscapeDataString($depType))" `
+                -Severity 'Medium' -Compliant $false `
+                -Title "Dependency failure signal for '$depName'" `
+                -Detail "Dependency '$depName' ($depType) failed $count time(s) in the last $TimeRangeHours hour(s)." `
+                -ResourceId $resourceId -QueryType 'dependencies' `
+                -Extras @{
+                    DependencyName      = $depName
+                    DependencyType      = $depType
+                    Count               = $count
+                    TimeRangeHours      = $TimeRangeHours
+                }
+        }
+
+        $exceptionRows = @(Convert-AppInsightsQueryResults (Invoke-AppInsightsQuery -CommandName $commandName -Resource $resourceRef -QueryText $exceptionRateQuery -QueryTimeSpan $querySpan))
+        foreach ($row in $exceptionRows) {
+            $problemId = [string]$row.problemId
+            if ([string]::IsNullOrWhiteSpace($problemId)) { $problemId = 'unknown-problem' }
+            $count = 0
+            if ($row.PSObject.Properties['count_'] -and $row.count_ -ne $null) { $count = [int]$row.count_ }
+            if ($count -le 50) { continue }
+            Add-AppInsightsFinding -Collection $findings `
+                -Id "appinsights/$name/exceptions/$([System.Uri]::EscapeDataString($problemId))" `
+                -Severity 'High' -Compliant $false `
+                -Title "Exception cluster signal for '$problemId'" `
+                -Detail "Exception problemId '$problemId' occurred $count time(s) in the last $TimeRangeHours hour(s)." `
+                -ResourceId $resourceId -QueryType 'exceptions' `
+                -Extras @{
+                    ProblemId           = $problemId
+                    Count               = $count
+                    TimeRangeHours      = $TimeRangeHours
+                }
+        }
+    }
+
+    $result.Findings = @($findings)
+    $result.Message = "Scanned Application Insights telemetry for the last $TimeRangeHours hour(s); emitted $($findings.Count) finding(s)."
+} catch {
+    $result.Status = 'Failed'
+    $result.Message = "Application Insights query failed: $(Remove-Credentials -Text ([string]$_.Exception.Message))"
+    return [pscustomobject]$result
+}
+
+if ($OutputPath) {
+    try {
+        if (-not (Test-Path $OutputPath)) { New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null }
+        $raw = Join-Path $OutputPath "appinsights-$SubscriptionId-$(Get-Date -Format yyyyMMddHHmmss).json"
+        Set-Content -Path $raw -Value (Remove-Credentials ($result | ConvertTo-Json -Depth 30)) -Encoding utf8
+    } catch {
+        Write-Warning "Failed to write App Insights raw JSON: $(Remove-Credentials -Text ([string]$_.Exception.Message))"
+    }
+}
+
+return [pscustomobject]$result

--- a/modules/normalizers/Normalize-AppInsights.ps1
+++ b/modules/normalizers/Normalize-AppInsights.ps1
@@ -1,0 +1,134 @@
+#Requires -Version 7.4
+[CmdletBinding()]
+param ()
+
+. "$PSScriptRoot\..\shared\Schema.ps1"
+. "$PSScriptRoot\..\shared\Canonicalize.ps1"
+
+function Get-AppInsightsSeverity {
+    param([pscustomobject] $Finding)
+
+    $queryType = if ($Finding.PSObject.Properties['QueryType']) { [string]$Finding.QueryType } else { '' }
+    if ($queryType -eq 'requests') {
+        $avg = 0.0
+        if ($Finding.PSObject.Properties['AvgDurationSeconds']) { $avg = [double]$Finding.AvgDurationSeconds }
+        if ($avg -gt 30) { return 'High' }
+        if ($avg -gt 5) { return 'Medium' }
+        return 'Low'
+    }
+    if ($queryType -eq 'exceptions') { return 'High' }
+    if ($queryType -eq 'dependencies') { return 'Medium' }
+
+    switch -Regex ([string]$Finding.Severity) {
+        '^(?i)critical$' { 'Critical' }
+        '^(?i)high$'     { 'High' }
+        '^(?i)medium$'   { 'Medium' }
+        '^(?i)low$'      { 'Low' }
+        default          { 'Info' }
+    }
+}
+
+function Get-AppInsightsTitle {
+    param([pscustomobject] $Finding)
+
+    $queryType = if ($Finding.PSObject.Properties['QueryType']) { [string]$Finding.QueryType } else { '' }
+    $count = if ($Finding.PSObject.Properties['Count']) { [int]$Finding.Count } else { 0 }
+
+    switch ($queryType) {
+        'requests' {
+            $name = if ($Finding.PSObject.Properties['RequestName']) { [string]$Finding.RequestName } else { 'unknown-request' }
+            $avg = if ($Finding.PSObject.Properties['AvgDurationSeconds']) { [math]::Round([double]$Finding.AvgDurationSeconds, 3) } else { 0 }
+            return "Slow request: $name avg $avg`s over $count calls"
+        }
+        'dependencies' {
+            $name = if ($Finding.PSObject.Properties['DependencyName']) { [string]$Finding.DependencyName } else { 'unknown-dependency' }
+            $type = if ($Finding.PSObject.Properties['DependencyType']) { [string]$Finding.DependencyType } else { 'unknown' }
+            return "Dependency failures: $name ($type) failed $count times"
+        }
+        'exceptions' {
+            $problem = if ($Finding.PSObject.Properties['ProblemId']) { [string]$Finding.ProblemId } else { 'unknown-problem' }
+            return "Exception cluster: $problem hit $count times"
+        }
+        default {
+            if ($Finding.PSObject.Properties['Title'] -and $Finding.Title) { return [string]$Finding.Title }
+            return 'Application Insights finding'
+        }
+    }
+}
+
+function Get-AppInsightsLearnMoreUrl {
+    param([pscustomobject] $Finding)
+
+    if ($Finding.PSObject.Properties['LearnMoreUrl'] -and ([string]$Finding.LearnMoreUrl).StartsWith('https://', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return [string]$Finding.LearnMoreUrl
+    }
+
+    $resourceId = if ($Finding.PSObject.Properties['ResourceId']) { [string]$Finding.ResourceId } else { '' }
+    if ([string]::IsNullOrWhiteSpace($resourceId)) { return 'https://portal.azure.com/' }
+
+    $timeRangeHours = if ($Finding.PSObject.Properties['TimeRangeHours']) { [int]$Finding.TimeRangeHours } else { 24 }
+    $query = switch ([string]$Finding.QueryType) {
+        'requests'     { "requests | where timestamp > ago($($timeRangeHours)h)" }
+        'dependencies' { "dependencies | where timestamp > ago($($timeRangeHours)h) | where success == false" }
+        'exceptions'   { "exceptions | where timestamp > ago($($timeRangeHours)h)" }
+        default        { "traces | where timestamp > ago($($timeRangeHours)h)" }
+    }
+    $encodedQuery = [System.Uri]::EscapeDataString($query)
+    return "https://portal.azure.com/#@/resource$resourceId/logs?timespan=PT$($timeRangeHours)H&query=$encodedQuery"
+}
+
+function Normalize-AppInsights {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [PSCustomObject] $ToolResult
+    )
+
+    if ($ToolResult.Status -ne 'Success' -or -not $ToolResult.Findings) {
+        return @()
+    }
+
+    $runId = [guid]::NewGuid().ToString()
+    $normalized = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    foreach ($f in $ToolResult.Findings) {
+        $rawId = if ($f.PSObject.Properties['ResourceId'] -and $f.ResourceId) { [string]$f.ResourceId } else { '' }
+        if (-not $rawId) { continue }
+
+        $subId = ''
+        $rg = ''
+        if ($rawId -match '/subscriptions/([^/]+)') { $subId = $Matches[1] }
+        if ($rawId -match '/resourceGroups/([^/]+)') { $rg = $Matches[1] }
+
+        try {
+            $canonicalId = (ConvertTo-CanonicalEntityId -RawId $rawId -EntityType 'AzureResource').CanonicalId
+        } catch {
+            $canonicalId = $rawId.ToLowerInvariant()
+        }
+
+        $row = New-FindingRow -Id $(if ($f.PSObject.Properties['Id']) { [string]$f.Id } else { [guid]::NewGuid().ToString() }) `
+            -Source $(if ($f.PSObject.Properties['Source']) { [string]$f.Source } else { 'appinsights' }) `
+            -EntityId $canonicalId -EntityType 'AzureResource' `
+            -Title (Get-AppInsightsTitle -Finding $f) `
+            -Compliant $(if ($f.PSObject.Properties['Compliant']) { [bool]$f.Compliant } else { $false }) `
+            -ProvenanceRunId $runId -Platform 'Azure' `
+            -Category $(if ($f.PSObject.Properties['Category']) { [string]$f.Category } else { 'Performance' }) `
+            -Severity (Get-AppInsightsSeverity -Finding $f) `
+            -Detail $(if ($f.PSObject.Properties['Detail']) { [string]$f.Detail } else { '' }) `
+            -Remediation $(if ($f.PSObject.Properties['Remediation']) { [string]$f.Remediation } else { '' }) `
+            -LearnMoreUrl (Get-AppInsightsLearnMoreUrl -Finding $f) `
+            -ResourceId $rawId -SubscriptionId $subId -ResourceGroup $rg
+
+        if ($null -eq $row) { continue }
+
+        foreach ($extra in @('QueryType', 'RequestName', 'DependencyName', 'DependencyType', 'ProblemId', 'Count', 'AvgDurationSeconds', 'TimeRangeHours')) {
+            if ($f.PSObject.Properties[$extra] -and $null -ne $f.$extra) {
+                $row | Add-Member -NotePropertyName $extra -NotePropertyValue $f.$extra -Force
+            }
+        }
+
+        $normalized.Add($row)
+    }
+
+    return @($normalized)
+}

--- a/queries/appinsights-dependency-failures.json
+++ b/queries/appinsights-dependency-failures.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "name": "App Insights - Dependency failures",
+    "description": "Find dependency targets with repeated failed calls over the selected lookback window.",
+    "version": "1.0.0"
+  },
+  "queries": [
+    {
+      "guid": "466f1969-b8d1-4a9d-b36d-662ef2ef3ac6",
+      "category": "Performance",
+      "subcategory": "Dependencies",
+      "severity": "Medium",
+      "text": "Dependencies with more than 5 failed calls",
+      "queryable": true,
+      "kql": "dependencies | where timestamp > ago(24h) | where success == false | summarize count() by name, type | where count_ > 5 | extend compliant = false"
+    }
+  ]
+}

--- a/queries/appinsights-exception-rate.json
+++ b/queries/appinsights-exception-rate.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "name": "App Insights - Exception clusters",
+    "description": "Find exception problem IDs with high frequency over the selected lookback window.",
+    "version": "1.0.0"
+  },
+  "queries": [
+    {
+      "guid": "7e6cbfa1-8756-4548-bb8f-e9f4d40eb625",
+      "category": "Performance",
+      "subcategory": "Exceptions",
+      "severity": "High",
+      "text": "Exception clusters with more than 50 occurrences",
+      "queryable": true,
+      "kql": "exceptions | where timestamp > ago(24h) | summarize count() by problemId | where count_ > 50 | extend compliant = false"
+    }
+  ]
+}

--- a/queries/appinsights-slow-requests.json
+++ b/queries/appinsights-slow-requests.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "name": "App Insights - Slow requests",
+    "description": "Find request operations with sustained slow duration over the selected lookback window.",
+    "version": "1.0.0"
+  },
+  "queries": [
+    {
+      "guid": "f13e1f90-a2de-4b04-9d3b-4df39efcc4f0",
+      "category": "Performance",
+      "subcategory": "Requests",
+      "severity": "Medium",
+      "text": "Request operations averaging over 5 seconds with more than 10 calls",
+      "queryable": true,
+      "kql": "requests | where timestamp > ago(24h) | where duration > 5s | summarize count(), avg(duration) by name | where count_ > 10 | extend compliant = false"
+    }
+  ]
+}

--- a/scripts/Generate-ToolCatalog.ps1
+++ b/scripts/Generate-ToolCatalog.ps1
@@ -92,6 +92,7 @@ $consumerDocLinks = @{
 # absent so the catalog never ships an empty cell.
 $consumerBlurb = @{
     'azqr'                     = 'Azure best-practice review across reliability, security, cost, performance and operational excellence.'
+    'appinsights'              = 'Application Insights telemetry signals: slow requests, dependency failures, and exception clusters via KQL.'
     'kubescape'                = 'Runtime posture for AKS clusters: misconfigurations, RBAC, network policies, vulnerabilities.'
     'kube-bench'               = 'CIS Kubernetes benchmark for AKS node hardening.'
     'defender-for-cloud'       = 'Pulls Microsoft Defender for Cloud Secure Score and active recommendations per subscription.'

--- a/tests/fixtures/appinsights/appinsights-output.json
+++ b/tests/fixtures/appinsights/appinsights-output.json
@@ -1,0 +1,81 @@
+{
+  "Source": "appinsights",
+  "SchemaVersion": "1.0",
+  "Status": "Success",
+  "Message": "fixture",
+  "Findings": [
+    {
+      "Id": "appinsights/appi-prod/requests/get-orders",
+      "Source": "appinsights",
+      "Category": "Performance",
+      "Severity": "Medium",
+      "Compliant": false,
+      "Detail": "Request GET /orders was slow.",
+      "ResourceId": "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/perf-rg/providers/Microsoft.Insights/components/appi-prod",
+      "LearnMoreUrl": "",
+      "QueryType": "requests",
+      "RequestName": "GET /orders",
+      "Count": 22,
+      "AvgDurationSeconds": 31.2,
+      "TimeRangeHours": 24
+    },
+    {
+      "Id": "appinsights/appi-prod/requests/get-catalog",
+      "Source": "appinsights",
+      "Category": "Performance",
+      "Severity": "Medium",
+      "Compliant": false,
+      "Detail": "Request GET /catalog was slow.",
+      "ResourceId": "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/perf-rg/providers/Microsoft.Insights/components/appi-prod",
+      "LearnMoreUrl": "",
+      "QueryType": "requests",
+      "RequestName": "GET /catalog",
+      "Count": 12,
+      "AvgDurationSeconds": 29.9,
+      "TimeRangeHours": 24
+    },
+    {
+      "Id": "appinsights/appi-prod/dependencies/sql",
+      "Source": "appinsights",
+      "Category": "Performance",
+      "Severity": "Medium",
+      "Compliant": false,
+      "Detail": "SQL dependency failed repeatedly.",
+      "ResourceId": "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/perf-rg/providers/Microsoft.Insights/components/appi-prod",
+      "LearnMoreUrl": "",
+      "QueryType": "dependencies",
+      "DependencyName": "sql-prod",
+      "DependencyType": "SQL",
+      "Count": 7,
+      "TimeRangeHours": 24
+    },
+    {
+      "Id": "appinsights/appi-prod/exceptions/nullref",
+      "Source": "appinsights",
+      "Category": "Performance",
+      "Severity": "High",
+      "Compliant": false,
+      "Detail": "Null reference spikes observed.",
+      "ResourceId": "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/perf-rg/providers/Microsoft.Insights/components/appi-prod",
+      "LearnMoreUrl": "",
+      "QueryType": "exceptions",
+      "ProblemId": "NullReferenceException",
+      "Count": 88,
+      "TimeRangeHours": 24
+    },
+    {
+      "Id": "appinsights/appi-prod/exceptions/timeout",
+      "Source": "appinsights",
+      "Category": "Performance",
+      "Severity": "High",
+      "Compliant": false,
+      "Detail": "Timeout spikes observed.",
+      "ResourceId": "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/perf-rg/providers/Microsoft.Insights/components/appi-prod",
+      "LearnMoreUrl": "",
+      "QueryType": "exceptions",
+      "ProblemId": "TimeoutException",
+      "Count": 51,
+      "TimeRangeHours": 24
+    }
+  ]
+}

--- a/tests/normalizers/Normalize-AppInsights.Tests.ps1
+++ b/tests/normalizers/Normalize-AppInsights.Tests.ps1
@@ -1,0 +1,49 @@
+Describe 'Normalize-AppInsights' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..' '..' 'modules' 'normalizers' 'Normalize-AppInsights.ps1')
+        $script:Fixture = Get-Content (Join-Path $PSScriptRoot '..' 'fixtures' 'appinsights' 'appinsights-output.json') -Raw | ConvertFrom-Json
+    }
+
+    It 'returns empty when Status is not Success' {
+        $rows = @(Normalize-AppInsights -ToolResult ([pscustomobject]@{ Status = 'Skipped'; Findings = @() }))
+        $rows.Count | Should -Be 0
+    }
+
+    It 'emits one FindingRow per fixture finding' {
+        $rows = @(Normalize-AppInsights -ToolResult $script:Fixture)
+        $rows.Count | Should -Be 5
+    }
+
+    It 'maps to AzureResource entity type and Azure platform' {
+        $rows = @(Normalize-AppInsights -ToolResult $script:Fixture)
+        foreach ($row in $rows) {
+            $row.EntityType | Should -Be 'AzureResource'
+            $row.Platform | Should -Be 'Azure'
+            $row.Source | Should -Be 'appinsights'
+        }
+    }
+
+    It 'applies severity boundaries for slow requests and fixed severities for other query types' {
+        $rows = @(Normalize-AppInsights -ToolResult $script:Fixture)
+        ($rows | Where-Object { $_.Id -eq 'appinsights/appi-prod/requests/get-orders' }).Severity | Should -Be 'High'
+        ($rows | Where-Object { $_.Id -eq 'appinsights/appi-prod/requests/get-catalog' }).Severity | Should -Be 'Medium'
+        ($rows | Where-Object { $_.Id -eq 'appinsights/appi-prod/dependencies/sql' }).Severity | Should -Be 'Medium'
+        ($rows | Where-Object { $_.Id -eq 'appinsights/appi-prod/exceptions/nullref' }).Severity | Should -Be 'High'
+    }
+
+    It 'builds expected title patterns' {
+        $rows = @(Normalize-AppInsights -ToolResult $script:Fixture)
+        ($rows | Where-Object { $_.Id -eq 'appinsights/appi-prod/requests/get-orders' }).Title | Should -Be 'Slow request: GET /orders avg 31.2s over 22 calls'
+        ($rows | Where-Object { $_.Id -eq 'appinsights/appi-prod/dependencies/sql' }).Title | Should -Be 'Dependency failures: sql-prod (SQL) failed 7 times'
+        ($rows | Where-Object { $_.Id -eq 'appinsights/appi-prod/exceptions/nullref' }).Title | Should -Be 'Exception cluster: NullReferenceException hit 88 times'
+    }
+
+    It 'sets HTTPS portal deep links with query and timespan' {
+        $rows = @(Normalize-AppInsights -ToolResult $script:Fixture)
+        foreach ($row in $rows) {
+            $row.LearnMoreUrl | Should -Match '^https://portal\.azure\.com/'
+            $row.LearnMoreUrl | Should -Match 'timespan=PT24H'
+        }
+        ($rows | Where-Object { $_.Id -eq 'appinsights/appi-prod/requests/get-orders' }).LearnMoreUrl | Should -Match 'requests%20%7C%20where%20timestamp'
+    }
+}

--- a/tests/wrappers/Invoke-AppInsights.Tests.ps1
+++ b/tests/wrappers/Invoke-AppInsights.Tests.ps1
@@ -1,0 +1,193 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    $script:Here = Split-Path $PSCommandPath -Parent
+    $script:RepoRoot = Resolve-Path (Join-Path $script:Here '..' '..')
+    $script:Wrapper = Join-Path $script:RepoRoot 'modules' 'Invoke-AppInsights.ps1'
+    $script:SubId = '00000000-0000-0000-0000-000000000000'
+    $script:AppId = "/subscriptions/$($script:SubId)/resourceGroups/perf-rg/providers/Microsoft.Insights/components/appi-prod"
+}
+
+Describe 'Invoke-AppInsights' {
+    BeforeEach {
+        $global:TestAppId = $script:AppId
+        $global:TestSubId = $script:SubId
+        $global:CapturedUris = [System.Collections.Generic.List[string]]::new()
+        $global:CapturedTimeSpans = [System.Collections.Generic.List[double]]::new()
+        $global:RequestQueryCalls = 0
+
+        function global:Get-Module {
+            [CmdletBinding()]
+            param([string] $Name, [switch] $ListAvailable)
+            [pscustomobject]@{ Name = 'Az.Accounts' }
+        }
+        function global:Get-AzContext {
+            [CmdletBinding()]
+            param()
+            [pscustomobject]@{ Account = 'user@test.com' }
+        }
+        function global:Import-Module {
+            [CmdletBinding()]
+            param([string] $Name)
+        }
+        function global:Start-Sleep { param([int] $Seconds) }
+    }
+
+    AfterEach {
+        foreach ($fn in @('Get-Module', 'Get-AzContext', 'Import-Module', 'Invoke-AzRestMethod', 'Invoke-AzApplicationInsightsQuery', 'Invoke-AzOperationalInsightsQuery', 'Start-Sleep')) {
+            if (Test-Path "Function:\global:$fn") {
+                Remove-Item "Function:\global:$fn" -ErrorAction SilentlyContinue
+            }
+        }
+        foreach ($v in @('CapturedUris', 'CapturedTimeSpans', 'RequestQueryCalls')) {
+            Remove-Variable -Name $v -Scope Global -ErrorAction SilentlyContinue
+        }
+        Remove-Variable -Name TestAppId -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name TestSubId -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    It 'returns Skipped when Az.Accounts module is missing' {
+        function global:Get-Module {
+            [CmdletBinding()]
+            param([string] $Name, [switch] $ListAvailable)
+            $null
+        }
+        $result = & $script:Wrapper -SubscriptionId $script:SubId
+        $result.Status | Should -Be 'Skipped'
+        $result.Message | Should -Match 'Az.Accounts'
+    }
+
+    It 'discovers resources and emits all three query finding types' {
+        function global:Invoke-AzRestMethod {
+            [CmdletBinding()]
+            param($Method, $Uri)
+            $global:CapturedUris.Add([string]$Uri) | Out-Null
+            [pscustomobject]@{
+                StatusCode = 200
+                Content    = (@{
+                        value = @(
+                            @{
+                                id = $global:TestAppId
+                                name = 'appi-prod'
+                                properties = @{
+                                    WorkspaceResourceId = "/subscriptions/$($global:TestSubId)/resourceGroups/perf-rg/providers/Microsoft.OperationalInsights/workspaces/ws1"
+                                }
+                            }
+                        )
+                    } | ConvertTo-Json -Depth 10)
+            }
+        }
+
+        function global:Invoke-AzApplicationInsightsQuery {
+            [CmdletBinding()]
+            param(
+                [string] $ResourceGroupName,
+                [string] $Name,
+                [string] $Query,
+                [timespan] $TimeSpan
+            )
+            $global:CapturedTimeSpans.Add($TimeSpan.TotalHours) | Out-Null
+
+            if ($Query -match '^requests') {
+                return [pscustomobject]@{
+                    Results = @(
+                        [pscustomobject]@{ name = 'GET /orders'; count_ = 12; avg_duration = '00:00:06' }
+                    )
+                }
+            }
+            if ($Query -match '^dependencies') {
+                return [pscustomobject]@{
+                    Results = @(
+                        [pscustomobject]@{ name = 'sql-prod'; type = 'SQL'; count_ = 6 }
+                    )
+                }
+            }
+            if ($Query -match '^exceptions') {
+                return [pscustomobject]@{
+                    Results = @(
+                        [pscustomobject]@{ problemId = 'NullReferenceException'; count_ = 75 }
+                    )
+                }
+            }
+            return [pscustomobject]@{ Results = @() }
+        }
+
+        $result = & $script:Wrapper -SubscriptionId $script:SubId -TimeRangeHours 24
+        if ($result.Status -eq 'Failed') { throw $result.Message }
+
+        $result.Status | Should -Be 'Success'
+        $result.Findings.Count | Should -Be 3
+        @($result.Findings | Where-Object { $_.QueryType -eq 'requests' }).Count | Should -Be 1
+        @($result.Findings | Where-Object { $_.QueryType -eq 'dependencies' }).Count | Should -Be 1
+        @($result.Findings | Where-Object { $_.QueryType -eq 'exceptions' }).Count | Should -Be 1
+        @($global:CapturedTimeSpans | Select-Object -Unique) | Should -Be @(24)
+    }
+
+    It 'uses resource group and app name filters in discovery URI' {
+        function global:Invoke-AzRestMethod {
+            [CmdletBinding()]
+            param($Method, $Uri)
+            $global:CapturedUris.Add([string]$Uri) | Out-Null
+            [pscustomobject]@{
+                StatusCode = 200
+                Content    = (@{
+                        id   = $global:TestAppId
+                        name = 'appi-prod'
+                    } | ConvertTo-Json -Depth 10)
+            }
+        }
+
+        function global:Invoke-AzApplicationInsightsQuery {
+            [CmdletBinding()]
+            param([string] $ResourceGroupName, [string] $Name, [string] $Query, [timespan] $TimeSpan)
+            [pscustomobject]@{ Results = @() }
+        }
+
+        $result = & $script:Wrapper -SubscriptionId $script:SubId -ResourceGroup 'perf-rg' -AppInsightsName 'appi-prod'
+        if ($result.Status -eq 'Failed') { throw $result.Message }
+
+        $global:CapturedUris.Count | Should -BeGreaterThan 0
+        $global:CapturedUris[0] | Should -Match '/resourceGroups/perf-rg/providers/Microsoft\.Insights/components/appi-prod'
+    }
+
+    It 'retries query on transient throttling' {
+        function global:Invoke-AzRestMethod {
+            [CmdletBinding()]
+            param($Method, $Uri)
+            [pscustomobject]@{
+                StatusCode = 200
+                Content    = (@{
+                        value = @(
+                            @{
+                                id = $global:TestAppId
+                                name = 'appi-prod'
+                            }
+                        )
+                    } | ConvertTo-Json -Depth 10)
+            }
+        }
+
+        function global:Invoke-AzApplicationInsightsQuery {
+            [CmdletBinding()]
+            param([string] $ResourceGroupName, [string] $Name, [string] $Query, [timespan] $TimeSpan)
+            if ($Query -match '^requests') {
+                $global:RequestQueryCalls++
+                if ($global:RequestQueryCalls -eq 1) {
+                    throw '429 Too Many Requests'
+                }
+                return [pscustomobject]@{
+                    Results = @([pscustomobject]@{ name = 'GET /health'; count_ = 11; avg_duration = '00:00:07' })
+                }
+            }
+            return [pscustomobject]@{ Results = @() }
+        }
+
+        $result = & $script:Wrapper -SubscriptionId $script:SubId
+        if ($result.Status -eq 'Failed') { throw $result.Message }
+
+        $result.Status | Should -Be 'Success'
+        $global:RequestQueryCalls | Should -BeGreaterThan 1
+    }
+}

--- a/tools/tool-manifest.json
+++ b/tools/tool-manifest.json
@@ -191,6 +191,32 @@
       }
     },
     {
+      "name": "appinsights",
+      "displayName": "Application Insights Performance Signals",
+      "source": "appinsights",
+      "provider": "azure",
+      "scope": "subscription",
+      "normalizer": "Normalize-AppInsights",
+      "invokeMethod": "script",
+      "type": "collector",
+      "script": "modules/Invoke-AppInsights.ps1",
+      "requiredParams": ["SubscriptionId"],
+      "optionalParams": [
+        "ResourceGroup",
+        "AppInsightsName",
+        "TimeRangeHours",
+        "OutputPath"
+      ],
+      "requiredPermissionTier": 0,
+      "platforms": ["windows", "macos", "linux"],
+      "enabled": true,
+      "report": { "label": "App Insights", "color": "#00838f", "phase": 4 },
+      "install": {
+        "kind": "psmodule",
+        "modules": ["Az.Accounts", "Az.ApplicationInsights", "Az.Monitor"]
+      }
+    },
+    {
       "name": "loadtesting",
       "displayName": "Azure Load Testing (Failed and Regressed Runs)",
       "source": "loadtesting",


### PR DESCRIPTION
## Summary
Adds a new `appinsights` Azure wrapper and normalizer for KQL-driven performance findings from Application Insights.

## Design
- New tool manifest entry: `appinsights` (`provider=azure`, `scope=subscription`)
- Wrapper: `modules/Invoke-AppInsights.ps1`
  - Params: `-SubscriptionId` (required), `-ResourceGroup`, `-AppInsightsName`, `-TimeRangeHours` (default 24)
  - Discovers `Microsoft.Insights/components`
  - Runs KQL signals:
    - Slow requests: `requests ... duration > 5s ... count_ > 10`
    - Dependency failures: `dependencies ... success == false ... count_ > 5`
    - Exception clusters: `exceptions ... count_ > 50`
  - Severity ladder:
    - Slow requests: `Medium` when avg duration > 5s, `High` when avg duration > 30s
    - Dependency failures: `Medium`
    - Exception clusters: `High`
  - Query execution wrapped with `Invoke-WithRetry` and `Invoke-WithTimeout` (300s helper path)
  - v1 envelope output with sanitized optional disk output
- Normalizer: `modules/normalizers/Normalize-AppInsights.ps1`
  - Converts v1 findings to v2 `FindingRow` via `New-FindingRow`
  - `EntityType=AzureResource`
  - Title patterns:
    - `Slow request: <name> avg <duration>s over <count> calls`
    - `Dependency failures: <name> (<type>) failed <count> times`
    - `Exception cluster: <problemId> hit <count> times`
  - Builds HTTPS App Insights portal deep links with encoded query and timespan

## Tests
- Added wrapper tests: `tests/wrappers/Invoke-AppInsights.Tests.ps1`
  - discovery
  - all 3 query paths
  - time-range propagation
  - throttling retry (429)
- Added normalizer tests: `tests/normalizers/Normalize-AppInsights.Tests.ps1`
  - empty/non-success behavior
  - severity boundaries (above/below slow-request threshold)
  - title/deep-link format
- Added fixture: `tests/fixtures/appinsights/appinsights-output.json`
- Full suite: `Invoke-Pester -Path .\tests -CI` -> Passed (1264 passed, 0 failed, 5 skipped)

## Docs
- `docs/consumer/permissions/appinsights.md` (Reader + Log Analytics Reader)
- Updated `README.md`, `docs/consumer/README.md`, `CHANGELOG.md`
- Regenerated catalog/index docs:
  - `docs/consumer/tool-catalog.md`
  - `docs/contributor/tool-catalog.md`
  - `PERMISSIONS.md`

## Issue
Closes #237