### PR TITLE
chore(ci): add ALZ query drift detection workflow

### DIFF
--- a/.github/workflows/alz-queries-drift-check.yml
+++ b/.github/workflows/alz-queries-drift-check.yml
@@ -1,0 +1,28 @@
+name: ALZ queries drift check
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    name: Detect ALZ query drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run ALZ query sync in dry-run mode
+        shell: pwsh
+        run: |
+          $result = ./scripts/Sync-AlzQueries.ps1 -DryRun
+          if ($result.Changed) {
+            throw 'ALZ query drift detected. Run scripts/Sync-AlzQueries.ps1 and commit the updated queries/alz_additional_queries.json cache.'
+          }
+
+          Write-Host 'ALZ query cache is in sync with upstream.'

--- a/.squad/agents/forge/history.md
+++ b/.squad/agents/forge/history.md
@@ -83,3 +83,8 @@ Accumulated learnings from prior sessions (summarized 2026-04-22):
 - Added `tests/scripts/Sync-AlzQueries.Tests.ps1` covering dry-run no-write behavior, idempotent re-run no-op behavior, transient-clone retry behavior, and credential redaction in verbose logs.
 - Baseline preserved and extended: full Pester run moved from 1349 passed (pre-change) to 1354 passed (post-change), 0 failed, 5 skipped.
 - Key upstream-path learning: the canonical source file in `martinopedal/alz-graph-queries` lives at `queries/alz_additional_queries.json` (not repo root), and sync logic now treats this as the default upstream relative path.
+
+### 2026-04-22: Issue #316 — scheduled ALZ query drift detection workflow
+- Added `.github/workflows/alz-queries-drift-check.yml` with weekly Monday 06:00 UTC schedule plus manual dispatch to run `scripts/Sync-AlzQueries.ps1 -DryRun` and fail when `.Changed` is true.
+- Kept permissions minimal (`contents: read`) and action pinning compliant (`actions/checkout@de0fac2e... # v6`) to satisfy repo security posture and Actions CodeQL scanning.
+- Updated `CHANGELOG.md` and validated baseline remained green at `Tests Passed: 1354, Failed: 0, Skipped: 5`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Added
 
+- ci: weekly ALZ query drift-check workflow (`alz-queries-drift-check.yml`) that runs `scripts/Sync-AlzQueries.ps1 -DryRun` and fails when upstream `martinopedal/alz-graph-queries` diverges from local `queries/` cache (closes #316).
 - feat: Azure Quota Reports wrapper (modules/Invoke-AzureQuotaReports.ps1) adds subscription+region fanout over az vm list-usage and az network list-usages with configurable compliance threshold (Threshold default 80), emitting v1 envelope findings for quota capacity risk (closes #322).
-
 - Schema: `RuleId` field on `New-FindingRow` (FindingRow v2.1) for stable rule identification (foundational for #227, #229).
 - Schema: `AdoProject` and `KarpenterProvisioner` added to the `EntityType` enum (foundational for #232, #234).
 - Docs: opt-in elevated RBAC tier for Karpenter inspection scaffolded in `PERMISSIONS.md` (foundational for #234; opt-in mechanism TBD, lands with #234 in Stage 2).


### PR DESCRIPTION
## Summary
- add weekly + manual GitHub Actions workflow to detect ALZ query cache drift
- run scripts/Sync-AlzQueries.ps1 -DryRun and fail when drift is detected
- update CHANGELOG and Forge history

Builds on #315

Closes #316