### PR TITLE
feat: CI/CD cost telemetry - GitHub Actions billing + ADO pipeline consumption (v1.2.0, closes #232)

### DIFF
--- a/.squad/agents/atlas/history.md
+++ b/.squad/agents/atlas/history.md
@@ -101,3 +101,9 @@ First merge attempt failed with "2 of 2 required status checks are expected" eve
 ## 2026-04-20 - Issue #230 framework matrix
 
 Implemented framework x tool coverage matrix in New-HtmlReport with click-to-filter, manifest frameworks[] source-of-truth, regenerated tool catalogs + permissions index, and added report tests (full suite 1294 pass / 5 skipped).
+
+## 2026-04-20T21:28:04Z - Issue #232 CI/CD cost telemetry
+
+Implemented GH Actions billing plus ADO pipeline consumption cost telemetry for v1.2.0 with two independent wrappers (Invoke-GhActionsBilling.ps1, Invoke-AdoConsumption.ps1), two normalizers (Normalize-GhActionsBilling, Normalize-AdoConsumption), manifest registration, fixtures, wrapper and normalizer tests, and permission docs (gh-actions-billing.md, ado-consumption.md).
+
+Validation: full Invoke-Pester -Path .\\tests -CI passed with **1321 passed / 0 failed / 5 skipped** (baseline before work: **1307 passed**), plus manifest-driven docs regeneration (Generate-ToolCatalog.ps1, Generate-PermissionsIndex.ps1).

--- a/.squad/decisions/inbox/atlas-issue-232-complete-2026-04-20T21-29-30Z.md
+++ b/.squad/decisions/inbox/atlas-issue-232-complete-2026-04-20T21-29-30Z.md
@@ -1,0 +1,33 @@
+# Atlas - Issue #232 complete: CI/CD cost telemetry
+
+- **Date (UTC):** 2026-04-20T21:29:30Z
+- **Agent:** Atlas
+- **Issue:** [#232](https://github.com/martinopedal/azure-analyzer/issues/232) - feat: CI/CD cost telemetry (GH Actions billing + ADO consumption)
+- **Decision status:** Implemented locally (pending PR and merge flow).
+
+## Tool split decision
+
+Implemented two wrappers and two manifest entries:
+
+- `gh-actions-billing` (provider `github`)
+- `ado-consumption` (provider `ado`)
+
+Rationale: independent auth surfaces, independent enable/disable controls, and cleaner permission docs.
+
+## Threshold defaults
+
+- GitHub org over-budget: `included_minutes_used > included_minutes` (High)
+- GitHub run anomaly: run duration `> 60 minutes` and `> 2x` peer baseline (Low)
+- ADO project share: `>= 40%` of org runner minutes (Medium)
+- ADO duration regression: second-half average `> 25%` above first-half average (Medium)
+- ADO failed run rate: `> 10%` (High)
+- Optional `MonthlyBudgetUsd` threshold on both wrappers uses an estimated USD/min model.
+
+## Validation snapshot
+
+- Pester baseline before change: **1307 discovered, 1307 passed**.
+- Pester after change: **1326 discovered, 1321 passed, 0 failed, 5 skipped**.
+- New test delta: **+19 tests** (wrappers + normalizers).
+- Manifest-driven docs regenerated:
+  - `scripts/Generate-ToolCatalog.ps1`
+  - `scripts/Generate-PermissionsIndex.ps1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to azure-analyzer will be documented here.
 - Schema: `AdoProject` and `KarpenterProvisioner` added to the `EntityType` enum (foundational for #232, #234).
 - Docs: opt-in elevated RBAC tier for Karpenter inspection scaffolded in `PERMISSIONS.md` (foundational for #234; opt-in mechanism TBD, lands with #234 in Stage 2).
 - feat(reports): top recommendations by impact panel using v2.1 RuleId (closes #227)
+- feat: GitHub Actions billing wrapper (org budget, top repo consumers, run anomaly) (closes #232)
+- feat: ADO pipeline consumption wrapper (parallel-job ratio, duration regression, failed pipeline rate) (closes #232)
 
 ### Changed
 

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -59,6 +59,7 @@ Per-tool permission detail lives under [`docs/consumer/permissions/`](docs/consu
 
 | Tool | Scope | Detail |
 |---|---|---|
+| **GitHub Actions Billing** | Repository | [`gh-actions-billing.md`](docs/consumer/permissions/gh-actions-billing.md) |
 | **OpenSSF Scorecard** | Repository | [`scorecard.md`](docs/consumer/permissions/scorecard.md) |
 
 ### Azure DevOps
@@ -66,6 +67,7 @@ Per-tool permission detail lives under [`docs/consumer/permissions/`](docs/consu
 | Tool | Scope | Detail |
 |---|---|---|
 | **ADO Service Connections** | ADO Org | [`ado-connections.md`](docs/consumer/permissions/ado-connections.md) |
+| **ADO Pipeline Consumption** | ADO Org | [`ado-consumption.md`](docs/consumer/permissions/ado-consumption.md) |
 | **ADO Pipeline Run Correlator** | ADO Org | [`ado-pipeline-correlator.md`](docs/consumer/permissions/ado-pipeline-correlator.md) |
 | **ADO Pipeline Security** | ADO Org | [`ado-pipelines.md`](docs/consumer/permissions/ado-pipelines.md) |
 | **ADO Repos Secret Scanning** | ADO Org | [`ado-repos-secrets.md`](docs/consumer/permissions/ado-repos-secrets.md) |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CodeQL](https://github.com/martinopedal/azure-analyzer/actions/workflows/codeql.yml/badge.svg)](https://github.com/martinopedal/azure-analyzer/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**One PowerShell command, 29 read-only Azure assessment tools, one unified HTML and Markdown report.** Cloud-first by default: target remote GitHub and Azure DevOps repositories without cloning anything by hand.
+**One PowerShell command, 32 read-only Azure assessment tools, one unified HTML and Markdown report.** Cloud-first by default: target remote GitHub and Azure DevOps repositories without cloning anything by hand.
 
 ## Install
 
@@ -63,7 +63,7 @@ The HTML report includes an executive Summary tab, a Top recommendations by impa
 
 ## What you get
 
-- **29 tools** across Azure resources, Entra ID, GitHub, and Azure DevOps.
+- **32 tools** across Azure resources, Entra ID, GitHub, and Azure DevOps.
 - **Unified v2 schema** with 5 severity levels (Critical, High, Medium, Low, Info) and 14 entity types across 4 platforms (Azure, Entra, GitHub, ADO).
 - **Read-only everywhere.** No write permissions on any cloud. See [PERMISSIONS.md](PERMISSIONS.md) for exact scopes.
 - **HTML + Markdown reports** with executive summary, top impact recommendations, heatmap, framework coverage matrix, filtering, control-framework chips, and CSV export.
@@ -78,7 +78,8 @@ The three quickstart scenarios above are the common path. The consumer index in 
 
 - Azure plus Entra identity (Maester) and cross-tenant identity-graph expansion
 - GitHub Enterprise (GHEC-DR / GHES) targeting
-- Azure DevOps Services and Azure DevOps Server pipeline, service-connection, and repo-secret posture
+- Azure DevOps Services and Azure DevOps Server pipeline, service-connection, repo-secret, and pipeline-consumption posture
+- GitHub Actions billing and runner-minute cost telemetry
 - Sentinel coverage and active incidents
 - Application Insights performance signals (slow requests, dependency failures, exception clusters)
 - Azure Load Testing failed and regressed runs
@@ -97,8 +98,8 @@ All tools run **read-only**. Most common scopes:
 | Azure **Reader** | azqr, PSRule, AzGovViz, ALZ Queries, WARA, Azure Cost, FinOps Signals, App Insights, Defender for Cloud |
 | **Cost Management Reader** (recommended) | FinOps Signals, Azure Cost |
 | Microsoft **Graph** (read) | Maester (Entra ID) |
-| **GitHub PAT** (optional) | Scorecard, remote repo scans |
-| **Azure DevOps PAT** (optional) | ADO Service Connections, Pipeline Security, Repo Secrets, Pipeline Correlator |
+| **GitHub PAT** (optional) | Scorecard, GitHub Actions Billing, remote repo scans |
+| **Azure DevOps PAT** (optional) | ADO Service Connections, Pipeline Security, Pipeline Consumption, Repo Secrets, Pipeline Correlator |
 | Local CLI only (no cloud) | zizmor, gitleaks, Trivy on a local path |
 
 Full breakdown, token types, and setup commands: [PERMISSIONS.md](PERMISSIONS.md).

--- a/docs/consumer/README.md
+++ b/docs/consumer/README.md
@@ -13,4 +13,4 @@ All advanced consumer docs live here. The root `README.md` is your starting poin
 - [permissions/loadtesting.md](permissions/loadtesting.md) - Azure Load Testing failed-run and regression permissions and usage.
 - [permissions/aks-rightsizing.md](permissions/aks-rightsizing.md) - AKS Container Insights rightsizing permissions and usage.
 - [sinks/log-analytics.md](sinks/log-analytics.md) - Streaming azure-analyzer findings into Azure Log Analytics.
-- Cost and performance tools are listed in [tool-catalog.md](tool-catalog.md); permission details are in [permissions/](permissions/README.md).
+- Cost and performance tools include Azure Cost, FinOps Signals, GitHub Actions Billing, and ADO Pipeline Consumption. Tool coverage is listed in [tool-catalog.md](tool-catalog.md); permission details are in [permissions/](permissions/README.md).

--- a/docs/consumer/permissions/ado-consumption.md
+++ b/docs/consumer/permissions/ado-consumption.md
@@ -1,0 +1,34 @@
+# ADO pipeline consumption - Required permissions
+
+**Display name:** ADO Pipeline Consumption
+
+**Scope:** ado | **Provider:** ado
+
+The ADO consumption wrapper reads build run telemetry to detect cost and reliability regressions. It only performs GET operations against Azure DevOps REST APIs.
+
+## Required PAT scopes
+
+| PAT scope | Why |
+|---|---|
+| `Build (Read)` | Read build run history and result metadata |
+| `Project and Team (Read)` | Enumerate projects when `-Project` is not specified |
+| `Identity (Read)` | Resolve project context and principal metadata returned by build APIs |
+
+## Parameters
+
+- `-Organization <name>` (required): Azure DevOps organization.
+- `-Project <name>` (optional): single project filter.
+- `-DaysBack <int>` (default `30`): telemetry lookback.
+- `-MonthlyBudgetUsd <double>` (optional): soft cost threshold.
+- `-AdoPat <token>` (optional): PAT override; env fallback supported.
+
+## What it scans
+
+- Project share of org runner-minute consumption.
+- Build duration regression greater than 25 percent.
+- Failed build run rate greater than 10 percent.
+
+## What it does NOT do
+
+- No pipeline edits.
+- No variable or agent pool changes.

--- a/docs/consumer/permissions/gh-actions-billing.md
+++ b/docs/consumer/permissions/gh-actions-billing.md
@@ -1,0 +1,33 @@
+# GitHub Actions billing - Required permissions
+
+**Display name:** GitHub Actions Billing
+
+**Scope:** repository | **Provider:** github
+
+The GitHub Actions billing wrapper reads org billing metrics and workflow run duration telemetry for cost signals. It does not mutate repositories, workflows, or billing settings.
+
+## Required token scopes
+
+| Token scope | Why |
+|---|---|
+| `read:org` | Read org billing endpoint `/orgs/{org}/settings/billing/actions` |
+| `repo` | Read private repository metadata and workflow runs |
+| `actions:read` | Read workflow run history under `/repos/{org}/{repo}/actions/runs` |
+
+## Parameters
+
+- `-Org <name>` (required): GitHub organization.
+- `-Repo <name>` (optional): single repository filter.
+- `-DaysBack <int>` (default `30`): workflow run lookback.
+- `-MonthlyBudgetUsd <double>` (optional): soft cost threshold.
+
+## What it scans
+
+- Included versus used org Actions minutes.
+- Top repositories by runner minute consumption.
+- Long-running workflow anomalies against 30-day baseline.
+
+## What it does NOT do
+
+- No workflow edits or billing changes.
+- No secret write operations.

--- a/docs/consumer/tool-catalog.md
+++ b/docs/consumer/tool-catalog.md
@@ -8,13 +8,14 @@ Manifest schema version: `2.2`
 
 This page lists every analyzer tool azure-analyzer can run, what it covers, what scope it targets, and where to find consumer-focused setup notes when one exists. For the full manifest fields (normalizer, install kind, upstream pin, report color/phase) see [docs/contributor/tool-catalog.md](../contributor/tool-catalog.md).
 
-**Total enabled:** 30. **Disabled / opt-in:** 1.
+**Total enabled:** 32. **Disabled / opt-in:** 1.
 
 ## Enabled by default
 
 | Name | Display name | Scope | Provider | Frameworks | What it does | Docs |
 |---|---|---|---|---|---|---|
 | `ado-connections` | ADO Service Connections | ado | ado | NIST 800-53, SOC2, PCI-DSS | Azure DevOps service-connection security: identity, scope, federation. | - |
+| `ado-consumption` | ADO Pipeline Consumption | ado | ado | Azure CAF, SOC2 | Azure DevOps pipeline consumption telemetry: runner share, duration regression, and failure waste. | [docs](./permissions/ado-consumption.md) |
 | `ado-pipeline-correlator` | ADO Pipeline Run Correlator | ado | ado | NIST 800-53, SOC2 | Correlates ADO pipeline runs with downstream Azure resource changes. | - |
 | `ado-pipelines` | ADO Pipeline Security | ado | ado | NIST 800-53, SOC2, PCI-DSS | Azure DevOps pipeline-security posture (variable groups, environments, approvals). | - |
 | `ado-repos-secrets` | ADO Repos Secret Scanning | ado | ado | NIST 800-53, SOC2, PCI-DSS | Secret scanning across Azure DevOps repositories via gitleaks. | [docs](./gitleaks-pattern-tuning.md) |
@@ -28,6 +29,7 @@ This page lists every analyzer tool azure-analyzer can run, what it covers, what
 | `defender-for-cloud` | Microsoft Defender for Cloud | subscription | azure | CIS Azure, NIST 800-53, Azure WAF, Azure CAF, SOC2, PCI-DSS | Pulls Microsoft Defender for Cloud Secure Score and active recommendations per subscription. | - |
 | `falco` | Falco (AKS runtime anomaly detection) | subscription | azure | CIS Azure, NIST 800-53 | AKS runtime anomaly detection (syscall-level threat detection). | - |
 | `finops` | FinOps Signals (Idle Resource Detection) | subscription | azure | Azure WAF, Azure CAF | FinOps signals: idle / orphaned resources that drive avoidable spend. | - |
+| `gh-actions-billing` | GitHub Actions Billing | repository | github | Azure CAF, SOC2 | GitHub Actions billing and runner-minute telemetry for CI/CD cost optimization. | [docs](./permissions/gh-actions-billing.md) |
 | `gitleaks` | gitleaks (Secrets Scanner) | repository | cli | NIST 800-53, SOC2, PCI-DSS | Secret scanning across local or remote git repositories. | [docs](./gitleaks-pattern-tuning.md) |
 | `identity-correlator` | Identity Correlator | tenant | graph | NIST 800-53, SOC2, PCI-DSS | Correlates Entra identities, role assignments, and resource ownership. | - |
 | `identity-graph-expansion` | Identity Graph Expansion | tenant | graph | NIST 800-53, SOC2 | Expands the identity graph: cross-tenant B2B + service-principal-to-resource edges. | - |

--- a/docs/contributor/tool-catalog.md
+++ b/docs/contributor/tool-catalog.md
@@ -8,13 +8,14 @@ Manifest schema version: `2.2`
 
 Full manifest projection: every wired tool with normalizer, invocation, install, report, and upstream metadata. For the consumer-friendly subset see [docs/consumer/tool-catalog.md](../consumer/tool-catalog.md). To onboard a new tool follow [adding-a-tool.md](./adding-a-tool.md).
 
-**Total tools registered:** 31.
+**Total tools registered:** 33.
 
 ## Registration matrix
 
 | Name | Display name | Type | Provider | Scope | Status | Tier | Platforms | Frameworks |
 |---|---|---|---|---|---|---|---|---|
 | `ado-connections` | ADO Service Connections | collector | ado | ado | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
+| `ado-consumption` | ADO Pipeline Consumption | collector | ado | ado | Enabled | 0 | windows, macos, linux | Azure CAF, SOC2 |
 | `ado-pipeline-correlator` | ADO Pipeline Run Correlator | correlator | ado | ado | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2 |
 | `ado-pipelines` | ADO Pipeline Security | collector | ado | ado | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
 | `ado-repos-secrets` | ADO Repos Secret Scanning | collector | ado | ado | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
@@ -29,6 +30,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | `defender-for-cloud` | Microsoft Defender for Cloud | enrichment | azure | subscription | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53, Azure WAF, Azure CAF, SOC2, PCI-DSS |
 | `falco` | Falco (AKS runtime anomaly detection) | scanner | azure | subscription | Enabled | 0 | windows, macos, linux | CIS Azure, NIST 800-53 |
 | `finops` | FinOps Signals (Idle Resource Detection) | collector | azure | subscription | Enabled | 0 | windows, macos, linux | Azure WAF, Azure CAF |
+| `gh-actions-billing` | GitHub Actions Billing | collector | github | repository | Enabled | 0 | windows, macos, linux | Azure CAF, SOC2 |
 | `gitleaks` | gitleaks (Secrets Scanner) | collector | cli | repository | Enabled | 0 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
 | `identity-correlator` | Identity Correlator | correlator | graph | tenant | Enabled | 3 | windows, macos, linux | NIST 800-53, SOC2, PCI-DSS |
 | `identity-graph-expansion` | Identity Graph Expansion | correlator | graph | tenant | Enabled | 3 | windows, macos, linux | NIST 800-53, SOC2 |
@@ -51,6 +53,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | Name | Normalizer | Invoke | Script / module | Required params |
 |---|---|---|---|---|
 | `ado-connections` | `Normalize-ADOConnections` | script | `modules/Invoke-ADOServiceConnections.ps1` | AdoOrg |
+| `ado-consumption` | `Normalize-AdoConsumption` | script | `modules/Invoke-AdoConsumption.ps1` | Organization |
 | `ado-pipeline-correlator` | `Normalize-ADOPipelineCorrelator` | script | `modules/Invoke-ADOPipelineCorrelator.ps1` | AdoOrg |
 | `ado-pipelines` | `Normalize-ADOPipelineSecurity` | script | `modules/Invoke-ADOPipelineSecurity.ps1` | AdoOrg |
 | `ado-repos-secrets` | `Normalize-ADORepoSecrets` | script | `modules/Invoke-ADORepoSecrets.ps1` | AdoOrg |
@@ -65,6 +68,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | `defender-for-cloud` | `Normalize-DefenderForCloud` | script | `modules/Invoke-DefenderForCloud.ps1` | SubscriptionId |
 | `falco` | `Normalize-Falco` | script | `modules/Invoke-Falco.ps1` | SubscriptionId |
 | `finops` | `Normalize-FinOpsSignals` | script | `modules/Invoke-FinOpsSignals.ps1` | SubscriptionId |
+| `gh-actions-billing` | `Normalize-GhActionsBilling` | script | `modules/Invoke-GhActionsBilling.ps1` | Org |
 | `gitleaks` | `Normalize-Gitleaks` | script | `modules/Invoke-Gitleaks.ps1` | - |
 | `identity-correlator` | `Normalize-IdentityCorrelation` | function | `modules/shared/IdentityCorrelator.ps1` | TenantId |
 | `identity-graph-expansion` | `Normalize-IdentityGraphExpansion` | function | `modules/Invoke-IdentityGraphExpansion.ps1` | TenantId |
@@ -87,6 +91,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | Name | Install kind | Upstream pin | Report color | Phase |
 |---|---|---|---|---|
 | `ado-connections` | none | n/a | `#0078d4` | 2 |
+| `ado-consumption` | none | n/a | `#5e35b1` | 2 |
 | `ado-pipeline-correlator` | none | n/a | `#00838f` | 2 |
 | `ado-pipelines` | none | n/a | `#006064` | 2 |
 | `ado-repos-secrets` | none | n/a | `#ad1457` | 2 |
@@ -101,6 +106,7 @@ Full manifest projection: every wired tool with normalizer, invocation, install,
 | `defender-for-cloud` | psmodule | n/a | `#0078d4` | 4 |
 | `falco` | psmodule | falcosecurity/falco @ 0.42.0 | `#ef6c00` | 6 |
 | `finops` | psmodule | n/a | `#00897b` | 4 |
+| `gh-actions-billing` | cli ("gh") | n/a | `#8e24aa` | 1 |
 | `gitleaks` | cli ("gitleaks") | gitleaks/gitleaks @ latest | `#c62828` | 3 |
 | `identity-correlator` | psmodule | n/a | `#5e35b1` | 2 |
 | `identity-graph-expansion` | psmodule | n/a | `#283593` | 2 |

--- a/modules/Invoke-AdoConsumption.ps1
+++ b/modules/Invoke-AdoConsumption.ps1
@@ -1,0 +1,339 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+    Azure DevOps pipeline consumption telemetry.
+.DESCRIPTION
+    Collects build run duration and reliability signals from Azure DevOps REST APIs.
+    Emits v1 findings for project share of org runner minutes, duration regression,
+    and failed build rate.
+.PARAMETER Organization
+    Azure DevOps organization name.
+.PARAMETER Project
+    Optional project filter. When omitted, all projects in the organization are scanned.
+.PARAMETER DaysBack
+    Lookback window in days. Defaults to 30.
+.PARAMETER MonthlyBudgetUsd
+    Optional soft budget threshold for estimated paid minute cost.
+.PARAMETER AdoPat
+    ADO PAT token. Falls back to ADO_PAT_TOKEN, AZURE_DEVOPS_EXT_PAT, AZ_DEVOPS_PAT.
+#>
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [Alias('AdoOrg')]
+    [ValidateNotNullOrEmpty()]
+    [string] $Organization,
+
+    [Alias('AdoProject')]
+    [string] $Project,
+
+    [ValidateRange(1, 365)]
+    [int] $DaysBack = 30,
+
+    [double] $MonthlyBudgetUsd,
+
+    [Alias('AdoPatToken')]
+    [string] $AdoPat
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$sharedDir = Join-Path $PSScriptRoot 'shared'
+. (Join-Path $sharedDir 'Retry.ps1')
+. (Join-Path $sharedDir 'Sanitize.ps1')
+
+function Resolve-AdoPat {
+    param ([string]$Explicit)
+    if ($Explicit) { return $Explicit }
+    if ($env:ADO_PAT_TOKEN) { return $env:ADO_PAT_TOKEN }
+    if ($env:AZURE_DEVOPS_EXT_PAT) { return $env:AZURE_DEVOPS_EXT_PAT }
+    if ($env:AZ_DEVOPS_PAT) { return $env:AZ_DEVOPS_PAT }
+    return $null
+}
+
+function Invoke-AdoApi {
+    param (
+        [Parameter(Mandatory)]
+        [string] $Uri,
+        [Parameter(Mandatory)]
+        [hashtable] $Headers
+    )
+
+    Invoke-WithRetry -ScriptBlock {
+        $webResponse = Invoke-WebRequest -Uri $Uri -Headers $Headers -Method Get -ContentType 'application/json'
+        $bodyText = [string]$webResponse.Content
+        $body = if ([string]::IsNullOrWhiteSpace($bodyText)) {
+            [PSCustomObject]@{}
+        } else {
+            $bodyText | ConvertFrom-Json -Depth 100
+        }
+
+        $continuationToken = $null
+        if ($webResponse.Headers -and $webResponse.Headers.ContainsKey('x-ms-continuationtoken')) {
+            $tokenValue = $webResponse.Headers['x-ms-continuationtoken']
+            if ($tokenValue -is [array]) { $continuationToken = $tokenValue[0] } else { $continuationToken = $tokenValue }
+        }
+
+        [PSCustomObject]@{
+            Body = $body
+            ContinuationToken = $continuationToken
+        }
+    }
+}
+
+function Get-AdoPagedValues {
+    param (
+        [Parameter(Mandatory)]
+        [string] $Uri,
+        [Parameter(Mandatory)]
+        [hashtable] $Headers
+    )
+
+    $items = [System.Collections.Generic.List[object]]::new()
+    $continuationToken = $null
+    do {
+        $pagedUri = $Uri
+        if ($continuationToken) {
+            $separator = if ($pagedUri -like '*?*') { '&' } else { '?' }
+            $pagedUri += "$separator" + 'continuationToken=' + [uri]::EscapeDataString([string]$continuationToken)
+        }
+
+        $response = Invoke-AdoApi -Uri $pagedUri -Headers $Headers
+        $body = if ($response) { $response.Body } else { $null }
+        if ($body -and $body.PSObject.Properties['value']) {
+            foreach ($item in @($body.value)) { $items.Add($item) }
+        }
+        $continuationToken = if ($response) { $response.ContinuationToken } else { $null }
+    } while ($continuationToken)
+
+    return @($items)
+}
+
+function Get-AdoProjects {
+    param (
+        [Parameter(Mandatory)]
+        [string] $Org,
+        [Parameter(Mandatory)]
+        [hashtable] $Headers
+    )
+
+    $orgEnc = [uri]::EscapeDataString($Org)
+    $uri = "https://dev.azure.com/$orgEnc/_apis/projects?api-version=7.1&`$top=200"
+    return @(Get-AdoPagedValues -Uri $uri -Headers $Headers)
+}
+
+function Get-ProjectBuilds {
+    param (
+        [Parameter(Mandatory)]
+        [string] $Org,
+        [Parameter(Mandatory)]
+        [string] $ProjectName,
+        [Parameter(Mandatory)]
+        [datetime] $SinceUtc,
+        [Parameter(Mandatory)]
+        [hashtable] $Headers
+    )
+
+    $orgEnc = [uri]::EscapeDataString($Org)
+    $projectEnc = [uri]::EscapeDataString($ProjectName)
+    $minTime = [uri]::EscapeDataString($SinceUtc.ToString('o'))
+    $uri = "https://dev.azure.com/$orgEnc/$projectEnc/_apis/build/builds?api-version=7.1&queryOrder=finishTimeDescending&minTime=$minTime&`$top=200"
+    return @(Get-AdoPagedValues -Uri $uri -Headers $Headers)
+}
+
+function Get-BuildDurationMinutes {
+    param ([Parameter(Mandatory)][psobject]$Build)
+    if (-not $Build.PSObject.Properties['startTime'] -or -not $Build.startTime) { return 0.0 }
+    if (-not $Build.PSObject.Properties['finishTime'] -or -not $Build.finishTime) { return 0.0 }
+    try {
+        $start = [datetime]$Build.startTime
+        $finish = [datetime]$Build.finishTime
+        if ($finish -le $start) { return 0.0 }
+        return [math]::Round(($finish - $start).TotalMinutes, 2)
+    } catch {
+        return 0.0
+    }
+}
+
+$pat = Resolve-AdoPat -Explicit $AdoPat
+if (-not $pat) {
+    return [PSCustomObject]@{
+        Source   = 'ado-consumption'
+        Status   = 'Skipped'
+        Message  = 'No ADO PAT provided. Set -AdoPat, ADO_PAT_TOKEN, AZURE_DEVOPS_EXT_PAT, or AZ_DEVOPS_PAT.'
+        Findings = @()
+    }
+}
+
+$pair = ":$pat"
+$bytes = [System.Text.Encoding]::UTF8.GetBytes($pair)
+$base64 = [System.Convert]::ToBase64String($bytes)
+$headers = @{ Authorization = "Basic $base64" }
+
+try {
+    $sinceUtc = (Get-Date).ToUniversalTime().AddDays(-1 * $DaysBack)
+    $projects = @()
+    if ($Project) {
+        $projects = @([PSCustomObject]@{ name = $Project })
+    } else {
+        $projects = @(Get-AdoProjects -Org $Organization -Headers $headers)
+    }
+
+    if ($projects.Count -eq 0) {
+        return [PSCustomObject]@{
+            Source   = 'ado-consumption'
+            Status   = 'Success'
+            Message  = "No projects found in organization '$Organization'."
+            Findings = @()
+        }
+    }
+
+    $projectStats = [System.Collections.Generic.List[PSCustomObject]]::new()
+    foreach ($projectObj in $projects) {
+        $projectName = if ($projectObj.PSObject.Properties['name'] -and $projectObj.name) { [string]$projectObj.name } else { '' }
+        if (-not $projectName) { continue }
+        $builds = @(Get-ProjectBuilds -Org $Organization -ProjectName $projectName -SinceUtc $sinceUtc -Headers $headers)
+
+        $minutes = [System.Collections.Generic.List[double]]::new()
+        $failed = 0
+        $nowUtc = (Get-Date).ToUniversalTime()
+        $midpointUtc = $sinceUtc.AddTicks([int64](($nowUtc - $sinceUtc).Ticks / 2))
+        $firstHalf = [System.Collections.Generic.List[double]]::new()
+        $secondHalf = [System.Collections.Generic.List[double]]::new()
+
+        foreach ($build in $builds) {
+            $duration = Get-BuildDurationMinutes -Build $build
+            if ($duration -gt 0) {
+                $minutes.Add($duration)
+            }
+
+            $resultValue = if ($build.PSObject.Properties['result'] -and $build.result) { [string]$build.result } else { '' }
+            if ($resultValue -match '^(?i)failed$') {
+                $failed++
+            }
+
+            if ($build.PSObject.Properties['finishTime'] -and $build.finishTime -and $duration -gt 0) {
+                try {
+                    $finishUtc = ([datetime]$build.finishTime).ToUniversalTime()
+                    if ($finishUtc -lt $midpointUtc) { $firstHalf.Add($duration) } else { $secondHalf.Add($duration) }
+                } catch {
+                    continue
+                }
+            }
+        }
+
+        $totalRuns = $builds.Count
+        $totalMinutes = if ($minutes.Count -gt 0) { [math]::Round(($minutes | Measure-Object -Sum).Sum, 2) } else { 0.0 }
+        $firstAvg = if ($firstHalf.Count -gt 0) { [math]::Round(($firstHalf | Measure-Object -Average).Average, 2) } else { 0.0 }
+        $secondAvg = if ($secondHalf.Count -gt 0) { [math]::Round(($secondHalf | Measure-Object -Average).Average, 2) } else { 0.0 }
+        $failRate = if ($totalRuns -gt 0) { [math]::Round((100.0 * $failed / $totalRuns), 2) } else { 0.0 }
+
+        $projectStats.Add([PSCustomObject]@{
+                Project      = $projectName
+                TotalRuns    = $totalRuns
+                FailedRuns   = $failed
+                TotalMinutes = $totalMinutes
+                FirstAvg     = $firstAvg
+                SecondAvg    = $secondAvg
+                FailRate     = $failRate
+            })
+    }
+
+    $orgTotalMinutes = [math]::Round((@($projectStats | Measure-Object TotalMinutes -Sum).Sum), 2)
+    $findings = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    foreach ($stat in $projectStats) {
+        $projectId = "ado://$($Organization.ToLowerInvariant())/$($stat.Project.ToLowerInvariant())"
+        $learnMore = "https://dev.azure.com/$Organization/$($stat.Project)/_build"
+        $sharePercent = if ($orgTotalMinutes -gt 0) { [math]::Round((100.0 * $stat.TotalMinutes / $orgTotalMinutes), 2) } else { 0.0 }
+
+        if ($sharePercent -ge 40) {
+            $findings.Add([PSCustomObject]@{
+                    Id           = [guid]::NewGuid().ToString()
+                    Source       = 'ado-consumption'
+                    RuleId       = 'ado.parallel-job-ratio'
+                    Category     = 'Cost'
+                    Title        = "ADO project '$($stat.Project)' consumes a high share of org runner minutes"
+                    Compliant    = $false
+                    Severity     = 'Medium'
+                    Detail       = "Project consumed $sharePercent% of org runner minutes over the last $DaysBack day(s)."
+                    Remediation  = 'Review agent pool usage, split heavy schedules, and optimize long-running jobs.'
+                    ResourceId   = $projectId
+                    LearnMoreUrl = $learnMore
+                    SchemaVersion = '1.0'
+                })
+        }
+
+        if ($stat.FirstAvg -gt 0 -and $stat.SecondAvg -gt ($stat.FirstAvg * 1.25)) {
+            $regressionPct = [math]::Round((($stat.SecondAvg - $stat.FirstAvg) / $stat.FirstAvg) * 100.0, 2)
+            $findings.Add([PSCustomObject]@{
+                    Id           = [guid]::NewGuid().ToString()
+                    Source       = 'ado-consumption'
+                    RuleId       = 'ado.duration-regression'
+                    Category     = 'Cost'
+                    Title        = "ADO project '$($stat.Project)' pipeline duration regressed"
+                    Compliant    = $false
+                    Severity     = 'Medium'
+                    Detail       = "Average duration increased $regressionPct% (first half $($stat.FirstAvg) min, second half $($stat.SecondAvg) min)."
+                    Remediation  = 'Inspect recent pipeline changes, dependency updates, and queue bottlenecks.'
+                    ResourceId   = $projectId
+                    LearnMoreUrl = $learnMore
+                    SchemaVersion = '1.0'
+                })
+        }
+
+        if ($stat.TotalRuns -gt 0 -and $stat.FailRate -gt 10) {
+            $findings.Add([PSCustomObject]@{
+                    Id           = [guid]::NewGuid().ToString()
+                    Source       = 'ado-consumption'
+                    RuleId       = 'ado.failed-pipeline-rate'
+                    Category     = 'Cost'
+                    Title        = "ADO project '$($stat.Project)' failed pipeline rate is high"
+                    Compliant    = $false
+                    Severity     = 'High'
+                    Detail       = "Failed run rate is $($stat.FailRate)% ($($stat.FailedRuns)/$($stat.TotalRuns)) in the last $DaysBack day(s)."
+                    Remediation  = 'Fix flaky tests and unstable deployment steps to reduce failed run waste.'
+                    ResourceId   = $projectId
+                    LearnMoreUrl = $learnMore
+                    SchemaVersion = '1.0'
+                })
+        }
+
+        if ($PSBoundParameters.ContainsKey('MonthlyBudgetUsd') -and $MonthlyBudgetUsd -gt 0) {
+            $estimatedSpend = [math]::Round(($stat.TotalMinutes * 0.008), 2)
+            if ($estimatedSpend -gt $MonthlyBudgetUsd) {
+                $findings.Add([PSCustomObject]@{
+                        Id           = [guid]::NewGuid().ToString()
+                        Source       = 'ado-consumption'
+                        RuleId       = 'ado.monthly-budget-exceeded'
+                        Category     = 'Cost'
+                        Title        = "ADO project '$($stat.Project)' estimated pipeline spend exceeded budget"
+                        Compliant    = $false
+                        Severity     = 'High'
+                        Detail       = "Estimated spend $$estimatedSpend exceeded configured budget $$MonthlyBudgetUsd at 0.008 USD per minute."
+                        Remediation  = 'Tune trigger volume, queue concurrency, and long-running stages.'
+                        ResourceId   = $projectId
+                        LearnMoreUrl = $learnMore
+                        SchemaVersion = '1.0'
+                    })
+            }
+        }
+    }
+
+    return [PSCustomObject]@{
+        Source   = 'ado-consumption'
+        Status   = 'Success'
+        Message  = Remove-Credentials "Scanned $($projectStats.Count) project(s); produced $($findings.Count) ADO consumption finding(s)."
+        Findings = @($findings)
+    }
+} catch {
+    $msg = Remove-Credentials ([string]$_.Exception.Message)
+    Write-Warning "ADO consumption scan failed: $msg"
+    return [PSCustomObject]@{
+        Source   = 'ado-consumption'
+        Status   = 'Failed'
+        Message  = $msg
+        Findings = @()
+    }
+}

--- a/modules/Invoke-GhActionsBilling.ps1
+++ b/modules/Invoke-GhActionsBilling.ps1
@@ -1,0 +1,276 @@
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+    GitHub Actions billing and runtime cost telemetry.
+.DESCRIPTION
+    Uses gh api to collect org billing signals plus per-repo workflow run
+    durations. Emits v1 findings for:
+      - org included minute overage
+      - top repository consumers (top 5 by minutes)
+      - long-run anomaly (>60 min and above 30-day average)
+.PARAMETER Org
+    GitHub organization name.
+.PARAMETER Repo
+    Optional repo filter. When omitted, all org repos are queried.
+.PARAMETER DaysBack
+    Lookback window for workflow runs. Defaults to 30.
+.PARAMETER MonthlyBudgetUsd
+    Optional soft budget threshold for estimated paid minute cost.
+#>
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $Org,
+
+    [string] $Repo,
+
+    [ValidateRange(1, 365)]
+    [int] $DaysBack = 30,
+
+    [double] $MonthlyBudgetUsd
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$sharedDir = Join-Path $PSScriptRoot 'shared'
+. (Join-Path $sharedDir 'Retry.ps1')
+. (Join-Path $sharedDir 'Sanitize.ps1')
+$installerPath = Join-Path $sharedDir 'Installer.ps1'
+if (Test-Path $installerPath) { . $installerPath }
+if (-not (Get-Command Invoke-WithTimeout -ErrorAction SilentlyContinue)) {
+    function Invoke-WithTimeout {
+        param([string]$Command, [string[]]$Arguments, [int]$TimeoutSec = 300)
+        $stdout = & $Command @Arguments 2>&1 | Out-String
+        [PSCustomObject]@{ ExitCode = $LASTEXITCODE; Output = $stdout }
+    }
+}
+
+function Invoke-GhApi {
+    param (
+        [Parameter(Mandatory)]
+        [string] $Endpoint
+    )
+
+    Invoke-WithRetry -ScriptBlock {
+        $result = Invoke-WithTimeout -Command 'gh' -Arguments @('api', $Endpoint) -TimeoutSec 300
+        if ($result.ExitCode -ne 0) {
+            throw "gh api $Endpoint failed: $($result.Output)"
+        }
+        $text = [string]$result.Output
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            return [PSCustomObject]@{}
+        }
+        return $text | ConvertFrom-Json -Depth 100
+    }
+}
+
+function Get-RepoRunMinutes {
+    param (
+        [Parameter(Mandatory)]
+        [string] $OrgName,
+        [Parameter(Mandatory)]
+        [string] $RepoName,
+        [Parameter(Mandatory)]
+        [datetime] $SinceUtc
+    )
+
+    $sinceDate = $SinceUtc.ToString('yyyy-MM-dd')
+    $createdFilter = [uri]::EscapeDataString(">=$sinceDate")
+    $runsResponse = Invoke-GhApi -Endpoint "repos/$OrgName/$RepoName/actions/runs?per_page=100&created=$createdFilter"
+    $runs = if ($runsResponse -and $runsResponse.PSObject.Properties['workflow_runs']) { @($runsResponse.workflow_runs) } else { @() }
+
+    $durations = [System.Collections.Generic.List[double]]::new()
+    foreach ($run in $runs) {
+        $minutes = 0.0
+        if ($run.PSObject.Properties['run_duration_ms'] -and $run.run_duration_ms) {
+            $minutes = [math]::Round(([double]$run.run_duration_ms / 60000.0), 2)
+        } elseif ($run.PSObject.Properties['run_started_at'] -and $run.PSObject.Properties['updated_at'] -and $run.run_started_at -and $run.updated_at) {
+            try {
+                $start = [datetime]$run.run_started_at
+                $finish = [datetime]$run.updated_at
+                if ($finish -gt $start) {
+                    $minutes = [math]::Round(($finish - $start).TotalMinutes, 2)
+                }
+            } catch {
+                $minutes = 0.0
+            }
+        }
+        if ($minutes -gt 0) {
+            $durations.Add($minutes)
+        }
+    }
+
+    $total = if ($durations.Count -gt 0) { [math]::Round(($durations | Measure-Object -Sum).Sum, 2) } else { 0.0 }
+    $avg = if ($durations.Count -gt 0) { [math]::Round(($durations | Measure-Object -Average).Average, 2) } else { 0.0 }
+    return [PSCustomObject]@{
+        Runs      = $runs
+        Durations = @($durations)
+        Total     = $total
+        Average   = $avg
+    }
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    return [PSCustomObject]@{
+        Source   = 'gh-actions-billing'
+        Status   = 'Skipped'
+        Message  = 'gh CLI not installed. Install GitHub CLI and authenticate with gh auth login.'
+        Findings = @()
+    }
+}
+
+try {
+    $sinceUtc = (Get-Date).ToUniversalTime().AddDays(-1 * $DaysBack)
+    $billing = Invoke-GhApi -Endpoint "orgs/$Org/settings/billing/actions"
+
+    $repos = @()
+    if ($Repo) {
+        $repos = @([PSCustomObject]@{ name = $Repo; full_name = "$Org/$Repo"; owner = [PSCustomObject]@{ login = $Org } })
+    } else {
+        $repoResponse = Invoke-GhApi -Endpoint "orgs/$Org/repos?per_page=100&type=all"
+        $repos = @($repoResponse)
+    }
+
+    $findings = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $repoUsage = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $billingUrl = "https://github.com/organizations/$Org/settings/billing/actions"
+
+    $includedMinutes = 0.0
+    if ($billing.PSObject.Properties['included_minutes']) { $includedMinutes = [double]$billing.included_minutes }
+    $includedUsed = 0.0
+    if ($billing.PSObject.Properties['included_minutes_used']) { $includedUsed = [double]$billing.included_minutes_used }
+    elseif ($billing.PSObject.Properties['total_minutes_used']) { $includedUsed = [double]$billing.total_minutes_used }
+    $paidMinutes = 0.0
+    if ($billing.PSObject.Properties['total_paid_minutes_used']) { $paidMinutes = [double]$billing.total_paid_minutes_used }
+
+    if ($includedMinutes -gt 0 -and $includedUsed -gt $includedMinutes) {
+        $findings.Add([PSCustomObject]@{
+                Id           = [guid]::NewGuid().ToString()
+                Source       = 'gh-actions-billing'
+                RuleId       = 'gh-actions.org-over-budget'
+                Category     = 'Cost'
+                Title        = "Org '$Org' exceeded included GitHub Actions minutes"
+                Compliant    = $false
+                Severity     = 'High'
+                Detail       = "Included minutes used $includedUsed exceeds included minutes $includedMinutes."
+                Remediation  = 'Review high-minute repositories, optimize workflow runtime, and move heavy workloads to self-hosted runners where appropriate.'
+                ResourceId   = "github.com/$($Org.ToLowerInvariant())/_org-billing"
+                LearnMoreUrl = $billingUrl
+                SchemaVersion = '1.0'
+            })
+    }
+
+    foreach ($repoItem in $repos) {
+        if (-not $repoItem) { continue }
+        $repoName = if ($repoItem.PSObject.Properties['name'] -and $repoItem.name) { [string]$repoItem.name } else { '' }
+        if (-not $repoName) { continue }
+        $ownerName = if ($repoItem.PSObject.Properties['owner'] -and $repoItem.owner -and $repoItem.owner.PSObject.Properties['login']) { [string]$repoItem.owner.login } else { $Org }
+        $usage = Get-RepoRunMinutes -OrgName $ownerName -RepoName $repoName -SinceUtc $sinceUtc
+        $repoUsage.Add([PSCustomObject]@{
+                Org      = $ownerName
+                Repo     = $repoName
+                Total    = $usage.Total
+                Average  = $usage.Average
+                Runs     = $usage.Runs
+            })
+
+        foreach ($run in @($usage.Runs)) {
+            $runMinutes = 0.0
+            if ($run.PSObject.Properties['run_duration_ms'] -and $run.run_duration_ms) {
+                $runMinutes = [math]::Round(([double]$run.run_duration_ms / 60000.0), 2)
+            } elseif ($run.PSObject.Properties['run_started_at'] -and $run.PSObject.Properties['updated_at'] -and $run.run_started_at -and $run.updated_at) {
+                try {
+                    $start = [datetime]$run.run_started_at
+                    $finish = [datetime]$run.updated_at
+                    if ($finish -gt $start) { $runMinutes = [math]::Round(($finish - $start).TotalMinutes, 2) }
+                } catch {
+                    $runMinutes = 0.0
+                }
+            }
+            if ($runMinutes -le 60) { continue }
+
+            $baseline = $usage.Average
+            if ($usage.Durations.Count -gt 1) {
+                $other = @($usage.Durations | Where-Object { $_ -ne $runMinutes } | Select-Object -First ($usage.Durations.Count - 1))
+                if (@($other).Count -gt 0) {
+                    $baseline = [math]::Round((@($other) | Measure-Object -Average).Average, 2)
+                }
+            }
+            if ($baseline -gt 0 -and $runMinutes -le ($baseline * 2.0)) { continue }
+
+            $runId = if ($run.PSObject.Properties['id']) { [string]$run.id } else { 'unknown' }
+            $runUrl = if ($run.PSObject.Properties['html_url'] -and $run.html_url) { [string]$run.html_url } else { "https://github.com/$ownerName/$repoName/actions" }
+            $findings.Add([PSCustomObject]@{
+                    Id           = [guid]::NewGuid().ToString()
+                    Source       = 'gh-actions-billing'
+                    RuleId       = 'gh-actions.run-duration-anomaly'
+                    Category     = 'Cost'
+                    Title        = "Workflow run anomaly in $ownerName/$repoName"
+                    Compliant    = $false
+                    Severity     = 'Low'
+                    Detail       = "Run $runId consumed $runMinutes minutes; comparison baseline is $baseline minutes."
+                    Remediation  = 'Inspect the workflow run logs and optimize slow jobs, cache misses, and redundant test matrices.'
+                    ResourceId   = "github.com/$($ownerName.ToLowerInvariant())/$($repoName.ToLowerInvariant())"
+                    LearnMoreUrl = $runUrl
+                    SchemaVersion = '1.0'
+                })
+        }
+    }
+
+    $topConsumers = @($repoUsage | Sort-Object Total -Descending | Select-Object -First 5)
+    foreach ($consumer in $topConsumers) {
+        if ($consumer.Total -le 0) { continue }
+        $findings.Add([PSCustomObject]@{
+                Id           = [guid]::NewGuid().ToString()
+                Source       = 'gh-actions-billing'
+                RuleId       = 'gh-actions.top-consumer'
+                Category     = 'Cost'
+                Title        = "Top GitHub Actions minute consumer: $($consumer.Org)/$($consumer.Repo)"
+                Compliant    = $false
+                Severity     = 'Medium'
+                Detail       = "Repository used $($consumer.Total) runner minutes in the last $DaysBack day(s)."
+                Remediation  = 'Review matrix size, unnecessary workflow triggers, and long-running jobs.'
+                ResourceId   = "github.com/$($consumer.Org.ToLowerInvariant())/$($consumer.Repo.ToLowerInvariant())"
+                LearnMoreUrl = "https://github.com/$($consumer.Org)/$($consumer.Repo)/actions"
+                SchemaVersion = '1.0'
+            })
+    }
+
+    if ($PSBoundParameters.ContainsKey('MonthlyBudgetUsd') -and $MonthlyBudgetUsd -gt 0) {
+        $estimatedSpend = [math]::Round(($paidMinutes * 0.008), 2)
+        if ($estimatedSpend -gt $MonthlyBudgetUsd) {
+            $findings.Add([PSCustomObject]@{
+                    Id           = [guid]::NewGuid().ToString()
+                    Source       = 'gh-actions-billing'
+                    RuleId       = 'gh-actions.monthly-budget-exceeded'
+                    Category     = 'Cost'
+                    Title        = "Org '$Org' estimated Actions spend exceeded monthly budget"
+                    Compliant    = $false
+                    Severity     = 'High'
+                    Detail       = "Estimated spend $$estimatedSpend exceeded configured budget $$MonthlyBudgetUsd based on paid minutes ($paidMinutes) at 0.008 USD per minute."
+                    Remediation  = 'Set stricter workflow concurrency limits, reduce paid runner use, and enforce workflow ownership review.'
+                    ResourceId   = "github.com/$($Org.ToLowerInvariant())/_org-billing"
+                    LearnMoreUrl = $billingUrl
+                    SchemaVersion = '1.0'
+                })
+        }
+    }
+
+    return [PSCustomObject]@{
+        Source   = 'gh-actions-billing'
+        Status   = 'Success'
+        Message  = Remove-Credentials "Scanned $($repos.Count) repo(s); produced $($findings.Count) GitHub Actions cost finding(s)."
+        Findings = @($findings)
+    }
+} catch {
+    $msg = Remove-Credentials ([string]$_.Exception.Message)
+    Write-Warning "GitHub Actions billing scan failed: $msg"
+    return [PSCustomObject]@{
+        Source   = 'gh-actions-billing'
+        Status   = 'Failed'
+        Message  = $msg
+        Findings = @()
+    }
+}

--- a/modules/normalizers/Normalize-AdoConsumption.ps1
+++ b/modules/normalizers/Normalize-AdoConsumption.ps1
@@ -1,0 +1,55 @@
+#Requires -Version 7.4
+[CmdletBinding()]
+param ()
+
+. "$PSScriptRoot\..\shared\Schema.ps1"
+. "$PSScriptRoot\..\shared\Canonicalize.ps1"
+
+function Normalize-AdoConsumption {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [PSCustomObject] $ToolResult
+    )
+
+    if ($ToolResult.Status -notin @('Success', 'PartialSuccess') -or -not $ToolResult.Findings) {
+        return @()
+    }
+
+    $runId = [guid]::NewGuid().ToString()
+    $normalized = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    foreach ($finding in @($ToolResult.Findings)) {
+        $rawId = if ($finding.PSObject.Properties['ResourceId'] -and $finding.ResourceId) { [string]$finding.ResourceId } else { '' }
+        if ([string]::IsNullOrWhiteSpace($rawId)) { continue }
+
+        $canonicalId = $rawId.ToLowerInvariant()
+        try {
+            $canonicalId = (ConvertTo-CanonicalEntityId -RawId $rawId -EntityType 'AdoProject').CanonicalId
+        } catch {
+            $canonicalId = $rawId.ToLowerInvariant()
+        }
+
+        $severity = switch -Regex ([string]$finding.Severity) {
+            '^(?i)critical$' { 'Critical' }
+            '^(?i)high$'     { 'High' }
+            '^(?i)medium$'   { 'Medium' }
+            '^(?i)low$'      { 'Low' }
+            default          { 'Info' }
+        }
+
+        $ruleId = if ($finding.PSObject.Properties['RuleId'] -and $finding.RuleId) { [string]$finding.RuleId } else { '' }
+        $row = New-FindingRow -Id ([string]$finding.Id) `
+            -Source 'ado-consumption' -EntityId $canonicalId -EntityType 'AdoProject' `
+            -Title ([string]$finding.Title) -Compliant ([bool]$finding.Compliant) -ProvenanceRunId $runId `
+            -Platform 'ADO' -Category ([string]$finding.Category) -Severity $severity `
+            -Detail ([string]$finding.Detail) -Remediation ([string]$finding.Remediation) `
+            -LearnMoreUrl ([string]$finding.LearnMoreUrl) -ResourceId $rawId -RuleId $ruleId
+
+        if ($null -ne $row) {
+            $normalized.Add($row)
+        }
+    }
+
+    return @($normalized)
+}

--- a/modules/normalizers/Normalize-GhActionsBilling.ps1
+++ b/modules/normalizers/Normalize-GhActionsBilling.ps1
@@ -1,0 +1,55 @@
+#Requires -Version 7.4
+[CmdletBinding()]
+param ()
+
+. "$PSScriptRoot\..\shared\Schema.ps1"
+. "$PSScriptRoot\..\shared\Canonicalize.ps1"
+
+function Normalize-GhActionsBilling {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [PSCustomObject] $ToolResult
+    )
+
+    if ($ToolResult.Status -notin @('Success', 'PartialSuccess') -or -not $ToolResult.Findings) {
+        return @()
+    }
+
+    $runId = [guid]::NewGuid().ToString()
+    $normalized = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+    foreach ($finding in @($ToolResult.Findings)) {
+        $rawId = if ($finding.PSObject.Properties['ResourceId'] -and $finding.ResourceId) { [string]$finding.ResourceId } else { '' }
+        if ([string]::IsNullOrWhiteSpace($rawId)) { continue }
+
+        $canonicalId = $rawId.ToLowerInvariant()
+        try {
+            $canonicalId = (ConvertTo-CanonicalEntityId -RawId $rawId -EntityType 'Repository').CanonicalId
+        } catch {
+            $canonicalId = $rawId.ToLowerInvariant()
+        }
+
+        $severity = switch -Regex ([string]$finding.Severity) {
+            '^(?i)critical$' { 'Critical' }
+            '^(?i)high$'     { 'High' }
+            '^(?i)medium$'   { 'Medium' }
+            '^(?i)low$'      { 'Low' }
+            default          { 'Info' }
+        }
+
+        $ruleId = if ($finding.PSObject.Properties['RuleId'] -and $finding.RuleId) { [string]$finding.RuleId } else { '' }
+        $row = New-FindingRow -Id ([string]$finding.Id) `
+            -Source 'gh-actions-billing' -EntityId $canonicalId -EntityType 'Repository' `
+            -Title ([string]$finding.Title) -Compliant ([bool]$finding.Compliant) -ProvenanceRunId $runId `
+            -Platform 'GitHub' -Category ([string]$finding.Category) -Severity $severity `
+            -Detail ([string]$finding.Detail) -Remediation ([string]$finding.Remediation) `
+            -LearnMoreUrl ([string]$finding.LearnMoreUrl) -ResourceId $rawId -RuleId $ruleId
+
+        if ($null -ne $row) {
+            $normalized.Add($row)
+        }
+    }
+
+    return @($normalized)
+}

--- a/scripts/Generate-ToolCatalog.ps1
+++ b/scripts/Generate-ToolCatalog.ps1
@@ -86,6 +86,8 @@ $consumerDocLinks = @{
     'maester'         = 'ai-triage.md'
     'gitleaks'        = 'gitleaks-pattern-tuning.md'
     'ado-repos-secrets' = 'gitleaks-pattern-tuning.md'
+    'gh-actions-billing' = 'permissions/gh-actions-billing.md'
+    'ado-consumption' = 'permissions/ado-consumption.md'
 }
 
 # Short, consumer-friendly description per tool. Falls back to displayName when
@@ -106,8 +108,10 @@ $consumerBlurb = @{
     'wara'                     = 'Well-Architected Reliability Assessment workflow for production workloads.'
     'maester'                  = 'Microsoft Entra (Identity) security baseline: conditional access, MFA, privileged roles.'
     'scorecard'                = 'OpenSSF Scorecard for repository supply-chain hygiene.'
+    'gh-actions-billing'       = 'GitHub Actions billing and runner-minute telemetry for CI/CD cost optimization.'
     'ado-connections'          = 'Azure DevOps service-connection security: identity, scope, federation.'
     'ado-pipelines'            = 'Azure DevOps pipeline-security posture (variable groups, environments, approvals).'
+    'ado-consumption'          = 'Azure DevOps pipeline consumption telemetry: runner share, duration regression, and failure waste.'
     'ado-repos-secrets'        = 'Secret scanning across Azure DevOps repositories via gitleaks.'
     'ado-pipeline-correlator'  = 'Correlates ADO pipeline runs with downstream Azure resource changes.'
     'identity-correlator'      = 'Correlates Entra identities, role assignments, and resource ownership.'

--- a/tests/fixtures/cicd-cost/ado-consumption-output.json
+++ b/tests/fixtures/cicd-cost/ado-consumption-output.json
@@ -1,0 +1,43 @@
+{
+  "Source": "ado-consumption",
+  "Status": "Success",
+  "Message": "fixture",
+  "Findings": [
+    {
+      "Id": "44444444-4444-4444-4444-444444444444",
+      "RuleId": "ado.parallel-job-ratio",
+      "Category": "Cost",
+      "Title": "High share",
+      "Compliant": false,
+      "Severity": "Medium",
+      "Detail": "Project consumes high share.",
+      "Remediation": "Tune pools.",
+      "ResourceId": "ado://contoso/payments",
+      "LearnMoreUrl": "https://dev.azure.com/contoso/payments/_build"
+    },
+    {
+      "Id": "55555555-5555-5555-5555-555555555555",
+      "RuleId": "ado.duration-regression",
+      "Category": "Cost",
+      "Title": "Duration regression",
+      "Compliant": false,
+      "Severity": "Medium",
+      "Detail": "Duration increased.",
+      "Remediation": "Investigate slowdown.",
+      "ResourceId": "ado://contoso/payments",
+      "LearnMoreUrl": "https://dev.azure.com/contoso/payments/_build"
+    },
+    {
+      "Id": "66666666-6666-6666-6666-666666666666",
+      "RuleId": "ado.failed-pipeline-rate",
+      "Category": "Cost",
+      "Title": "Failure rate high",
+      "Compliant": false,
+      "Severity": "High",
+      "Detail": "Failure rate over threshold.",
+      "Remediation": "Fix flaky jobs.",
+      "ResourceId": "ado://contoso/payments",
+      "LearnMoreUrl": "https://dev.azure.com/contoso/payments/_build"
+    }
+  ]
+}

--- a/tests/fixtures/cicd-cost/gh-actions-billing-output.json
+++ b/tests/fixtures/cicd-cost/gh-actions-billing-output.json
@@ -1,0 +1,43 @@
+{
+  "Source": "gh-actions-billing",
+  "Status": "Success",
+  "Message": "fixture",
+  "Findings": [
+    {
+      "Id": "11111111-1111-1111-1111-111111111111",
+      "RuleId": "gh-actions.org-over-budget",
+      "Category": "Cost",
+      "Title": "Org over budget",
+      "Compliant": false,
+      "Severity": "High",
+      "Detail": "Included minutes exceeded.",
+      "Remediation": "Optimize workflows.",
+      "ResourceId": "github.com/contoso/_org-billing",
+      "LearnMoreUrl": "https://github.com/organizations/contoso/settings/billing/actions"
+    },
+    {
+      "Id": "22222222-2222-2222-2222-222222222222",
+      "RuleId": "gh-actions.top-consumer",
+      "Category": "Cost",
+      "Title": "Top consumer",
+      "Compliant": false,
+      "Severity": "Medium",
+      "Detail": "Repo consumed high minutes.",
+      "Remediation": "Reduce runtime.",
+      "ResourceId": "github.com/contoso/api",
+      "LearnMoreUrl": "https://github.com/contoso/api/actions"
+    },
+    {
+      "Id": "33333333-3333-3333-3333-333333333333",
+      "RuleId": "gh-actions.run-duration-anomaly",
+      "Category": "Cost",
+      "Title": "Run anomaly",
+      "Compliant": false,
+      "Severity": "Low",
+      "Detail": "Run exceeded baseline.",
+      "Remediation": "Inspect run.",
+      "ResourceId": "github.com/contoso/api",
+      "LearnMoreUrl": "https://github.com/contoso/api/actions/runs/1"
+    }
+  ]
+}

--- a/tests/normalizers/Normalize-AdoConsumption.Tests.ps1
+++ b/tests/normalizers/Normalize-AdoConsumption.Tests.ps1
@@ -1,0 +1,29 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+    . (Join-Path $repoRoot 'modules\shared\Canonicalize.ps1')
+    . (Join-Path $repoRoot 'modules\shared\Schema.ps1')
+    . (Join-Path $repoRoot 'modules\normalizers\Normalize-AdoConsumption.ps1')
+
+    $script:Fixture = Get-Content (Join-Path $PSScriptRoot '..\fixtures\cicd-cost\ado-consumption-output.json') -Raw | ConvertFrom-Json
+}
+
+Describe 'Normalize-AdoConsumption' {
+    It 'returns rows for successful tool output' {
+        $rows = @(Normalize-AdoConsumption -ToolResult $script:Fixture)
+        $rows.Count | Should -Be 3
+    }
+
+    It 'uses AdoProject entity type with canonical ado:// IDs' {
+        $rows = @(Normalize-AdoConsumption -ToolResult $script:Fixture)
+        @($rows | Where-Object { $_.EntityType -ne 'AdoProject' }).Count | Should -Be 0
+        @($rows | Where-Object { $_.EntityId -notmatch '^ado://' }).Count | Should -Be 0
+    }
+
+    It 'stamps RuleId values' {
+        $rows = @(Normalize-AdoConsumption -ToolResult $script:Fixture)
+        @($rows | Where-Object { [string]::IsNullOrWhiteSpace($_.RuleId) }).Count | Should -Be 0
+    }
+}

--- a/tests/normalizers/Normalize-GhActionsBilling.Tests.ps1
+++ b/tests/normalizers/Normalize-GhActionsBilling.Tests.ps1
@@ -1,0 +1,29 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+    . (Join-Path $repoRoot 'modules\shared\Canonicalize.ps1')
+    . (Join-Path $repoRoot 'modules\shared\Schema.ps1')
+    . (Join-Path $repoRoot 'modules\normalizers\Normalize-GhActionsBilling.ps1')
+
+    $script:Fixture = Get-Content (Join-Path $PSScriptRoot '..\fixtures\cicd-cost\gh-actions-billing-output.json') -Raw | ConvertFrom-Json
+}
+
+Describe 'Normalize-GhActionsBilling' {
+    It 'returns rows for successful tool output' {
+        $rows = @(Normalize-GhActionsBilling -ToolResult $script:Fixture)
+        $rows.Count | Should -Be 3
+    }
+
+    It 'uses Repository entity type and GitHub platform' {
+        $rows = @(Normalize-GhActionsBilling -ToolResult $script:Fixture)
+        @($rows | Where-Object { $_.EntityType -ne 'Repository' }).Count | Should -Be 0
+        @($rows | Where-Object { $_.Platform -ne 'GitHub' }).Count | Should -Be 0
+    }
+
+    It 'stamps RuleId values' {
+        $rows = @(Normalize-GhActionsBilling -ToolResult $script:Fixture)
+        @($rows | Where-Object { [string]::IsNullOrWhiteSpace($_.RuleId) }).Count | Should -Be 0
+    }
+}

--- a/tests/wrappers/Invoke-AdoConsumption.Tests.ps1
+++ b/tests/wrappers/Invoke-AdoConsumption.Tests.ps1
@@ -1,0 +1,123 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    $script:Here = Split-Path $PSCommandPath -Parent
+    $script:RepoRoot = Resolve-Path (Join-Path $script:Here '..' '..')
+    $script:Wrapper = Join-Path $script:RepoRoot 'modules' 'Invoke-AdoConsumption.ps1'
+
+    function New-TestHttpException {
+        param([int]$StatusCode, [string]$Message)
+        $ex = [System.Exception]::new($Message)
+        $ex | Add-Member -NotePropertyName Response -NotePropertyValue ([PSCustomObject]@{ StatusCode = $StatusCode }) -Force
+        return $ex
+    }
+}
+
+Describe 'Invoke-AdoConsumption' {
+    BeforeEach {
+        Remove-Item Env:\ADO_PAT_TOKEN -ErrorAction SilentlyContinue
+        Remove-Item Env:\AZURE_DEVOPS_EXT_PAT -ErrorAction SilentlyContinue
+        Remove-Item Env:\AZ_DEVOPS_PAT -ErrorAction SilentlyContinue
+    }
+
+    AfterAll {
+        Remove-Variable -Name ProjectsAttempts -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    Context 'when PAT is missing' {
+        It 'returns Skipped' {
+            $result = & $script:Wrapper -Organization 'contoso'
+            $result.Status | Should -Be 'Skipped'
+            @($result.Findings).Count | Should -Be 0
+        }
+    }
+
+    Context 'consumption findings are emitted' {
+        BeforeAll {
+            $env:ADO_PAT_TOKEN = 'fake-token'
+            Mock Invoke-WebRequest {
+                if ($Uri -match '_apis/projects') {
+                    return [PSCustomObject]@{
+                        Content = '{"value":[{"name":"payments"},{"name":"identity"}]}'
+                        Headers = @{}
+                    }
+                }
+                if ($Uri -match 'payments/_apis/build/builds') {
+                    return [PSCustomObject]@{
+                        Content = '{"value":[
+                          {"id":1,"startTime":"2026-04-01T00:00:00Z","finishTime":"2026-04-01T00:50:00Z","result":"failed"},
+                          {"id":2,"startTime":"2026-04-03T00:00:00Z","finishTime":"2026-04-03T00:40:00Z","result":"succeeded"},
+                          {"id":3,"startTime":"2026-04-20T00:00:00Z","finishTime":"2026-04-20T01:20:00Z","result":"failed"},
+                          {"id":4,"startTime":"2026-04-21T00:00:00Z","finishTime":"2026-04-21T01:10:00Z","result":"succeeded"}
+                        ]}'
+                        Headers = @{}
+                    }
+                }
+                if ($Uri -match 'identity/_apis/build/builds') {
+                    return [PSCustomObject]@{
+                        Content = '{"value":[
+                          {"id":10,"startTime":"2026-04-04T00:00:00Z","finishTime":"2026-04-04T00:15:00Z","result":"succeeded"},
+                          {"id":11,"startTime":"2026-04-05T00:00:00Z","finishTime":"2026-04-05T00:12:00Z","result":"succeeded"}
+                        ]}'
+                        Headers = @{}
+                    }
+                }
+                throw "Unexpected URI: $Uri"
+            }
+            $result = & $script:Wrapper -Organization 'contoso' -DaysBack 30
+        }
+
+        AfterAll {
+            Remove-Item Env:\ADO_PAT_TOKEN -ErrorAction SilentlyContinue
+        }
+
+        It 'returns Success' {
+            $result.Status | Should -Be 'Success'
+        }
+
+        It 'flags high share project' {
+            @($result.Findings | Where-Object { $_.RuleId -eq 'ado.parallel-job-ratio' }).Count | Should -BeGreaterThan 0
+        }
+
+        It 'flags duration regression' {
+            @($result.Findings | Where-Object { $_.RuleId -eq 'ado.duration-regression' }).Count | Should -BeGreaterThan 0
+        }
+
+        It 'flags failed pipeline rate above threshold' {
+            @($result.Findings | Where-Object { $_.RuleId -eq 'ado.failed-pipeline-rate' }).Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context 'retry and sanitization' {
+        BeforeAll {
+            $env:ADO_PAT_TOKEN = 'fake-token'
+            $global:ProjectsAttempts = 0
+            Mock Invoke-WebRequest {
+                if ($Uri -match '_apis/projects') {
+                    $global:ProjectsAttempts++
+                    if ($global:ProjectsAttempts -eq 1) {
+                        throw (New-TestHttpException -StatusCode 429 -Message 'Authorization: Basic c2VjcmV0')
+                    }
+                    return [PSCustomObject]@{ Content = '{"value":[]}'; Headers = @{} }
+                }
+                throw "Unexpected URI: $Uri"
+            }
+            $result = & $script:Wrapper -Organization 'contoso'
+        }
+
+        AfterAll {
+            Remove-Item Env:\ADO_PAT_TOKEN -ErrorAction SilentlyContinue
+        }
+
+        It 'retries after throttle and succeeds' {
+            $result.Status | Should -Be 'Success'
+            $global:ProjectsAttempts | Should -Be 2
+        }
+
+        It 'does not leak PAT markers in message' {
+            $result.Message | Should -Not -Match 'Basic c2VjcmV0'
+        }
+    }
+}

--- a/tests/wrappers/Invoke-GhActionsBilling.Tests.ps1
+++ b/tests/wrappers/Invoke-GhActionsBilling.Tests.ps1
@@ -1,0 +1,108 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+BeforeAll {
+    $script:Here = Split-Path $PSCommandPath -Parent
+    $script:RepoRoot = Resolve-Path (Join-Path $script:Here '..' '..')
+    $script:Wrapper = Join-Path $script:RepoRoot 'modules' 'Invoke-GhActionsBilling.ps1'
+    function global:Invoke-WithTimeout {
+        param([string]$Command, [string[]]$Arguments, [int]$TimeoutSec)
+        [PSCustomObject]@{ ExitCode = 0; Output = '{}' }
+    }
+}
+
+AfterAll {
+    Remove-Item Function:\Invoke-WithTimeout -ErrorAction SilentlyContinue
+    Remove-Variable -Name BillingAttempt -Scope Global -ErrorAction SilentlyContinue
+}
+
+Describe 'Invoke-GhActionsBilling' {
+    Context 'when gh is missing' {
+        BeforeAll {
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'gh' }
+            $result = & $script:Wrapper -Org 'contoso'
+        }
+
+        It 'returns Skipped' {
+            $result.Status | Should -Be 'Skipped'
+            @($result.Findings).Count | Should -Be 0
+        }
+    }
+
+    Context 'budget exceeded top consumers and anomalies' {
+        BeforeAll {
+            Mock Get-Command {
+                if ($Name -eq 'gh') { return [PSCustomObject]@{ Name = 'gh' } }
+                return $null
+            }
+
+            Mock Invoke-WithTimeout {
+                $endpoint = $Arguments[1]
+                if ($endpoint -like 'orgs/contoso/settings/billing/actions*') {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = '{"included_minutes":2000,"included_minutes_used":2600,"total_paid_minutes_used":500}' }
+                }
+                if ($endpoint -like 'orgs/contoso/repos*') {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = '[{"name":"api","owner":{"login":"contoso"}},{"name":"web","owner":{"login":"contoso"}}]' }
+                }
+                if ($endpoint -like 'repos/contoso/api/actions/runs*') {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = '{"workflow_runs":[{"id":1,"run_duration_ms":4200000,"html_url":"https://github.com/contoso/api/actions/runs/1"},{"id":2,"run_duration_ms":1800000}]}' }
+                }
+                if ($endpoint -like 'repos/contoso/web/actions/runs*') {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = '{"workflow_runs":[{"id":10,"run_duration_ms":1200000},{"id":11,"run_duration_ms":1500000}]}' }
+                }
+                throw "Unexpected endpoint: $endpoint"
+            }
+
+            $result = & $script:Wrapper -Org 'contoso'
+        }
+
+        It 'returns Success' {
+            $result.Status | Should -Be 'Success'
+        }
+
+        It 'emits org over budget finding' {
+            @($result.Findings | Where-Object { $_.RuleId -eq 'gh-actions.org-over-budget' }).Count | Should -Be 1
+        }
+
+        It 'emits top consumer findings' {
+            @($result.Findings | Where-Object { $_.RuleId -eq 'gh-actions.top-consumer' }).Count | Should -BeGreaterThan 0
+        }
+
+        It 'emits duration anomaly finding' {
+            @($result.Findings | Where-Object { $_.RuleId -eq 'gh-actions.run-duration-anomaly' }).Count | Should -Be 1
+        }
+    }
+
+    Context 'retries throttled gh api calls' {
+        BeforeAll {
+            Mock Get-Command {
+                if ($Name -eq 'gh') { return [PSCustomObject]@{ Name = 'gh' } }
+                return $null
+            }
+
+            $global:BillingAttempt = 0
+            Mock Invoke-WithTimeout {
+                $endpoint = $Arguments[1]
+                if ($endpoint -like 'orgs/contoso/settings/billing/actions*') {
+                    $global:BillingAttempt++
+                    if ($global:BillingAttempt -eq 1) {
+                        return [PSCustomObject]@{ ExitCode = 1; Output = 'HTTP 429 rate limit exceeded' }
+                    }
+                    return [PSCustomObject]@{ ExitCode = 0; Output = '{"included_minutes":2000,"included_minutes_used":1200,"total_paid_minutes_used":0}' }
+                }
+                if ($endpoint -like 'orgs/contoso/repos*') {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = '[]' }
+                }
+                throw "Unexpected endpoint: $endpoint"
+            }
+
+            $result = & $script:Wrapper -Org 'contoso'
+        }
+
+        It 'succeeds after retry' {
+            $result.Status | Should -Be 'Success'
+            $global:BillingAttempt | Should -Be 2
+        }
+    }
+}

--- a/tools/tool-manifest.json
+++ b/tools/tool-manifest.json
@@ -733,6 +733,57 @@
       ]
     },
     {
+      "name": "gh-actions-billing",
+      "displayName": "GitHub Actions Billing",
+      "source": "gh-actions-billing",
+      "provider": "github",
+      "scope": "repository",
+      "normalizer": "Normalize-GhActionsBilling",
+      "invokeMethod": "script",
+      "type": "collector",
+      "script": "modules/Invoke-GhActionsBilling.ps1",
+      "requiredParams": [
+        "Org"
+      ],
+      "optionalParams": [
+        "Repo",
+        "DaysBack",
+        "MonthlyBudgetUsd"
+      ],
+      "requiredPermissionTier": 0,
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
+      "enabled": true,
+      "report": {
+        "color": "#8e24aa",
+        "phase": 1
+      },
+      "install": {
+        "kind": "cli",
+        "command": "gh",
+        "preferredManagers": [
+          "winget",
+          "brew"
+        ],
+        "windows": {
+          "winget": "GitHub.cli"
+        },
+        "macos": {
+          "brew": "gh"
+        },
+        "linux": {
+          "url": "https://cli.github.com/"
+        }
+      },
+      "frameworks": [
+        "Azure CAF",
+        "SOC2"
+      ]
+    },
+    {
       "name": "ado-connections",
       "displayName": "ADO Service Connections",
       "source": "ado-connections",
@@ -804,6 +855,44 @@
         "NIST 800-53",
         "SOC2",
         "PCI-DSS"
+      ]
+    },
+    {
+      "name": "ado-consumption",
+      "displayName": "ADO Pipeline Consumption",
+      "source": "ado-consumption",
+      "provider": "ado",
+      "scope": "ado",
+      "normalizer": "Normalize-AdoConsumption",
+      "invokeMethod": "script",
+      "type": "collector",
+      "script": "modules/Invoke-AdoConsumption.ps1",
+      "requiredParams": [
+        "Organization"
+      ],
+      "optionalParams": [
+        "Project",
+        "DaysBack",
+        "MonthlyBudgetUsd",
+        "AdoPat"
+      ],
+      "requiredPermissionTier": 0,
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
+      "enabled": true,
+      "report": {
+        "color": "#5e35b1",
+        "phase": 2
+      },
+      "install": {
+        "kind": "none"
+      },
+      "frameworks": [
+        "Azure CAF",
+        "SOC2"
       ]
     },
     {


### PR DESCRIPTION
## Summary

This PR adds CI/CD cost telemetry for issue #232 with two separate tools:

- gh-actions-billing (GitHub provider)
- do-consumption (ADO provider)

Closes #232.

## Why two wrappers instead of one

The wrappers are split by provider boundary to keep auth, RBAC, and execution scopes independent:

- GitHub uses gh api and GitHub PAT scopes.
- ADO uses Azure DevOps REST and ADO PAT scopes.

This keeps enable/disable controls clean in 	ools/tool-manifest.json and avoids mixed provider fallback behavior.

## Finding catalog and thresholds

### gh-actions-billing

- gh-actions.org-over-budget (High): included_minutes_used > included_minutes.
- gh-actions.top-consumer (Medium): top 5 repositories by total runner minutes in lookback window.
- gh-actions.run-duration-anomaly (Low): run duration > 60 min and > 2x peer baseline.
- gh-actions.monthly-budget-exceeded (High, optional): estimated spend exceeds MonthlyBudgetUsd.

### ado-consumption

- do.parallel-job-ratio (Medium): project share of org runner minutes >= 40%.
- do.duration-regression (Medium): second-half average duration > 25% above first-half average.
- do.failed-pipeline-rate (High): failed run rate > 10%.
- do.monthly-budget-exceeded (High, optional): estimated spend exceeds MonthlyBudgetUsd.

## EntityType usage (v2.1)

- GitHub findings normalize to EntityType=Repository.
- ADO findings normalize to EntityType=AdoProject with canonical IDs do://{org}/{project} from Stage 1 schema work.

Reference: Stage 1 PR #281 (2e215b2) and Brady decisions doc:
.squad/decisions/inbox/coordinator-brady-vnext-decisions-2026-04-20T22-48-04Z.md.

## RBAC and permission docs

- Added docs/consumer/permissions/gh-actions-billing.md for GitHub PAT scopes.
- Added docs/consumer/permissions/ado-consumption.md for ADO PAT scopes.
- Regenerated manifest-driven docs (	ool-catalog and PERMISSIONS.md index).

## Validation

- Baseline before: Invoke-Pester -Path .\\tests -CI discovered 1307, passed 1307.
- After changes: discovered 1326, passed 1321, failed 0, skipped 5.
- Added 19 new tests (wrappers + normalizers + fixtures).
- Em-dash guard run for changed files: clean.