### PR TITLE
feat(reports): framework x tool coverage matrix with click-to-filter (closes #230)

### DIFF
--- a/.squad/agents/atlas/history.md
+++ b/.squad/agents/atlas/history.md
@@ -1,7 +1,7 @@
 # Project Context
 
 - **Owner:** martinopedal
-- **Project:** azure-analyzer — Automated Azure assessment bundling azqr, PSRule, AzGovViz, and ALZ Resource Graph queries
+- **Project:** azure-analyzer - Automated Azure assessment bundling azqr, PSRule, AzGovViz, and ALZ Resource Graph queries
 - **Stack:** Python (orchestrator), KQL/ARG queries (JSON), PowerShell, GitHub Actions
 - **Created:** 2026-04-15
 
@@ -31,7 +31,7 @@ Landed PR-1 of the 5-PR consumer-first documentation restructure: 9 doc moves un
 
 ## Learnings
 
-- **Em-dash gate** is real and zero-tolerance. `rg -- "—"` over every changed `.md` before commit. Stub template uses hyphens only.
+- **Em-dash gate** is real and zero-tolerance. `rg -- "-"` over every changed `.md` before commit. Stub template uses hyphens only.
 - **`docs-check.yml` detection model** is an inline `actions/github-script` JS snippet at `.github/workflows/docs-check.yml` lines ~38-74. Two structures matter: `ignoredPatterns` (regex array; what is NOT code) and `isDoc` predicate (originally a flat string array). Patching for the new tree means converting `isDoc` to `rootDocs.includes(f) || docPathPatterns.some(p => p.test(f))` so `docs/consumer/**` and `docs/contributor/**` count as docs. Failure message also referenced the old set; updated to mention the split tree.
 - **Link sweep gotcha**: `git mv` followed by writing a stub at the old path defeats git's automatic rename detection in `git status` (shows as "M old + A new" instead of "R old -> new"). History is still preserved because `git log --follow` runs rename detection at log time and the stub (~200 chars) is below similarity threshold vs the moved doc. Acceptable trade-off for stubs; for pure moves, commit the rename first and add stubs in a follow-up commit.
 - **Authority limits trump the "patch every hit" sweep instruction.** README/PERMISSIONS/CHANGELOG had hits to moved paths but were explicitly off-limits in this PR; stubs at old paths cover those references for now and PR-2/3 will rewrite README. Reading the authority block carefully prevents scope creep.
@@ -96,3 +96,8 @@ First merge attempt failed with "2 of 2 required status checks are expected" eve
 - The Comment Triage Loop / 3-model gate did not run because PR was non-squad-author; rubberduck-gate was skipped intentionally.
 - One `Get-Date -Format "yyyy-MM-ddTHH-mm-ssZ"` in PowerShell gives a perfect ISO-Z slug for decisions inbox files.
 - Always rebase before merge if --admin is being used; `mergeStateStatus` in PR JSON is the canonical signal.
+
+
+## 2026-04-20 - Issue #230 framework matrix
+
+Implemented framework x tool coverage matrix in New-HtmlReport with click-to-filter, manifest frameworks[] source-of-truth, regenerated tool catalogs + permissions index, and added report tests (full suite 1294 pass / 5 skipped).

--- a/.squad/decisions/inbox/atlas-issue-230-complete-2026-04-20T17-31-05Z.md
+++ b/.squad/decisions/inbox/atlas-issue-230-complete-2026-04-20T17-31-05Z.md
@@ -1,0 +1,85 @@
+# Atlas - Issue #230 complete: framework x tool coverage matrix
+
+- **Date (UTC):** 2026-04-20T17:31:39Z
+- **Agent:** Atlas
+- **Issue:** [#230](https://github.com/martinopedal/azure-analyzer/issues/230) - "feat(reports): framework x tool coverage matrix"
+- **Decision status:** Implemented in branch `feat/230-framework-matrix`.
+
+## Framework taxonomy
+
+Seed taxonomy in manifest and report matrix:
+
+- CIS Azure
+- NIST 800-53
+- Azure WAF
+- Azure CAF
+- SOC2
+- PCI-DSS
+
+## Manifest schema delta
+
+Added `frameworks: []` on every `tools[]` entry in `tools/tool-manifest.json`.
+
+- Mapping source of truth is now the manifest (Option A from issue design).
+- Disabled tools still carry `frameworks` for schema consistency.
+- Empty array means unmapped / intentionally no framework declaration.
+
+## Initial mapping table (for copy/paste on new tools)
+
+| Tool | Frameworks |
+|---|---|
+| azqr | Azure WAF, Azure CAF |
+| kubescape | CIS Azure, NIST 800-53 |
+| kube-bench | CIS Azure |
+| defender-for-cloud | CIS Azure, NIST 800-53, Azure WAF, Azure CAF, SOC2, PCI-DSS |
+| falco | CIS Azure, NIST 800-53 |
+| azure-cost | Azure CAF |
+| finops | Azure WAF, Azure CAF |
+| appinsights | Azure WAF |
+| loadtesting | Azure WAF |
+| aks-rightsizing | Azure WAF, Azure CAF |
+| psrule | CIS Azure, NIST 800-53, Azure WAF, Azure CAF |
+| azgovviz | Azure WAF, Azure CAF |
+| alz-queries | CIS Azure, NIST 800-53, Azure WAF, Azure CAF |
+| wara | Azure WAF, Azure CAF |
+| maester | NIST 800-53, SOC2, PCI-DSS |
+| scorecard | NIST 800-53, SOC2 |
+| ado-connections | NIST 800-53, SOC2, PCI-DSS |
+| ado-pipelines | NIST 800-53, SOC2, PCI-DSS |
+| ado-repos-secrets | NIST 800-53, SOC2, PCI-DSS |
+| ado-pipeline-correlator | NIST 800-53, SOC2 |
+| identity-correlator | NIST 800-53, SOC2, PCI-DSS |
+| identity-graph-expansion | NIST 800-53, SOC2 |
+| zizmor | NIST 800-53, SOC2 |
+| gitleaks | NIST 800-53, SOC2, PCI-DSS |
+| trivy | CIS Azure, NIST 800-53, PCI-DSS |
+| bicep-iac | CIS Azure, NIST 800-53, Azure WAF, Azure CAF |
+| infracost | Azure CAF |
+| terraform-iac | CIS Azure, NIST 800-53, Azure WAF, Azure CAF |
+| sentinel-incidents | NIST 800-53, SOC2 |
+| sentinel-coverage | NIST 800-53, SOC2, PCI-DSS, Azure WAF |
+| copilot-triage | *(none)* |
+
+## Report integration summary
+
+- Added **Framework Coverage** section in `New-HtmlReport.ps1` below the severity heatmap.
+- Matrix rows = frameworks, columns = enabled tools from manifest.
+- Cell behavior:
+  - `-` for no tool/framework mapping.
+  - `✓ 0` for mapped with zero findings.
+  - Count + per-severity mini chips for mapped intersections with findings.
+  - Weighted heat intensity by severity distribution.
+- Added summary column (total per framework) and summary row (total per tool).
+- Added click-to-filter integration via global filter state (`tool + framework`).
+
+## Validation snapshot
+
+- Added tests: `tests/reports/Framework-Matrix.Tests.ps1`.
+- Full suite: **1294 passed, 0 failed, 5 skipped**.
+- Catalog freshness regeneration completed:
+  - `pwsh scripts/Generate-ToolCatalog.ps1`
+  - `pwsh scripts/Generate-PermissionsIndex.ps1`
+
+## Notes
+
+Severity strip (#270 lineage) and collapsible findings tree (#275 lineage) remain intact and covered by existing tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Added
 
+- feat(reports): framework x tool coverage matrix with click-to-filter (closes #230)
 - feat: Application Insights perf wrapper (slow requests + dependency failures + exception rate via KQL) (closes #237)
 - feat(reports): collapsible Tool/Category/Rule tree with persisted expand state and severity-strip integration (closes #229)
 - **K8s wrappers + orchestrator: `-KubeAuthMode` (Default | Kubelogin | WorkloadIdentity) for kubescape, falco, kube-bench (closes #236, #241, #242).**

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -133,6 +133,42 @@ function SeverityClass([string]$s) {
     }
 }
 
+function Get-CanonicalFrameworkName([string]$Name) {
+    if ([string]::IsNullOrWhiteSpace($Name)) { return '' }
+    $trimmed = $Name.Trim()
+    switch -Regex ($trimmed) {
+        '^(?i)cis(\s+azure.*)?$' { return 'CIS Azure' }
+        '^(?i)nist(\s*800[-\s]?53.*)?$' { return 'NIST 800-53' }
+        '^(?i)(azure\s+)?waf(\s+.*)?$' { return 'Azure WAF' }
+        '^(?i)(azure\s+)?caf(\s+.*)?$' { return 'Azure CAF' }
+        '^(?i)soc[\s-]*2.*$' { return 'SOC2' }
+        '^(?i)pci(\s*[-\s]?dss.*)?$' { return 'PCI-DSS' }
+        default { return $trimmed }
+    }
+}
+
+function Get-FindingFrameworkNames($Finding) {
+    $frameworks = New-Object System.Collections.Generic.List[string]
+
+    if ($Finding.PSObject.Properties.Match('Frameworks').Count -gt 0 -and $Finding.Frameworks) {
+        foreach ($fw in @($Finding.Frameworks)) {
+            $raw = if ($fw -is [string]) { $fw } elseif ($fw.PSObject.Properties.Match('Name').Count -gt 0) { [string]$fw.Name } elseif ($fw.PSObject.Properties.Match('framework').Count -gt 0) { [string]$fw.framework } else { [string]$fw }
+            $normalized = Get-CanonicalFrameworkName $raw
+            if (-not [string]::IsNullOrWhiteSpace($normalized)) { $frameworks.Add($normalized) }
+        }
+    }
+    if ($Finding.PSObject.Properties.Match('Controls').Count -gt 0 -and $Finding.Controls) {
+        foreach ($ctrl in @($Finding.Controls)) {
+            $normalized = Get-CanonicalFrameworkName ([string]$ctrl)
+            if ($normalized -in @('CIS Azure', 'NIST 800-53', 'Azure WAF', 'Azure CAF', 'SOC2', 'PCI-DSS')) {
+                $frameworks.Add($normalized)
+            }
+        }
+    }
+
+    return @($frameworks | Select-Object -Unique)
+}
+
 function Get-AnchorId([string]$text) {
     if ([string]::IsNullOrWhiteSpace($text)) { return 'portfolio-sub-unknown' }
     return ('portfolio-sub-' + (($text.ToLowerInvariant() -replace '[^a-z0-9]+', '-') -replace '(^-|-$)', ''))
@@ -180,10 +216,17 @@ $manifestPath = Join-Path $PSScriptRoot 'tools' 'tool-manifest.json'
 $allSources   = @()
 $sourceLabels = @{}
 $sourceColors = @{}
+$frameworkPriority = @('CIS Azure', 'NIST 800-53', 'Azure WAF', 'Azure CAF', 'SOC2', 'PCI-DSS')
+$sourceFrameworks = @{}
 if (Test-Path $manifestPath) {
     try {
         $manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
         foreach ($t in $manifest.tools) {
+            $mappedFrameworks = @()
+            if ($t.PSObject.Properties['frameworks'] -and $t.frameworks) {
+                $mappedFrameworks = @($t.frameworks | ForEach-Object { Get-CanonicalFrameworkName ([string]$_) } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+            }
+            $sourceFrameworks[$t.name] = $mappedFrameworks
             if (-not $t.enabled) { continue }
             $allSources += $t.name
             $sourceLabels[$t.name] = $t.displayName
@@ -203,6 +246,7 @@ if ($allSources.Count -eq 0) {
     $allSources   = @('azqr','psrule','azgovviz','alz-queries','wara','defender-for-cloud','kubescape','kube-bench','falco','maester','scorecard','ado-connections','ado-pipelines','identity-correlator','zizmor','gitleaks','trivy','azure-cost','finops','bicep-iac','terraform-iac','sentinel-incidents','sentinel-coverage')
     $sourceLabels = @{ 'azqr'='Azure Quick Review'; 'psrule'='PSRule'; 'azgovviz'='AzGovViz'; 'alz-queries'='ALZ Queries'; 'wara'='WARA'; 'defender-for-cloud'='Defender for Cloud'; 'kubescape'='Kubescape'; 'kube-bench'='kube-bench'; 'falco'='Falco'; 'maester'='Maester'; 'scorecard'='Scorecard'; 'ado-connections'='ADO Service Connections'; 'ado-pipelines'='ADO Pipeline Security'; 'identity-correlator'='Identity Correlator'; 'zizmor'='zizmor'; 'gitleaks'='gitleaks'; 'trivy'='Trivy'; 'azure-cost'='Azure Cost'; 'finops'='FinOps Signals'; 'bicep-iac'='Bicep IaC Validation'; 'terraform-iac'='Terraform IaC Validation'; 'sentinel-incidents'='Microsoft Sentinel'; 'sentinel-coverage'='Sentinel Coverage' }
     $sourceColors = @{ 'azqr'='#1565c0'; 'psrule'='#6a1b9a'; 'azgovviz'='#00838f'; 'alz-queries'='#e65100'; 'wara'='#2e7d32'; 'defender-for-cloud'='#0078d4'; 'kubescape'='#7b1fa2'; 'kube-bench'='#5e35b1'; 'falco'='#ef6c00'; 'maester'='#7b1fa2'; 'scorecard'='#ff6f00'; 'ado-connections'='#0277bd'; 'ado-pipelines'='#006064'; 'identity-correlator'='#ad1457'; 'zizmor'='#4527a0'; 'gitleaks'='#c62828'; 'trivy'='#00695c'; 'azure-cost'='#388e3c'; 'finops'='#00897b'; 'bicep-iac'='#0d47a1'; 'terraform-iac'='#5c4ee5'; 'sentinel-incidents'='#0078d4'; 'sentinel-coverage'='#3949ab' }
+    foreach ($src in $allSources) { $sourceFrameworks[$src] = @() }
 }
 $sourceGroups = @($findings | Group-Object -Property Source)
 $sourceCountMap = @{}
@@ -375,6 +419,8 @@ $findingsTreeHtml = foreach ($tool in $toolGroups) {
                 $sevClass = SeverityClass $f.Severity
                 $compliantBool = if ($f.Compliant) { 'true' } else { 'false' }
                 $resourceGroup = HE (Get-FindingResourceGroup $f)
+                $frameworkList = @((Get-FindingFrameworkNames $f) | ForEach-Object { [string]$_ })
+                $frameworkAttr = HE (($frameworkList -join '|').ToLowerInvariant())
                 $resourceId = HE ([string]$f.ResourceId)
                 $detail = HE ([string]$f.Detail)
                 $remediationHtml = Linkify ([string]$f.Remediation)
@@ -392,7 +438,7 @@ $findingsTreeHtml = foreach ($tool in $toolGroups) {
                     }
                 }
                 @"
-<article class="tree-finding" data-tree-finding="true" data-tree-path="$(HE "$rulePath|finding::$([string]$f.Id)")" data-severity="$(HE ([string]$f.Severity))" data-compliant="$compliantBool" data-source="$(HE ([string]$f.Source))" data-platform="$(HE ([string]$f.Platform))" data-status="$(HE $rowStatus)" data-resourcegroup="$resourceGroup">
+<article class="tree-finding" data-tree-finding="true" data-tree-path="$(HE "$rulePath|finding::$([string]$f.Id)")" data-severity="$(HE ([string]$f.Severity))" data-compliant="$compliantBool" data-source="$(HE ([string]$f.Source))" data-platform="$(HE ([string]$f.Platform))" data-status="$(HE $rowStatus)" data-resourcegroup="$resourceGroup" data-frameworks="$frameworkAttr">
   <header class="tree-finding-header">
     <span class="badge $sevClass">$(HE ([string]$f.Severity))</span>
     <strong class="tree-finding-title">$(HE ([string]$f.Title))</strong>$statusBadge$controlBadgesHtml
@@ -760,6 +806,139 @@ if ($rgSeverityMap.Count -gt 0) {
 "@
 }
 
+# --- Framework coverage matrix (Framework x Tool) ---
+$frameworkCoverageMatrixHtml = ''
+$frameworkCatalog = [System.Collections.Generic.List[string]]::new()
+foreach ($fw in $frameworkPriority) {
+    if ($frameworkCatalog -notcontains $fw) { $frameworkCatalog.Add($fw) }
+}
+foreach ($src in $allSources) {
+    $mapped = if ($sourceFrameworks.ContainsKey($src)) { @($sourceFrameworks[$src]) } else { @() }
+    foreach ($fw in $mapped) {
+        if ($frameworkCatalog -notcontains $fw) { $frameworkCatalog.Add($fw) }
+    }
+}
+
+$frameworkCellMap = @{}
+$frameworkTotals = @{}
+$toolTotalsByFramework = @{}
+$severityWeight = @{ Critical = 5; High = 4; Medium = 3; Low = 2; Info = 1 }
+
+foreach ($fw in $frameworkCatalog) {
+    $frameworkTotals[$fw] = 0
+}
+foreach ($src in $allSources) {
+    $toolTotalsByFramework[$src] = 0
+}
+
+foreach ($f in $findings) {
+    $src = [string]$f.Source
+    if ($allSources -notcontains $src) { continue }
+    $fws = @(Get-FindingFrameworkNames $f)
+    if ($fws.Count -eq 0) { continue }
+    foreach ($fw in $fws) {
+        if ($frameworkCatalog -notcontains $fw) { continue }
+        $key = "$src||$fw"
+        if (-not $frameworkCellMap.ContainsKey($key)) {
+            $frameworkCellMap[$key] = @{
+                Count = 0
+                Weighted = 0
+                Severity = (New-SeverityCountMap)
+            }
+        }
+        $frameworkCellMap[$key].Count++
+        Add-SeverityToCountMap -Map $frameworkCellMap[$key].Severity -Severity ([string]$f.Severity)
+        $normalizedSeverity = [string]$f.Severity
+        $weight = if ($severityWeight.ContainsKey($normalizedSeverity)) { [int]$severityWeight[$normalizedSeverity] } else { 1 }
+        $frameworkCellMap[$key].Weighted += $weight
+        $frameworkTotals[$fw]++
+        $toolTotalsByFramework[$src]++
+    }
+}
+
+$matrixMaxWeighted = 0
+foreach ($k in $frameworkCellMap.Keys) {
+    if ([int]$frameworkCellMap[$k].Weighted -gt $matrixMaxWeighted) {
+        $matrixMaxWeighted = [int]$frameworkCellMap[$k].Weighted
+    }
+}
+if ($matrixMaxWeighted -lt 1) { $matrixMaxWeighted = 1 }
+
+if ($frameworkCatalog.Count -gt 0 -and $allSources.Count -gt 0) {
+    $headerCells = @("<th class='fxm-stub'>Framework</th>")
+    foreach ($src in $allSources) {
+        $headerCells += "<th title='$(HE $sourceLabels[$src])'>$(HE $sourceLabels[$src])</th>"
+    }
+    $headerCells += "<th class='fxm-summary-head'>Total</th>"
+
+    $bodyRows = foreach ($fw in $frameworkCatalog) {
+        $cells = @("<th class='fxm-framework' scope='row'>$(HE $fw)</th>")
+        foreach ($src in $allSources) {
+            $mapped = $sourceFrameworks.ContainsKey($src) -and (@($sourceFrameworks[$src]) -contains $fw)
+            $key = "$src||$fw"
+            $cell = if ($frameworkCellMap.ContainsKey($key)) { $frameworkCellMap[$key] } else { $null }
+            $count = if ($cell) { [int]$cell.Count } else { 0 }
+            $sevCounts = if ($cell) { $cell.Severity } else { New-SeverityCountMap }
+            $weighted = if ($cell) { [int]$cell.Weighted } else { 0 }
+            $intensity = if ($weighted -le 0) { 0 } else { [math]::Round([double]$weighted / [double]$matrixMaxWeighted, 3) }
+            $alpha = if ($intensity -le 0) { 0 } else { [math]::Round(0.22 + (0.68 * $intensity), 3) }
+            $bg = if ($weighted -le 0) { '#ffffff' } else { "rgba(21, 101, 192, $alpha)" }
+            $txtColor = if ($intensity -gt 0.55) { '#ffffff' } else { '#1f2937' }
+            $srcAttr = HE $src
+            $fwAttr = HE $fw
+            $countLabel = if ($count -eq 1) { '1 finding' } else { "$count findings" }
+            if (-not $mapped) {
+                $cells += "<td class='fxm-cell fxm-unmapped' title='Unmapped for $(HE $sourceLabels[$src])'>-</td>"
+            } else {
+                $sevHint = "Critical $([int]$sevCounts['Critical']) | High $([int]$sevCounts['High']) | Medium $([int]$sevCounts['Medium']) | Low $([int]$sevCounts['Low']) | Info $([int]$sevCounts['Info'])"
+                if ($count -eq 0) {
+                    $cells += "<td class='fxm-cell fxm-mapped-zero'><button type='button' class='fxm-button fxm-button-zero' data-source='$srcAttr' data-framework='$fwAttr' title='Mapped with no findings. Click to filter.' onclick=`"filterByFrameworkMatrix('$srcAttr','$fwAttr')`">&#x2713;<span class='fxm-cell-count'>0</span></button></td>"
+                } else {
+                    $cells += @"
+<td class='fxm-cell fxm-mapped-hit'>
+  <button type='button' class='fxm-button fxm-button-hit' data-source='$srcAttr' data-framework='$fwAttr' style='background:$bg;color:$txtColor' title='$(HE $countLabel). $sevHint. Click to filter.' onclick="filterByFrameworkMatrix('$srcAttr','$fwAttr')">
+    <span class='fxm-cell-count'>$count</span>
+    <span class='fxm-sev-mini'>
+      <span class='fxm-sev-dot fxm-sev-critical' title='Critical $([int]$sevCounts['Critical'])'>$([int]$sevCounts['Critical'])</span>
+      <span class='fxm-sev-dot fxm-sev-high' title='High $([int]$sevCounts['High'])'>$([int]$sevCounts['High'])</span>
+      <span class='fxm-sev-dot fxm-sev-medium' title='Medium $([int]$sevCounts['Medium'])'>$([int]$sevCounts['Medium'])</span>
+      <span class='fxm-sev-dot fxm-sev-low' title='Low $([int]$sevCounts['Low'])'>$([int]$sevCounts['Low'])</span>
+      <span class='fxm-sev-dot fxm-sev-info' title='Info $([int]$sevCounts['Info'])'>$([int]$sevCounts['Info'])</span>
+    </span>
+  </button>
+</td>
+"@
+                }
+            }
+        }
+        $cells += "<td class='fxm-summary-cell'>$([int]$frameworkTotals[$fw])</td>"
+        "<tr data-framework='$(HE $fw)'>$($cells -join '')</tr>"
+    }
+
+    $summaryCells = @("<th class='fxm-summary-head' scope='row'>Total</th>")
+    foreach ($src in $allSources) {
+        $summaryCells += "<td class='fxm-summary-cell'>$([int]$toolTotalsByFramework[$src])</td>"
+    }
+    $overallTotal = [int](@($frameworkTotals.Values | Measure-Object -Sum).Sum)
+    $summaryCells += "<td class='fxm-summary-cell fxm-summary-total'>$overallTotal</td>"
+
+    $frameworkCoverageMatrixHtml = @"
+<section class="framework-matrix-section" aria-labelledby="framework-matrix-title">
+  <h2 id="framework-matrix-title">Framework Coverage</h2>
+  <p class="hm-hint">Click a mapped cell to filter findings by tool and framework intersection.</p>
+  <div class="framework-matrix-wrap">
+    <table id="framework-coverage-matrix" class="framework-matrix-table">
+      <thead><tr>$($headerCells -join '')</tr></thead>
+      <tbody>
+        $($bodyRows -join "`n")
+      </tbody>
+      <tfoot><tr>$($summaryCells -join '')</tr></tfoot>
+    </table>
+  </div>
+</section>
+"@
+}
+
 # --- Priority stack: top Critical/High non-compliant findings ---
 $priorityFindings = @($findings | Where-Object { -not $_.Compliant -and ($_.Severity -eq 'Critical' -or $_.Severity -eq 'High') } |
     Sort-Object @{Expression = { if ($_.Severity -eq 'Critical') { 0 } else { 1 } }}, Title)
@@ -789,6 +968,9 @@ $moreText
 $gfSourceOptions = ($sourcesWithResults | Sort-Object | ForEach-Object {
     $lbl = if ($sourceLabels.ContainsKey($_)) { $sourceLabels[$_] } else { $_ }
     "<option value=`"$(HE $_)`">$(HE $lbl)</option>"
+}) -join "`n"
+$gfFrameworkOptions = ($frameworkCatalog | Sort-Object | ForEach-Object {
+    "<option value=`"$(HE $_)`">$(HE $_)</option>"
 }) -join "`n"
 
 # --- Summary tab (issue #210): embed exec dashboard content as the first tab ---
@@ -1192,6 +1374,29 @@ $html = @"
     .hm-data { cursor: default; }
     .hm-data:hover { transform: none; box-shadow: none; }
   }
+  .framework-matrix-section { background: #fff; border-radius: 8px; padding: 18px 22px; margin-bottom: 24px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
+  .framework-matrix-wrap { overflow-x: auto; }
+  .framework-matrix-table { width: 100%; border-collapse: separate; border-spacing: 4px; min-width: 980px; }
+  .framework-matrix-table th, .framework-matrix-table td { padding: 6px; text-align: center; font-size: 12px; }
+  .framework-matrix-table thead th { background: #f8fafc; color: #334155; font-weight: 700; position: sticky; top: 0; z-index: 2; }
+  .framework-matrix-table .fxm-stub { text-align: left; min-width: 160px; }
+  .framework-matrix-table .fxm-framework { text-align: left; background: #f8fafc; color: #0f172a; font-weight: 600; position: sticky; left: 0; z-index: 1; }
+  .framework-matrix-table .fxm-cell { border: 1px solid #e2e8f0; border-radius: 6px; background: #fff; }
+  .framework-matrix-table .fxm-unmapped { color: #94a3b8; background: #f8fafc; }
+  .framework-matrix-table .fxm-mapped-zero { background: #ecfdf5; color: #166534; border-color: #a7f3d0; }
+  .framework-matrix-table .fxm-summary-cell, .framework-matrix-table .fxm-summary-head { background: #f8fafc; font-weight: 700; color: #1e293b; }
+  .framework-matrix-table .fxm-summary-total { background: #e2e8f0; }
+  .fxm-button { width: 100%; border: 0; border-radius: 5px; cursor: pointer; font-weight: 700; padding: 4px 3px; }
+  .fxm-button:hover { transform: translateY(-1px); box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+  .fxm-button-zero { background: transparent; color: #166534; }
+  .fxm-cell-count { display: block; font-size: 13px; line-height: 1.1; }
+  .fxm-sev-mini { margin-top: 3px; display: inline-flex; gap: 2px; }
+  .fxm-sev-dot { min-width: 16px; border-radius: 999px; font-size: 9px; line-height: 1; padding: 2px 3px; font-weight: 700; border: 1px solid transparent; }
+  .fxm-sev-critical { background: rgba(127,29,29,0.18); color: #7f1d1d; border-color: rgba(127,29,29,0.35); }
+  .fxm-sev-high { background: rgba(220,38,38,0.18); color: #991b1b; border-color: rgba(220,38,38,0.35); }
+  .fxm-sev-medium { background: rgba(245,158,11,0.22); color: #92400e; border-color: rgba(245,158,11,0.35); }
+  .fxm-sev-low { background: rgba(59,130,246,0.2); color: #1d4ed8; border-color: rgba(59,130,246,0.35); }
+  .fxm-sev-info { background: rgba(100,116,139,0.2); color: #334155; border-color: rgba(100,116,139,0.35); }
   /* Resources tab (issue #209) */
   .resources-section { margin-bottom: 1.5rem; }
   .resource-row { cursor: pointer; }
@@ -1256,6 +1461,7 @@ $sparklineHtml
 $portfolioSectionHtml
 
 $heatmapHtml
+$frameworkCoverageMatrixHtml
 
 <!-- Per-Source Breakdown -->
 <h2>Findings by source</h2>
@@ -1287,6 +1493,10 @@ $complianceHtml
   <select id="gf-source" onchange="applyGlobalFilter()" aria-label="Filter by tool">
     <option value="">All Tools</option>
 $gfSourceOptions
+  </select>
+  <select id="gf-framework" onchange="applyGlobalFilter()" aria-label="Filter by framework">
+    <option value="">All Frameworks</option>
+$gfFrameworkOptions
   </select>
   <select id="gf-platform" onchange="applyGlobalFilter()" aria-label="Filter by platform">
     <option value="">All Platforms</option>
@@ -1332,6 +1542,7 @@ var activeSevFilter = null;
 // --- Global filter state ---
 var _gfActiveSev = new Set();
 var _gfSource = '';
+var _gfFramework = '';
 var _gfPlatform = '';
 var _gfStatus = '';
 var _gfText = '';
@@ -1372,7 +1583,7 @@ function filterBySeverityStrip(btn, severity) {
 }
 
 function treeHasActiveFilter() {
-  return _gfActiveSev.size > 0 || !!_gfSource || !!_gfPlatform || !!_gfStatus || !!_gfText || !!_gfRg;
+  return _gfActiveSev.size > 0 || !!_gfSource || !!_gfFramework || !!_gfPlatform || !!_gfStatus || !!_gfText || !!_gfRg;
 }
 
 function syncFindingsTreeVisibility() {
@@ -1391,6 +1602,7 @@ function syncFindingsTreeVisibility() {
 
 function applyGlobalFilter() {
   _gfSource   = document.getElementById('gf-source') ? document.getElementById('gf-source').value : '';
+  _gfFramework = document.getElementById('gf-framework') ? document.getElementById('gf-framework').value : '';
   _gfPlatform = document.getElementById('gf-platform') ? document.getElementById('gf-platform').value : '';
   _gfStatus   = document.getElementById('gf-status') ? document.getElementById('gf-status').value : '';
   _gfText     = (document.getElementById('gf-text') ? document.getElementById('gf-text').value : '').toLowerCase();
@@ -1402,16 +1614,18 @@ function applyGlobalFilter() {
     var platform = row.dataset.platform || '';
     var status   = row.dataset.compliant || '';
     var rg       = row.dataset.resourcegroup || '';
+    var frameworks = (row.dataset.frameworks || '').toLowerCase();
     var text     = row.textContent.toLowerCase();
 
     var sevOk  = _gfActiveSev.size === 0 || _gfActiveSev.has(sev);
     var srcOk  = !_gfSource   || source   === _gfSource;
+    var fwOk   = !_gfFramework || frameworks.split('|').includes(_gfFramework.toLowerCase());
     var platOk = !_gfPlatform || platform === _gfPlatform;
     var stOk   = !_gfStatus   || status   === _gfStatus;
     var rgOk   = !_gfRg       || rg       === _gfRg;
     var txtOk  = !_gfText     || text.includes(_gfText);
 
-    var show = sevOk && srcOk && platOk && stOk && rgOk && txtOk;
+    var show = sevOk && srcOk && fwOk && platOk && stOk && rgOk && txtOk;
     row.classList.toggle('tree-hidden', !show);
     if (show) visible++;
   });
@@ -1457,13 +1671,13 @@ function toggleSevFilter(btn, sev) {
 
 function resetGlobalFilter() {
   _gfActiveSev.clear();
-  _gfSource = _gfPlatform = _gfStatus = _gfText = _gfRg = '';
+  _gfSource = _gfFramework = _gfPlatform = _gfStatus = _gfText = _gfRg = '';
   document.querySelectorAll('.gf-chip').forEach(function(c) {
     c.dataset.active = 'false';
     if (c.dataset.sev === 'all') c.classList.add('gf-active');
     else c.classList.remove('gf-active');
   });
-  ['gf-source','gf-platform','gf-status','gf-text'].forEach(function(id) {
+  ['gf-source','gf-framework','gf-platform','gf-status','gf-text'].forEach(function(id) {
     var el = document.getElementById(id); if (el) el.value = '';
   });
   applyGlobalFilter();
@@ -1487,6 +1701,25 @@ function filterByHeatmap(rg, sev) {
   // Scroll to findings tables.
   var target = document.querySelector('details[id^="cat-"]') || document.getElementById('global-filter-bar');
   if (target && target.scrollIntoView) { target.scrollIntoView({behavior: 'smooth', block: 'start'}); }
+}
+
+function filterByFrameworkMatrix(source, framework) {
+  if (!source || !framework) { return; }
+  var normalizedFramework = framework.toLowerCase();
+  var sameIntersection = (_gfSource === source && _gfFramework.toLowerCase() === normalizedFramework);
+  if (sameIntersection) {
+    resetGlobalFilter();
+    return;
+  }
+  _gfSource = source;
+  _gfFramework = framework;
+  var sourceEl = document.getElementById('gf-source');
+  if (sourceEl) { sourceEl.value = source; }
+  var frameworkEl = document.getElementById('gf-framework');
+  if (frameworkEl) { frameworkEl.value = framework; }
+  applyGlobalFilter();
+  var target = document.getElementById('global-filter-bar');
+  if (target && target.scrollIntoView) { target.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
 }
 
 function treeStorageKey(path) {

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ New-MdReport   -InputPath .\output\results.json -OutputPath .\output\report.md
 
 `New-HtmlReport.ps1` renders the HTML report directly. There is no separate checked-in HTML template to maintain or customize.
 
-The HTML report includes an executive Summary tab, a severity-by-resource-group heatmap, a sticky severity strip (Critical, High, Medium, Low, Info, Total), a collapsible Tool -> Category -> Rule -> Finding tree with persisted expand state, a global filter bar (severity, platform, tool, free text), and a CSV export of the currently filtered view.
+The HTML report includes an executive Summary tab, a severity-by-resource-group heatmap, a Framework Coverage matrix (framework x tool with click-to-filter), a sticky severity strip (Critical, High, Medium, Low, Info, Total), a collapsible Tool -> Category -> Rule -> Finding tree with persisted expand state, a global filter bar (severity, framework, platform, tool, free text), and a CSV export of the currently filtered view.
 
 ## What you get
 
 - **29 tools** across Azure resources, Entra ID, GitHub, and Azure DevOps.
 - **Unified v2 schema** with 5 severity levels (Critical, High, Medium, Low, Info) and 14 entity types across 4 platforms (Azure, Entra, GitHub, ADO).
 - **Read-only everywhere.** No write permissions on any cloud. See [PERMISSIONS.md](PERMISSIONS.md) for exact scopes.
-- **HTML + Markdown reports** with executive summary, heatmap, filtering, control-framework chips, and CSV export.
+- **HTML + Markdown reports** with executive summary, heatmap, framework coverage matrix, filtering, control-framework chips, and CSV export.
 - **Manifest-driven installer.** Run with `-InstallMissingModules` to auto-install prerequisites (PSGallery modules, allow-listed package managers, HTTPS-only git clones).
 - **Markdown link CI checks** on PRs that change `.md` files, plus a weekly scheduled link-rot sweep.
 

--- a/docs/consumer/README.md
+++ b/docs/consumer/README.md
@@ -3,6 +3,7 @@
 All advanced consumer docs live here. The root `README.md` is your starting point.
 
 - [tool-catalog.md](tool-catalog.md) - Every tool azure-analyzer can run, what it covers, and what scope it targets. Generated from `tools/tool-manifest.json`.
+- HTML report view: Framework Coverage matrix (framework x tool), sourced from `tools/tool-manifest.json` `frameworks[]` mappings with click-to-filter intersections.
 - [permissions/](permissions/README.md) - Per-tool permission detail. The root [`PERMISSIONS.md`](../../PERMISSIONS.md) is the short summary; per-tool pages live here.
 - [continuous-control.md](continuous-control.md) - Continuous control monitoring patterns and integration guidance.
 - [ai-triage.md](ai-triage.md) - AI-assisted finding triage workflow and prompt design.

--- a/docs/consumer/tool-catalog.md
+++ b/docs/consumer/tool-catalog.md
@@ -12,46 +12,46 @@ This page lists every analyzer tool azure-analyzer can run, what it covers, what
 
 ## Enabled by default
 
-| Name | Display name | Scope | Provider | What it does | Docs |
-|---|---|---|---|---|---|
-| `ado-connections` | ADO Service Connections | ado | ado | Azure DevOps service-connection security: identity, scope, federation. | - |
-| `ado-pipeline-correlator` | ADO Pipeline Run Correlator | ado | ado | Correlates ADO pipeline runs with downstream Azure resource changes. | - |
-| `ado-pipelines` | ADO Pipeline Security | ado | ado | Azure DevOps pipeline-security posture (variable groups, environments, approvals). | - |
-| `ado-repos-secrets` | ADO Repos Secret Scanning | ado | ado | Secret scanning across Azure DevOps repositories via gitleaks. | [docs](./gitleaks-pattern-tuning.md) |
-| `aks-rightsizing` | AKS Rightsizing (Container Insights utilization) | subscription | azure | AKS Rightsizing (Container Insights utilization) | - |
-| `alz-queries` | ALZ Resource Graph Queries | managementGroup | azure | ALZ Resource Graph queries: landing-zone compliance and drift detection. | - |
-| `appinsights` | Application Insights Performance Signals | subscription | azure | Application Insights telemetry signals: slow requests, dependency failures, and exception clusters via KQL. | - |
-| `azgovviz` | AzGovViz | managementGroup | azure | Azure Governance Visualizer: management-group / subscription / RBAC / policy posture. | - |
-| `azqr` | Azure Quick Review | subscription | azure | Azure best-practice review across reliability, security, cost, performance and operational excellence. | - |
-| `azure-cost` | Azure Cost (Consumption API) | subscription | azure | Per-subscription monthly Azure spend pulled from the Consumption API. | - |
-| `bicep-iac` | Bicep IaC Validation | repository | cli | Bicep IaC validation: lint, build, and best-practice checks. | - |
-| `defender-for-cloud` | Microsoft Defender for Cloud | subscription | azure | Pulls Microsoft Defender for Cloud Secure Score and active recommendations per subscription. | - |
-| `falco` | Falco (AKS runtime anomaly detection) | subscription | azure | AKS runtime anomaly detection (syscall-level threat detection). | - |
-| `finops` | FinOps Signals (Idle Resource Detection) | subscription | azure | FinOps signals: idle / orphaned resources that drive avoidable spend. | - |
-| `gitleaks` | gitleaks (Secrets Scanner) | repository | cli | Secret scanning across local or remote git repositories. | [docs](./gitleaks-pattern-tuning.md) |
-| `identity-correlator` | Identity Correlator | tenant | graph | Correlates Entra identities, role assignments, and resource ownership. | - |
-| `identity-graph-expansion` | Identity Graph Expansion | tenant | graph | Expands the identity graph: cross-tenant B2B + service-principal-to-resource edges. | - |
-| `infracost` | Infracost IaC Cost Estimation | repository | cli | Pre-deploy cost estimate for Terraform and Bicep resources. | - |
-| `kube-bench` | kube-bench (AKS node-level CIS compliance) | subscription | azure | CIS Kubernetes benchmark for AKS node hardening. | - |
-| `kubescape` | Kubescape (AKS runtime posture) | subscription | azure | Runtime posture for AKS clusters: misconfigurations, RBAC, network policies, vulnerabilities. | - |
-| `loadtesting` | Azure Load Testing (Failed and Regressed Runs) | subscription | azure | Azure Load Testing reliability signals: failed runs, cancelled runs, and metric regressions. | - |
-| `maester` | Maester | tenant | microsoft365 | Microsoft Entra (Identity) security baseline: conditional access, MFA, privileged roles. | [docs](./ai-triage.md) |
-| `psrule` | PSRule for Azure | subscription | azure | Microsoft PSRule for Azure: Well-Architected and best-practice rule baseline. | - |
-| `scorecard` | OpenSSF Scorecard | repository | github | OpenSSF Scorecard for repository supply-chain hygiene. | - |
-| `sentinel-coverage` | Microsoft Sentinel (Coverage / Posture) | workspace | azure | Sentinel detection posture: analytic rules, watchlists, data connectors, hunting queries. | - |
-| `sentinel-incidents` | Microsoft Sentinel (Active Incidents) | workspace | azure | Pulls active Microsoft Sentinel incidents from a Log Analytics workspace. | - |
-| `terraform-iac` | Terraform IaC Validation | repository | cli | Terraform IaC validation: tflint / tfsec / checkov-style checks. | - |
-| `trivy` | Trivy Vulnerability Scanner | repository | cli | Vulnerability and IaC misconfiguration scanner for repos and container images. | - |
-| `wara` | Well-Architected Reliability Assessment | subscription | azure | Well-Architected Reliability Assessment workflow for production workloads. | - |
-| `zizmor` | zizmor (Actions YAML Scanner) | repository | cli | Static analysis for GitHub Actions workflow security risks. | - |
+| Name | Display name | Scope | Provider | Frameworks | What it does | Docs |
+|---|---|---|---|---|---|---|
+| `ado-connections` | ADO Service Connections | ado | ado | NIST 800-53, SOC2, PCI-DSS | Azure DevOps service-connection security: identity, scope, federation. | - |
+| `ado-pipeline-correlator` | ADO Pipeline Run Correlator | ado | ado | NIST 800-53, SOC2 | Correlates ADO pipeline runs with downstream Azure resource changes. | - |
+| `ado-pipelines` | ADO Pipeline Security | ado | ado | NIST 800-53, SOC2, PCI-DSS | Azure DevOps pipeline-security posture (variable groups, environments, approvals). | - |
+| `ado-repos-secrets` | ADO Repos Secret Scanning | ado | ado | NIST 800-53, SOC2, PCI-DSS | Secret scanning across Azure DevOps repositories via gitleaks. | [docs](./gitleaks-pattern-tuning.md) |
+| `aks-rightsizing` | AKS Rightsizing (Container Insights utilization) | subscription | azure | Azure WAF, Azure CAF | AKS Rightsizing (Container Insights utilization) | - |
+| `alz-queries` | ALZ Resource Graph Queries | managementGroup | azure | CIS Azure, NIST 800-53, Azure WAF, Azure CAF | ALZ Resource Graph queries: landing-zone compliance and drift detection. | - |
+| `appinsights` | Application Insights Performance Signals | subscription | azure | Azure WAF | Application Insights telemetry signals: slow requests, dependency failures, and exception clusters via KQL. | - |
+| `azgovviz` | AzGovViz | managementGroup | azure | Azure WAF, Azure CAF | Azure Governance Visualizer: management-group / subscription / RBAC / policy posture. | - |
+| `azqr` | Azure Quick Review | subscription | azure | Azure WAF, Azure CAF | Azure best-practice review across reliability, security, cost, performance and operational excellence. | - |
+| `azure-cost` | Azure Cost (Consumption API) | subscription | azure | Azure CAF | Per-subscription monthly Azure spend pulled from the Consumption API. | - |
+| `bicep-iac` | Bicep IaC Validation | repository | cli | CIS Azure, NIST 800-53, Azure WAF, Azure CAF | Bicep IaC validation: lint, build, and best-practice checks. | - |
+| `defender-for-cloud` | Microsoft Defender for Cloud | subscription | azure | CIS Azure, NIST 800-53, Azure WAF, Azure CAF, SOC2, PCI-DSS | Pulls Microsoft Defender for Cloud Secure Score and active recommendations per subscription. | - |
+| `falco` | Falco (AKS runtime anomaly detection) | subscription | azure | CIS Azure, NIST 800-53 | AKS runtime anomaly detection (syscall-level threat detection). | - |
+| `finops` | FinOps Signals (Idle Resource Detection) | subscription | azure | Azure WAF, Azure CAF | FinOps signals: idle / orphaned resources that drive avoidable spend. | - |
+| `gitleaks` | gitleaks (Secrets Scanner) | repository | cli | NIST 800-53, SOC2, PCI-DSS | Secret scanning across local or remote git repositories. | [docs](./gitleaks-pattern-tuning.md) |
+| `identity-correlator` | Identity Correlator | tenant | graph | NIST 800-53, SOC2, PCI-DSS | Correlates Entra identities, role assignments, and resource ownership. | - |
+| `identity-graph-expansion` | Identity Graph Expansion | tenant | graph | NIST 800-53, SOC2 | Expands the identity graph: cross-tenant B2B + service-principal-to-resource edges. | - |
+| `infracost` | Infracost IaC Cost Estimation | repository | cli | Azure CAF | Pre-deploy cost estimate for Terraform and Bicep resources. | - |
+| `kube-bench` | kube-bench (AKS node-level CIS compliance) | subscription | azure | CIS Azure | CIS Kubernetes benchmark for AKS node hardening. | - |
+| `kubescape` | Kubescape (AKS runtime posture) | subscription | azure | CIS Azure, NIST 800-53 | Runtime posture for AKS clusters: misconfigurations, RBAC, network policies, vulnerabilities. | - |
+| `loadtesting` | Azure Load Testing (Failed and Regressed Runs) | subscription | azure | Azure WAF | Azure Load Testing reliability signals: failed runs, cancelled runs, and metric regressions. | - |
+| `maester` | Maester | tenant | microsoft365 | NIST 800-53, SOC2, PCI-DSS | Microsoft Entra (Identity) security baseline: conditional access, MFA, privileged roles. | [docs](./ai-triage.md) |
+| `psrule` | PSRule for Azure | subscription | azure | CIS Azure, NIST 800-53, Azure WAF, Azure CAF | Microsoft PSRule for Azure: Well-Architected and best-practice rule baseline. | - |
+| `scorecard` | OpenSSF Scorecard | repository | github | NIST 800-53, SOC2 | OpenSSF Scorecard for repository supply-chain hygiene. | - |
+| `sentinel-coverage` | Microsoft Sentinel (Coverage / Posture) | workspace | azure | NIST 800-53, SOC2, PCI-DSS, Azure WAF | Sentinel detection posture: analytic rules, watchlists, data connectors, hunting queries. | - |
+| `sentinel-incidents` | Microsoft Sentinel (Active Incidents) | workspace | azure | NIST 800-53, SOC2 | Pulls active Microsoft Sentinel incidents from a Log Analytics workspace. | - |
+| `terraform-iac` | Terraform IaC Validation | repository | cli | CIS Azure, NIST 800-53, Azure WAF, Azure CAF | Terraform IaC validation: tflint / tfsec / checkov-style checks. | - |
+| `trivy` | Trivy Vulnerability Scanner | repository | cli | CIS Azure, NIST 800-53, PCI-DSS | Vulnerability and IaC misconfiguration scanner for repos and container images. | - |
+| `wara` | Well-Architected Reliability Assessment | subscription | azure | Azure WAF, Azure CAF | Well-Architected Reliability Assessment workflow for production workloads. | - |
+| `zizmor` | zizmor (Actions YAML Scanner) | repository | cli | NIST 800-53, SOC2 | Static analysis for GitHub Actions workflow security risks. | - |
 
 ## Disabled / opt-in
 
 These tools are wired but turned off in the manifest. Enable them by setting `enabled: true` in `tools/tool-manifest.json` or via `tools/install-config.json`.
 
-| Name | Display name | Scope | Provider | What it does |
-|---|---|---|---|---|
-| `copilot-triage` | Copilot AI Triage | repository | cli | Optional Copilot-powered AI triage for finding prioritization (disabled by default). |
+| Name | Display name | Scope | Provider | Frameworks | What it does |
+|---|---|---|---|---|---|
+| `copilot-triage` | Copilot AI Triage | repository | cli | - | Optional Copilot-powered AI triage for finding prioritization (disabled by default). |
 
 ## Scope reference
 

--- a/docs/contributor/tool-catalog.md
+++ b/docs/contributor/tool-catalog.md
@@ -12,39 +12,39 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 
 ## Registration matrix
 
-| Name | Display name | Type | Provider | Scope | Status | Tier | Platforms |
-|---|---|---|---|---|---|---|---|
-| `ado-connections` | ADO Service Connections | collector | ado | ado | Enabled | 0 | windows, macos, linux |
-| `ado-pipeline-correlator` | ADO Pipeline Run Correlator | correlator | ado | ado | Enabled | 0 | windows, macos, linux |
-| `ado-pipelines` | ADO Pipeline Security | collector | ado | ado | Enabled | 0 | windows, macos, linux |
-| `ado-repos-secrets` | ADO Repos Secret Scanning | collector | ado | ado | Enabled | 0 | windows, macos, linux |
-| `aks-rightsizing` | AKS Rightsizing (Container Insights utilization) | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `alz-queries` | ALZ Resource Graph Queries | collector | azure | managementGroup | Enabled | 0 | windows, macos, linux |
-| `appinsights` | Application Insights Performance Signals | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `azgovviz` | AzGovViz | collector | azure | managementGroup | Enabled | 0 | windows, macos, linux |
-| `azqr` | Azure Quick Review | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `azure-cost` | Azure Cost (Consumption API) | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `bicep-iac` | Bicep IaC Validation | collector | cli | repository | Enabled | 0 | windows, macos, linux |
-| `copilot-triage` | Copilot AI Triage | enrichment | cli | repository | Disabled | 0 | windows, macos, linux |
-| `defender-for-cloud` | Microsoft Defender for Cloud | enrichment | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `falco` | Falco (AKS runtime anomaly detection) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `finops` | FinOps Signals (Idle Resource Detection) | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `gitleaks` | gitleaks (Secrets Scanner) | collector | cli | repository | Enabled | 0 | windows, macos, linux |
-| `identity-correlator` | Identity Correlator | correlator | graph | tenant | Enabled | 3 | windows, macos, linux |
-| `identity-graph-expansion` | Identity Graph Expansion | correlator | graph | tenant | Enabled | 3 | windows, macos, linux |
-| `infracost` | Infracost IaC Cost Estimation | collector | cli | repository | Enabled | 0 | windows, macos, linux |
-| `kube-bench` | kube-bench (AKS node-level CIS compliance) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `kubescape` | Kubescape (AKS runtime posture) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `loadtesting` | Azure Load Testing (Failed and Regressed Runs) | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `maester` | Maester | collector | microsoft365 | tenant | Enabled | 0 | windows, macos, linux |
-| `psrule` | PSRule for Azure | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `scorecard` | OpenSSF Scorecard | collector | github | repository | Enabled | 0 | windows, macos, linux |
-| `sentinel-coverage` | Microsoft Sentinel (Coverage / Posture) | collector | azure | workspace | Enabled | 0 | windows, macos, linux |
-| `sentinel-incidents` | Microsoft Sentinel (Active Incidents) | enrichment | azure | workspace | Enabled | 0 | windows, macos, linux |
-| `terraform-iac` | Terraform IaC Validation | collector | cli | repository | Enabled | 0 | windows, macos, linux |
-| `trivy` | Trivy Vulnerability Scanner | collector | cli | repository | Enabled | 0 | windows, macos, linux |
-| `wara` | Well-Architected Reliability Assessment | collector | azure | subscription | Enabled | 0 | windows, macos, linux |
-| `zizmor` | zizmor (Actions YAML Scanner) | collector | cli | repository | Enabled | 0 | windows, macos, linux |
+| Name | Display name | Type | Provider | Scope | Status | Tier | Platforms | Frameworks |
+|---|---|---|---|---|---|---|---|---|
+| `ado-connections` | ADO Service Connections | collector | ado | ado | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
+| `ado-pipeline-correlator` | ADO Pipeline Run Correlator | correlator | ado | ado | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2 |
+| `ado-pipelines` | ADO Pipeline Security | collector | ado | ado | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
+| `ado-repos-secrets` | ADO Repos Secret Scanning | collector | ado | ado | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
+| `aks-rightsizing` | AKS Rightsizing (Container Insights utilization) | collector | azure | subscription | Enabled | 0 | windows, macos, linux | Azure WAF, Azure CAF |
+| `alz-queries` | ALZ Resource Graph Queries | collector | azure | managementGroup | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53, Azure WAF, Azure CAF |
+| `appinsights` | Application Insights Performance Signals | collector | azure | subscription | Enabled | 0 | windows, macos, linux | Azure WAF |
+| `azgovviz` | AzGovViz | collector | azure | managementGroup | Enabled | 0 | windows, macos, linux | Azure WAF, Azure CAF |
+| `azqr` | Azure Quick Review | collector | azure | subscription | Enabled | 0 | windows, macos, linux | Azure WAF, Azure CAF |
+| `azure-cost` | Azure Cost (Consumption API) | collector | azure | subscription | Enabled | 0 | windows, macos, linux | Azure CAF |
+| `bicep-iac` | Bicep IaC Validation | collector | cli | repository | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53, Azure WAF, Azure CAF |
+| `copilot-triage` | Copilot AI Triage | enrichment | cli | repository | Disabled | 0 | windows, macos, linux | - |
+| `defender-for-cloud` | Microsoft Defender for Cloud | enrichment | azure | subscription | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53, Azure WAF, Azure CAF, SOC2, PCI-DSS |
+| `falco` | Falco (AKS runtime anomaly detection) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53 |
+| `finops` | FinOps Signals (Idle Resource Detection) | collector | azure | subscription | Enabled | 0 | windows, macos, linux | Azure WAF, Azure CAF |
+| `gitleaks` | gitleaks (Secrets Scanner) | collector | cli | repository | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
+| `identity-correlator` | Identity Correlator | correlator | graph | tenant | Enabled | 3 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
+| `identity-graph-expansion` | Identity Graph Expansion | correlator | graph | tenant | Enabled | 3 | windows, macos, linux | NIST 800-53, SOC2 |
+| `infracost` | Infracost IaC Cost Estimation | collector | cli | repository | Enabled | 0 | windows, macos, linux | Azure CAF |
+| `kube-bench` | kube-bench (AKS node-level CIS compliance) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux | CIS Azure |
+| `kubescape` | Kubescape (AKS runtime posture) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53 |
+| `loadtesting` | Azure Load Testing (Failed and Regressed Runs) | collector | azure | subscription | Enabled | 0 | windows, macos, linux | Azure WAF |
+| `maester` | Maester | collector | microsoft365 | tenant | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
+| `psrule` | PSRule for Azure | collector | azure | subscription | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53, Azure WAF, Azure CAF |
+| `scorecard` | OpenSSF Scorecard | collector | github | repository | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2 |
+| `sentinel-coverage` | Microsoft Sentinel (Coverage / Posture) | collector | azure | workspace | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS, Azure WAF |
+| `sentinel-incidents` | Microsoft Sentinel (Active Incidents) | enrichment | azure | workspace | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2 |
+| `terraform-iac` | Terraform IaC Validation | collector | cli | repository | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53, Azure WAF, Azure CAF |
+| `trivy` | Trivy Vulnerability Scanner | collector | cli | repository | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53, PCI-DSS |
+| `wara` | Well-Architected Reliability Assessment | collector | azure | subscription | Enabled | 0 | windows, macos, linux | Azure WAF, Azure CAF |
+| `zizmor` | zizmor (Actions YAML Scanner) | collector | cli | repository | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2 |
 
 ## Invocation
 

--- a/scripts/Generate-ToolCatalog.ps1
+++ b/scripts/Generate-ToolCatalog.ps1
@@ -159,6 +159,12 @@ function Format-Platforms {
     return ($tool.platforms -join ', ')
 }
 
+function Format-Frameworks {
+    param($tool)
+    if ($tool.PSObject.Properties.Name -notcontains 'frameworks' -or -not $tool.frameworks) { return '-' }
+    return ($tool.frameworks -join ', ')
+}
+
 function Format-Color {
     param($tool)
     if ($tool.PSObject.Properties.Name -notcontains 'report' -or -not $tool.report) { return '' }
@@ -208,11 +214,11 @@ function New-ConsumerCatalog {
     [void]$sb.AppendLine()
     [void]$sb.AppendLine('## Enabled by default')
     [void]$sb.AppendLine()
-    [void]$sb.AppendLine('| Name | Display name | Scope | Provider | What it does | Docs |')
-    [void]$sb.AppendLine('|---|---|---|---|---|---|')
+    [void]$sb.AppendLine('| Name | Display name | Scope | Provider | Frameworks | What it does | Docs |')
+    [void]$sb.AppendLine('|---|---|---|---|---|---|---|')
     foreach ($t in $enabledTools) {
-        $row = '| `{0}` | {1} | {2} | {3} | {4} | {5} |' -f `
-            $t.name, $t.displayName, $t.scope, $t.provider, (Get-ConsumerBlurb $t), (Get-ConsumerDocLink $t.name)
+        $row = '| `{0}` | {1} | {2} | {3} | {4} | {5} | {6} |' -f `
+            $t.name, $t.displayName, $t.scope, $t.provider, (Format-Frameworks $t), (Get-ConsumerBlurb $t), (Get-ConsumerDocLink $t.name)
         [void]$sb.AppendLine($row)
     }
 
@@ -222,11 +228,11 @@ function New-ConsumerCatalog {
         [void]$sb.AppendLine()
         [void]$sb.AppendLine('These tools are wired but turned off in the manifest. Enable them by setting `enabled: true` in `tools/tool-manifest.json` or via `tools/install-config.json`.')
         [void]$sb.AppendLine()
-        [void]$sb.AppendLine('| Name | Display name | Scope | Provider | What it does |')
-        [void]$sb.AppendLine('|---|---|---|---|---|')
+        [void]$sb.AppendLine('| Name | Display name | Scope | Provider | Frameworks | What it does |')
+        [void]$sb.AppendLine('|---|---|---|---|---|---|')
         foreach ($t in $disabledTools) {
-            $row = '| `{0}` | {1} | {2} | {3} | {4} |' -f `
-                $t.name, $t.displayName, $t.scope, $t.provider, (Get-ConsumerBlurb $t)
+            $row = '| `{0}` | {1} | {2} | {3} | {4} | {5} |' -f `
+                $t.name, $t.displayName, $t.scope, $t.provider, (Format-Frameworks $t), (Get-ConsumerBlurb $t)
             [void]$sb.AppendLine($row)
         }
     }
@@ -267,13 +273,13 @@ function New-ContributorCatalog {
 
     [void]$sb.AppendLine('## Registration matrix')
     [void]$sb.AppendLine()
-    [void]$sb.AppendLine('| Name | Display name | Type | Provider | Scope | Status | Tier | Platforms |')
-    [void]$sb.AppendLine('|---|---|---|---|---|---|---|---|')
+    [void]$sb.AppendLine('| Name | Display name | Type | Provider | Scope | Status | Tier | Platforms | Frameworks |')
+    [void]$sb.AppendLine('|---|---|---|---|---|---|---|---|---|')
     foreach ($t in $sortedTools) {
         $type = if ($t.PSObject.Properties.Name -contains 'type') { $t.type } else { '' }
         $tier = if ($t.PSObject.Properties.Name -contains 'requiredPermissionTier') { [string]$t.requiredPermissionTier } else { '' }
-        $row = '| `{0}` | {1} | {2} | {3} | {4} | {5} | {6} | {7} |' -f `
-            $t.name, $t.displayName, $type, $t.provider, $t.scope, (Format-Status $t.enabled), $tier, (Format-Platforms $t)
+        $row = '| `{0}` | {1} | {2} | {3} | {4} | {5} | {6} | {7} | {8} |' -f `
+            $t.name, $t.displayName, $type, $t.provider, $t.scope, (Format-Status $t.enabled), $tier, (Format-Platforms $t), (Format-Frameworks $t)
         [void]$sb.AppendLine($row)
     }
 

--- a/tests/reports/Framework-Matrix.Tests.ps1
+++ b/tests/reports/Framework-Matrix.Tests.ps1
@@ -1,0 +1,62 @@
+#Requires -Version 7.4
+
+Describe 'HTML report framework coverage matrix' {
+    BeforeAll {
+        $script:RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:ManifestPath = Join-Path $RootDir 'tools' 'tool-manifest.json'
+    }
+
+    It 'renders Framework Coverage rows from manifest mappings' {
+        $tmp = Join-Path $TestDrive 'framework-matrix-rows'
+        $null = New-Item -ItemType Directory -Path $tmp -Force
+        $resultsPath = Join-Path $tmp 'results.json'
+        '[]' | Set-Content -Path $resultsPath -Encoding UTF8
+        $outputPath = Join-Path $tmp 'report.html'
+
+        & (Join-Path $RootDir 'New-HtmlReport.ps1') -InputPath $resultsPath -OutputPath $outputPath | Out-Null
+        $html = Get-Content $outputPath -Raw
+
+        $html | Should -Match 'id="framework-coverage-matrix"'
+        $html | Should -Match 'Framework Coverage'
+
+        $manifest = Get-Content $ManifestPath -Raw | ConvertFrom-Json
+        $required = @('CIS Azure', 'NIST 800-53', 'Azure WAF', 'Azure CAF', 'SOC2', 'PCI-DSS')
+        $mapped = @(
+            $manifest.tools |
+            Where-Object { $_.enabled -and $_.frameworks } |
+            ForEach-Object { @($_.frameworks) }
+        )
+        $frameworks = @($required + $mapped | Sort-Object -Unique)
+        foreach ($fw in $frameworks) {
+            $html | Should -Match ("<tr data-framework='{0}'>" -f [Regex]::Escape($fw))
+        }
+    }
+
+    It 'renders matrix cell counts for tool/framework intersections' {
+        $tmp = Join-Path $TestDrive 'framework-matrix-counts'
+        $null = New-Item -ItemType Directory -Path $tmp -Force
+
+        $findings = @(
+            [pscustomobject]@{ Id='F-1'; Source='azqr';  Category='Security'; Title='WAF policy check'; Severity='High'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg/providers/Microsoft.Network/firewallPolicies/p1'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@('Azure WAF') }
+            [pscustomobject]@{ Id='F-2'; Source='azqr';  Category='Security'; Title='WAF policy check 2'; Severity='Low'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='/subscriptions/a/resourceGroups/rg/providers/Microsoft.Network/firewallPolicies/p2'; LearnMoreUrl=''; Platform='Azure'; Controls=@(); Frameworks=@('Azure WAF','Azure CAF') }
+            [pscustomobject]@{ Id='F-3'; Source='trivy'; Category='Security'; Title='CVE-1'; Severity='Critical'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='repo://x'; LearnMoreUrl=''; Platform='GitHub'; Controls=@(); Frameworks=@('NIST 800-53') }
+            [pscustomobject]@{ Id='F-4'; Source='trivy'; Category='Security'; Title='CVE-2'; Severity='Medium'; Compliant=$false; Detail='d'; Remediation='r'; ResourceId='repo://y'; LearnMoreUrl=''; Platform='GitHub'; Controls=@(); Frameworks=@('NIST 800-53') }
+            [pscustomobject]@{ Id='F-5'; Source='trivy'; Category='Security'; Title='CVE-3'; Severity='Info'; Compliant=$true; Detail='d'; Remediation='r'; ResourceId='repo://z'; LearnMoreUrl=''; Platform='GitHub'; Controls=@(); Frameworks=@('PCI-DSS') }
+        )
+
+        $resultsPath = Join-Path $tmp 'results.json'
+        $findings | ConvertTo-Json -Depth 8 | Set-Content -Path $resultsPath -Encoding UTF8
+        $outputPath = Join-Path $tmp 'report.html'
+
+        & (Join-Path $RootDir 'New-HtmlReport.ps1') -InputPath $resultsPath -OutputPath $outputPath | Out-Null
+        $html = Get-Content $outputPath -Raw
+
+        $html | Should -Match 'data-source=''azqr'' data-framework=''Azure WAF'''
+        $html | Should -Match 'data-source=''azqr'' data-framework=''Azure CAF'''
+        $html | Should -Match 'data-source=''trivy'' data-framework=''NIST 800-53'''
+
+        $html | Should -Match "<button type='button' class='fxm-button fxm-button-hit' data-source='azqr' data-framework='Azure WAF'[^>]*>\s*<span class='fxm-cell-count'>2</span>"
+        $html | Should -Match "<button type='button' class='fxm-button fxm-button-hit' data-source='azqr' data-framework='Azure CAF'[^>]*>\s*<span class='fxm-cell-count'>1</span>"
+        $html | Should -Match "<button type='button' class='fxm-button fxm-button-hit' data-source='trivy' data-framework='NIST 800-53'[^>]*>\s*<span class='fxm-cell-count'>2</span>"
+    }
+}

--- a/tools/tool-manifest.json
+++ b/tools/tool-manifest.json
@@ -31,7 +31,10 @@
       "install": {
         "kind": "cli",
         "command": "azqr",
-        "preferredManagers": ["winget", "brew"],
+        "preferredManagers": [
+          "winget",
+          "brew"
+        ],
         "windows": {
           "winget": "azure-quick-review.azqr"
         },
@@ -47,7 +50,11 @@
         "releaseApi": "https://api.github.com/repos/Azure/azqr/releases/latest",
         "pinType": "cli-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "Azure WAF",
+        "Azure CAF"
+      ]
     },
     {
       "name": "kubescape",
@@ -59,26 +66,54 @@
       "invokeMethod": "script",
       "type": "scanner",
       "script": "modules/Invoke-Kubescape.ps1",
-      "requiredParams": ["SubscriptionId"],
-      "optionalParams": ["ClusterArmIds", "OutputPath"],
+      "requiredParams": [
+        "SubscriptionId"
+      ],
+      "optionalParams": [
+        "ClusterArmIds",
+        "OutputPath"
+      ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "color": "#7b1fa2", "phase": 6 },
+      "report": {
+        "color": "#7b1fa2",
+        "phase": 6
+      },
       "install": {
         "kind": "cli",
         "command": "kubescape",
-        "preferredManagers": ["winget", "brew"],
-        "windows": { "manager": "winget", "package": "ARMO.kubescape" },
-        "macos":   { "manager": "brew",   "package": "kubescape" },
-        "linux":   { "manager": "script", "url": "https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh" }
+        "preferredManagers": [
+          "winget",
+          "brew"
+        ],
+        "windows": {
+          "manager": "winget",
+          "package": "ARMO.kubescape"
+        },
+        "macos": {
+          "manager": "brew",
+          "package": "kubescape"
+        },
+        "linux": {
+          "manager": "script",
+          "url": "https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh"
+        }
       },
       "upstream": {
         "repo": "kubescape/kubescape",
         "releaseApi": "https://api.github.com/repos/kubescape/kubescape/releases/latest",
         "pinType": "version",
         "currentPin": "v3"
-      }
+      },
+      "frameworks": [
+        "CIS Azure",
+        "NIST 800-53"
+      ]
     },
     {
       "name": "kube-bench",
@@ -90,15 +125,32 @@
       "invokeMethod": "script",
       "type": "scanner",
       "script": "modules/Invoke-KubeBench.ps1",
-      "requiredParams": ["SubscriptionId"],
-      "optionalParams": ["ClusterArmIds", "OutputPath", "JobTimeoutSeconds", "KubeBenchImage"],
+      "requiredParams": [
+        "SubscriptionId"
+      ],
+      "optionalParams": [
+        "ClusterArmIds",
+        "OutputPath",
+        "JobTimeoutSeconds",
+        "KubeBenchImage"
+      ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "color": "#5e35b1", "phase": 6 },
+      "report": {
+        "color": "#5e35b1",
+        "phase": 6
+      },
       "install": {
         "kind": "none"
-      }
+      },
+      "frameworks": [
+        "CIS Azure"
+      ]
     },
     {
       "name": "defender-for-cloud",
@@ -110,16 +162,37 @@
       "invokeMethod": "script",
       "type": "enrichment",
       "script": "modules/Invoke-DefenderForCloud.ps1",
-      "requiredParams": ["SubscriptionId"],
-      "optionalParams": ["OutputPath"],
+      "requiredParams": [
+        "SubscriptionId"
+      ],
+      "optionalParams": [
+        "OutputPath"
+      ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "color": "#0078d4", "phase": 4 },
+      "report": {
+        "color": "#0078d4",
+        "phase": 4
+      },
       "install": {
         "kind": "psmodule",
-        "modules": ["Az.Accounts"]
-      }
+        "modules": [
+          "Az.Accounts"
+        ]
+      },
+      "frameworks": [
+        "CIS Azure",
+        "NIST 800-53",
+        "Azure WAF",
+        "Azure CAF",
+        "SOC2",
+        "PCI-DSS"
+      ]
     },
     {
       "name": "falco",
@@ -131,22 +204,42 @@
       "invokeMethod": "script",
       "type": "scanner",
       "script": "modules/Invoke-Falco.ps1",
-      "requiredParams": ["SubscriptionId"],
-      "optionalParams": ["ClusterArmIds", "InstallFalco", "UninstallFalco", "CaptureMinutes"],
+      "requiredParams": [
+        "SubscriptionId"
+      ],
+      "optionalParams": [
+        "ClusterArmIds",
+        "InstallFalco",
+        "UninstallFalco",
+        "CaptureMinutes"
+      ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "color": "#ef6c00", "phase": 6 },
+      "report": {
+        "color": "#ef6c00",
+        "phase": 6
+      },
       "install": {
         "kind": "psmodule",
-        "modules": ["Az.ResourceGraph"]
+        "modules": [
+          "Az.ResourceGraph"
+        ]
       },
       "upstream": {
         "repo": "falcosecurity/falco",
         "releaseApi": "https://api.github.com/repos/falcosecurity/falco/releases/latest",
         "pinType": "cli-version",
         "currentPin": "0.42.0"
-      }
+      },
+      "frameworks": [
+        "CIS Azure",
+        "NIST 800-53"
+      ]
     },
     {
       "name": "azure-cost",
@@ -158,16 +251,33 @@
       "invokeMethod": "script",
       "type": "collector",
       "script": "modules/Invoke-AzureCost.ps1",
-      "requiredParams": ["SubscriptionId"],
-      "optionalParams": ["TopN", "OutputPath"],
+      "requiredParams": [
+        "SubscriptionId"
+      ],
+      "optionalParams": [
+        "TopN",
+        "OutputPath"
+      ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "color": "#388e3c", "phase": 4 },
+      "report": {
+        "color": "#388e3c",
+        "phase": 4
+      },
       "install": {
         "kind": "psmodule",
-        "modules": ["Az.Accounts"]
-      }
+        "modules": [
+          "Az.Accounts"
+        ]
+      },
+      "frameworks": [
+        "Azure CAF"
+      ]
     },
     {
       "name": "finops",
@@ -179,16 +289,36 @@
       "invokeMethod": "script",
       "type": "collector",
       "script": "modules/Invoke-FinOpsSignals.ps1",
-      "requiredParams": ["SubscriptionId"],
-      "optionalParams": ["OutputPath", "QueryFiles"],
+      "requiredParams": [
+        "SubscriptionId"
+      ],
+      "optionalParams": [
+        "OutputPath",
+        "QueryFiles"
+      ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "label": "FinOps Signals", "color": "#00897b", "phase": 4 },
+      "report": {
+        "label": "FinOps Signals",
+        "color": "#00897b",
+        "phase": 4
+      },
       "install": {
         "kind": "psmodule",
-        "modules": ["Az.CostManagement", "Az.ResourceGraph"]
-      }
+        "modules": [
+          "Az.CostManagement",
+          "Az.ResourceGraph"
+        ]
+      },
+      "frameworks": [
+        "Azure WAF",
+        "Azure CAF"
+      ]
     },
     {
       "name": "appinsights",
@@ -200,7 +330,9 @@
       "invokeMethod": "script",
       "type": "collector",
       "script": "modules/Invoke-AppInsights.ps1",
-      "requiredParams": ["SubscriptionId"],
+      "requiredParams": [
+        "SubscriptionId"
+      ],
       "optionalParams": [
         "ResourceGroup",
         "AppInsightsName",
@@ -208,13 +340,28 @@
         "OutputPath"
       ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "label": "App Insights", "color": "#00838f", "phase": 4 },
+      "report": {
+        "label": "App Insights",
+        "color": "#00838f",
+        "phase": 4
+      },
       "install": {
         "kind": "psmodule",
-        "modules": ["Az.Accounts", "Az.ApplicationInsights", "Az.Monitor"]
-      }
+        "modules": [
+          "Az.Accounts",
+          "Az.ApplicationInsights",
+          "Az.Monitor"
+        ]
+      },
+      "frameworks": [
+        "Azure WAF"
+      ]
     },
     {
       "name": "loadtesting",
@@ -226,7 +373,9 @@
       "invokeMethod": "script",
       "type": "collector",
       "script": "modules/Invoke-AzureLoadTesting.ps1",
-      "requiredParams": ["SubscriptionId"],
+      "requiredParams": [
+        "SubscriptionId"
+      ],
       "optionalParams": [
         "ResourceGroup",
         "LoadTestResourceName",
@@ -236,13 +385,27 @@
         "OutputPath"
       ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "label": "Load Testing", "color": "#00695c", "phase": 4 },
+      "report": {
+        "label": "Load Testing",
+        "color": "#00695c",
+        "phase": 4
+      },
       "install": {
         "kind": "psmodule",
-        "modules": ["Az.Accounts", "Az.LoadTesting"]
-      }
+        "modules": [
+          "Az.Accounts",
+          "Az.LoadTesting"
+        ]
+      },
+      "frameworks": [
+        "Azure WAF"
+      ]
     },
     {
       "name": "aks-rightsizing",
@@ -254,7 +417,9 @@
       "invokeMethod": "script",
       "type": "collector",
       "script": "modules/Invoke-AksRightsizing.ps1",
-      "requiredParams": ["SubscriptionId"],
+      "requiredParams": [
+        "SubscriptionId"
+      ],
       "optionalParams": [
         "ResourceGroup",
         "ClusterName",
@@ -263,13 +428,29 @@
         "OutputPath"
       ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "label": "AKS Rightsizing", "color": "#2e7d32", "phase": 4 },
+      "report": {
+        "label": "AKS Rightsizing",
+        "color": "#2e7d32",
+        "phase": 4
+      },
       "install": {
         "kind": "psmodule",
-        "modules": ["Az.Accounts", "Az.ResourceGraph", "Az.OperationalInsights"]
-      }
+        "modules": [
+          "Az.Accounts",
+          "Az.ResourceGraph",
+          "Az.OperationalInsights"
+        ]
+      },
+      "frameworks": [
+        "Azure WAF",
+        "Azure CAF"
+      ]
     },
     {
       "name": "psrule",
@@ -310,7 +491,13 @@
         "releaseApi": "https://api.github.com/repos/microsoft/PSRule.Rules.Azure/releases/latest",
         "pinType": "psmodule-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "CIS Azure",
+        "NIST 800-53",
+        "Azure WAF",
+        "Azure CAF"
+      ]
     },
     {
       "name": "azgovviz",
@@ -351,7 +538,11 @@
         "releaseApi": "https://api.github.com/repos/JulianHayward/Azure-MG-Sub-Governance-Reporting/commits/master",
         "pinType": "sha",
         "currentPin": "HEAD"
-      }
+      },
+      "frameworks": [
+        "Azure WAF",
+        "Azure CAF"
+      ]
     },
     {
       "name": "alz-queries",
@@ -392,7 +583,13 @@
         "releaseApi": "https://api.github.com/repos/Azure/Azure-Landing-Zones-Library/commits/main",
         "pinType": "sha",
         "currentPin": "HEAD"
-      }
+      },
+      "frameworks": [
+        "CIS Azure",
+        "NIST 800-53",
+        "Azure WAF",
+        "Azure CAF"
+      ]
     },
     {
       "name": "wara",
@@ -433,7 +630,11 @@
         "releaseApi": "https://api.github.com/repos/Azure/Azure-Proactive-Resiliency-Library-v2/releases/latest",
         "pinType": "psmodule-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "Azure WAF",
+        "Azure CAF"
+      ]
     },
     {
       "name": "maester",
@@ -469,7 +670,12 @@
         "releaseApi": "https://api.github.com/repos/maester365/maester/releases/latest",
         "pinType": "psmodule-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2",
+        "PCI-DSS"
+      ]
     },
     {
       "name": "scorecard",
@@ -501,7 +707,10 @@
       "install": {
         "kind": "cli",
         "command": "scorecard",
-        "preferredManagers": ["winget", "brew"],
+        "preferredManagers": [
+          "winget",
+          "brew"
+        ],
         "windows": {
           "winget": "ossf.scorecard"
         },
@@ -517,7 +726,11 @@
         "releaseApi": "https://api.github.com/repos/ossf/scorecard/releases/latest",
         "pinType": "cli-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2"
+      ]
     },
     {
       "name": "ado-connections",
@@ -549,7 +762,12 @@
       },
       "install": {
         "kind": "none"
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2",
+        "PCI-DSS"
+      ]
     },
     {
       "name": "ado-pipelines",
@@ -581,7 +799,12 @@
       },
       "install": {
         "kind": "none"
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2",
+        "PCI-DSS"
+      ]
     },
     {
       "name": "ado-repos-secrets",
@@ -616,7 +839,12 @@
       },
       "install": {
         "kind": "none"
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2",
+        "PCI-DSS"
+      ]
     },
     {
       "name": "ado-pipeline-correlator",
@@ -649,7 +877,11 @@
       },
       "install": {
         "kind": "none"
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2"
+      ]
     },
     {
       "name": "identity-correlator",
@@ -684,7 +916,12 @@
           "Microsoft.Graph.Authentication",
           "Microsoft.Graph.Applications"
         ]
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2",
+        "PCI-DSS"
+      ]
     },
     {
       "name": "identity-graph-expansion",
@@ -724,7 +961,11 @@
           "Microsoft.Graph.Applications",
           "Az.Resources"
         ]
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2"
+      ]
     },
     {
       "name": "zizmor",
@@ -755,7 +996,10 @@
       "install": {
         "kind": "cli",
         "command": "zizmor",
-        "preferredManagers": ["pipx", "brew"],
+        "preferredManagers": [
+          "pipx",
+          "brew"
+        ],
         "windows": {
           "pipx": "zizmor"
         },
@@ -771,7 +1015,11 @@
         "releaseApi": "https://api.github.com/repos/woodruffw/zizmor/releases/latest",
         "pinType": "cli-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2"
+      ]
     },
     {
       "name": "gitleaks",
@@ -802,7 +1050,10 @@
       "install": {
         "kind": "cli",
         "command": "gitleaks",
-        "preferredManagers": ["winget", "brew"],
+        "preferredManagers": [
+          "winget",
+          "brew"
+        ],
         "windows": {
           "winget": "gitleaks.gitleaks"
         },
@@ -818,7 +1069,12 @@
         "releaseApi": "https://api.github.com/repos/gitleaks/gitleaks/releases/latest",
         "pinType": "cli-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2",
+        "PCI-DSS"
+      ]
     },
     {
       "name": "trivy",
@@ -849,7 +1105,10 @@
       "install": {
         "kind": "cli",
         "command": "trivy",
-        "preferredManagers": ["winget", "brew"],
+        "preferredManagers": [
+          "winget",
+          "brew"
+        ],
         "windows": {
           "winget": "AquaSecurity.Trivy"
         },
@@ -865,7 +1124,12 @@
         "releaseApi": "https://api.github.com/repos/aquasecurity/trivy/releases/latest",
         "pinType": "cli-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "CIS Azure",
+        "NIST 800-53",
+        "PCI-DSS"
+      ]
     },
     {
       "name": "bicep-iac",
@@ -912,7 +1176,13 @@
         "releaseApi": "https://api.github.com/repos/Azure/bicep/releases/latest",
         "pinType": "cli-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "CIS Azure",
+        "NIST 800-53",
+        "Azure WAF",
+        "Azure CAF"
+      ]
     },
     {
       "name": "infracost",
@@ -945,7 +1215,10 @@
       "install": {
         "kind": "cli",
         "command": "infracost",
-        "preferredManagers": ["winget", "brew"],
+        "preferredManagers": [
+          "winget",
+          "brew"
+        ],
         "windows": {
           "winget": "Infracost.Infracost"
         },
@@ -961,7 +1234,10 @@
         "releaseApi": "https://api.github.com/repos/infracost/infracost/releases/latest",
         "pinType": "cli-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "Azure CAF"
+      ]
     },
     {
       "name": "terraform-iac",
@@ -1007,7 +1283,13 @@
         "releaseApi": "https://api.github.com/repos/hashicorp/terraform/releases/latest",
         "pinType": "cli-version",
         "currentPin": "latest"
-      }
+      },
+      "frameworks": [
+        "CIS Azure",
+        "NIST 800-53",
+        "Azure WAF",
+        "Azure CAF"
+      ]
     },
     {
       "name": "sentinel-incidents",
@@ -1019,16 +1301,34 @@
       "invokeMethod": "script",
       "type": "enrichment",
       "script": "modules/Invoke-SentinelIncidents.ps1",
-      "requiredParams": ["WorkspaceResourceId"],
-      "optionalParams": ["LookbackDays", "OutputPath"],
+      "requiredParams": [
+        "WorkspaceResourceId"
+      ],
+      "optionalParams": [
+        "LookbackDays",
+        "OutputPath"
+      ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "color": "#0078d4", "phase": 4 },
+      "report": {
+        "color": "#0078d4",
+        "phase": 4
+      },
       "install": {
         "kind": "psmodule",
-        "modules": ["Az.Accounts"]
-      }
+        "modules": [
+          "Az.Accounts"
+        ]
+      },
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2"
+      ]
     },
     {
       "name": "sentinel-coverage",
@@ -1040,17 +1340,37 @@
       "invokeMethod": "script",
       "type": "collector",
       "script": "modules/Invoke-SentinelCoverage.ps1",
-      "requiredParams": ["WorkspaceResourceId"],
-      "optionalParams": ["LookbackDays", "OutputPath"],
+      "requiredParams": [
+        "WorkspaceResourceId"
+      ],
+      "optionalParams": [
+        "LookbackDays",
+        "OutputPath"
+      ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": true,
-      "report": { "color": "#3949ab", "phase": 4 },
+      "report": {
+        "color": "#3949ab",
+        "phase": 4
+      },
       "install": {
         "kind": "psmodule",
-        "modules": ["Az.Accounts"]
+        "modules": [
+          "Az.Accounts"
+        ]
       },
-      "comment": "Surfaces Sentinel detection posture (analytic rules, watchlists, connectors, hunting queries) via Microsoft.SecurityInsights REST. Read-only; pairs with sentinel-incidents."
+      "comment": "Surfaces Sentinel detection posture (analytic rules, watchlists, connectors, hunting queries) via Microsoft.SecurityInsights REST. Read-only; pairs with sentinel-incidents.",
+      "frameworks": [
+        "NIST 800-53",
+        "SOC2",
+        "PCI-DSS",
+        "Azure WAF"
+      ]
     },
     {
       "name": "copilot-triage",
@@ -1063,15 +1383,26 @@
       "type": "enrichment",
       "script": "modules/Invoke-CopilotTriage.ps1",
       "requiredParams": [],
-      "optionalParams": ["InputPath", "OutputPath"],
+      "optionalParams": [
+        "InputPath",
+        "OutputPath"
+      ],
       "requiredPermissionTier": 0,
-      "platforms": ["windows", "macos", "linux"],
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
       "enabled": false,
-      "report": { "color": "#6a1b9a", "phase": 8 },
+      "report": {
+        "color": "#6a1b9a",
+        "phase": 8
+      },
       "install": {
         "kind": "none"
       },
-      "comment": "Requires GitHub Copilot SDK token; opt-in via -EnableAiTriage switch."
+      "comment": "Requires GitHub Copilot SDK token; opt-in via -EnableAiTriage switch.",
+      "frameworks": []
     }
   ],
   "prerequisites": [
@@ -1079,11 +1410,18 @@
       "name": "kubelogin",
       "displayName": "Azure kubelogin (AAD exec plugin)",
       "purpose": "Required by Invoke-Kubescape / Invoke-Falco / Invoke-KubeBench when -KubeAuthMode is 'Kubelogin' or 'WorkloadIdentity'. Converts kubeconfig exec plugin entries to use AAD tokens (azurecli / spn / msi / workloadidentity).",
-      "consumedBy": ["kubescape", "falco", "kube-bench"],
+      "consumedBy": [
+        "kubescape",
+        "falco",
+        "kube-bench"
+      ],
       "install": {
         "kind": "cli",
         "command": "kubelogin",
-        "preferredManagers": ["winget", "brew"],
+        "preferredManagers": [
+          "winget",
+          "brew"
+        ],
         "windows": {
           "manager": "winget",
           "package": "Azure.Kubelogin"


### PR DESCRIPTION
## Summary

This PR adds a manifest-driven Framework Coverage view to `New-HtmlReport.ps1`.

- New report section: **Framework Coverage**
- Matrix axes: rows = frameworks, columns = tools
- Cell semantics:
  - `-` unmapped (tool has no framework mapping)
  - `✓ 0` mapped but zero findings
  - count + per-severity mini chips for mapped intersections with findings
- Severity-weighted heat intensity per mapped cell
- Click any mapped cell to filter findings to that `(tool, framework)` intersection
- Summary column (totals per framework) and summary row (totals per tool)

## Design choices

### Framework mapping source

Used **Option A**: `tools/tool-manifest.json` now has `frameworks: []` on every tool entry.

Initial taxonomy seeded:

- CIS Azure
- NIST 800-53
- Azure WAF
- Azure CAF
- SOC2
- PCI-DSS

`New-HtmlReport.ps1` reads these mappings directly.

### Integration with existing report views

- Preserves the severity heatmap view introduced in #221 lineage.
- Preserves severity strip behavior from #270.
- Preserves collapsible findings tree behavior from #275.
- Extends the global filter bar with `framework` filtering.

## Implementation notes

- Added framework normalization helpers in `New-HtmlReport.ps1`.
- Added `data-frameworks` attribute to tree finding nodes for client-side filtering.
- Added `filterByFrameworkMatrix(source, framework)` JS handler.
- Added matrix-specific CSS classes for heat + badge rendering.
- Added report test coverage: `tests/reports/Framework-Matrix.Tests.ps1`.
- Extended `scripts/Generate-ToolCatalog.ps1` to include manifest framework mappings in generated catalogs.

## Docs and generated artifacts

- `README.md` updated with Framework Coverage matrix mention.
- `docs/consumer/README.md` updated.
- `CHANGELOG.md` updated.
- Regenerated:
  - `docs/consumer/tool-catalog.md`
  - `docs/contributor/tool-catalog.md`

## Validation

- `Invoke-Pester -Path .\tests -CI`
  - Passed: **1294**
  - Failed: **0**
  - Skipped: **5**

## Screenshot description

In Findings tab, below the existing severity heatmap, a new **Framework Coverage** table appears with framework rows and tool columns. Cells show `-`, `✓ 0`, or a colored count badge with per-severity mini chips. Clicking a cell sets the Tool and Framework filters and narrows the collapsible findings tree to that intersection.