### PR TITLE
fix(ci): tool catalog fresh after rapid parallel manifest merges (closes #278)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -103,6 +103,10 @@ jobs:
         run: |
           pwsh -File scripts/Generate-ToolCatalog.ps1 -CheckOnly
           if ($LASTEXITCODE -ne 0) {
+            Write-Host "::group::Tool catalog manifest projection diff"
+            pwsh -File scripts/Generate-ToolCatalog.ps1
+            git --no-pager diff -- docs/consumer/tool-catalog.md docs/contributor/tool-catalog.md
+            Write-Host "::endgroup::"
             Write-Host "::error::docs/consumer/tool-catalog.md or docs/contributor/tool-catalog.md is stale."
             Write-Host "::error::Run 'pwsh -File scripts/Generate-ToolCatalog.ps1' and commit the result."
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to azure-analyzer will be documented here.
 - docs: update README tool count to 27 to match current manifest (closes #235)
 - ci: improved CI failure watchdog error extraction to prioritize GitHub Actions annotations (`##[error]`, `::error::`) and fall back to broader exception/exit-code patterns so ci-failure issues include actionable first error lines.
 - fix(ci): prevent docs-check from re-firing + watchdog hash dedupe (closes #266)
+- fix(ci): regenerate tool catalog and permissions index after rapid parallel manifest merges; docs-check now prints manifest-projection diffs when catalog freshness fails (closes #278)
 
 ### Permissions documentation split (closes #252)
 

--- a/tests/scripts/Generate-ToolCatalog.Tests.ps1
+++ b/tests/scripts/Generate-ToolCatalog.Tests.ps1
@@ -109,6 +109,28 @@ Describe 'Generate-ToolCatalog' {
             $exitCode | Should -Be 0
         }
 
+        It 'committed catalogs match the current manifest projection exactly' {
+            $tempConsumer = Join-Path ([System.IO.Path]::GetTempPath()) ("verify-consumer-{0}.md" -f ([Guid]::NewGuid()))
+            $tempContrib  = Join-Path ([System.IO.Path]::GetTempPath()) ("verify-contrib-{0}.md" -f ([Guid]::NewGuid()))
+            try {
+                & $script:ScriptPath `
+                    -ManifestPath $script:ManifestPath `
+                    -ConsumerOutPath $tempConsumer `
+                    -ContributorOutPath $tempContrib | Out-Null
+
+                $committedConsumer = (Get-Content -LiteralPath $script:ConsumerPath -Raw) -replace "`r`n", "`n"
+                $generatedConsumer = (Get-Content -LiteralPath $tempConsumer -Raw) -replace "`r`n", "`n"
+                $committedContrib  = (Get-Content -LiteralPath $script:ContribPath -Raw) -replace "`r`n", "`n"
+                $generatedContrib  = (Get-Content -LiteralPath $tempContrib -Raw) -replace "`r`n", "`n"
+
+                $committedConsumer | Should -Be $generatedConsumer
+                $committedContrib  | Should -Be $generatedContrib
+            } finally {
+                Remove-Item -LiteralPath $tempConsumer -Force -ErrorAction SilentlyContinue
+                Remove-Item -LiteralPath $tempContrib -Force -ErrorAction SilentlyContinue
+            }
+        }
+
         It 'CheckOnly fails when the committed file is stale' {
             $tempStale = Join-Path ([System.IO.Path]::GetTempPath()) ("stale-{0}.md" -f ([Guid]::NewGuid()))
             $tempContrib = Join-Path ([System.IO.Path]::GetTempPath()) ("stale-contrib-{0}.md" -f ([Guid]::NewGuid()))


### PR DESCRIPTION
## Summary
- Root cause: rapid-merge manifest/doc race left tool-catalog freshness failures on PR #277 (`577bea1acd83`).
- Harden docs-check `tool-catalog-fresh` to print the generated manifest-projection diff when stale.
- Add a Pester guard that compares committed tool catalogs to freshly generated manifest projection byte-for-byte.
- Add changelog entry for the CI fix.

## Root cause analysis
This was a rapid parallel merge race, not a generator logic bug. `Generate-ToolCatalog.ps1` already handled current manifest fields and `-CheckOnly` behavior correctly. The failure came from stale generated docs relative to the latest merged manifest projection.

## Validation
- `pwsh -File scripts/Generate-ToolCatalog.ps1 -CheckOnly`
- `pwsh -File scripts/Generate-PermissionsIndex.ps1 -CheckOnly`
- `Invoke-Pester -Path .\tests -CI` (1293 passed, 0 failed, 5 skipped)
- `rg -- "—" .github/workflows/docs-check.yml CHANGELOG.md tests/scripts/Generate-ToolCatalog.Tests.ps1` (clean)

## Failure reference
- https://github.com/martinopedal/azure-analyzer/actions/runs/24679487614