### PR TITLE
docs(azure-quota): finalize permissions doc + CHANGELOG (closes #325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Added
 
-- test(azure-quota): expanded `Invoke-AzureQuotaReports` wrapper coverage with realistic Azure CLI fixtures for subscription/region fanout, retry/error/sanitization paths, scope filters, threshold passthrough, and strict v1 envelope assertions (closes #324).
+- docs(azure-quota): expanded `docs/consumer/permissions/azure-quota.md` with the exact `az vm list-usage` / `az network list-usages` fanout, all wrapper parameters (`Subscriptions`, `Locations`, `Threshold`, `OutputPath`), a sample normalized `FindingRow`, and the locked severity ladder (>=99 Critical, >=95 High, >=Threshold Medium, <Threshold Info) (closes #325).
+- test(azure-quota):expanded `Invoke-AzureQuotaReports` wrapper coverage with realistic Azure CLI fixtures for subscription/region fanout, retry/error/sanitization paths, scope filters, threshold passthrough, and strict v1 envelope assertions (closes #324).
 - ci: weekly ALZ query drift-check workflow (`alz-queries-drift-check.yml`) that runs `scripts/Sync-AlzQueries.ps1 -DryRun` and fails when upstream `martinopedal/alz-graph-queries` diverges from local `queries/` cache (closes #316).
 - feat: Azure Quota Reports wrapper (modules/Invoke-AzureQuotaReports.ps1) adds subscription+region fanout over az vm list-usage and az network list-usages with configurable compliance threshold (Threshold default 80), emitting v1 envelope findings for quota capacity risk (closes #322).
 - feat: Azure Quota Reports normalizer (modules/normalizers/Normalize-AzureQuotaReports.ps1) converts wrapper v1 findings into v2 FindingRows with canonical subscription entity IDs, locked compliance rule (`UsagePercent < Threshold`), and reliability/capacity metadata (closes #323).

--- a/docs/consumer/permissions/azure-quota.md
+++ b/docs/consumer/permissions/azure-quota.md
@@ -14,27 +14,83 @@ The Azure Quota Reports tool uses Azure CLI quota APIs to read current quota uti
 
 ## Parameters
 
-- `-SubscriptionId <guid>` (required, passed by orchestrator).
-- `-OutputPath <dir>` (optional): write wrapper output for audit.
+- `-SubscriptionId <guid>` (optional): single-subscription run.
+- `-Subscriptions <guid[]>` (optional): explicit fanout list. When neither flag is supplied the wrapper enumerates every subscription returned by `az account list`.
+- `-Locations <string[]>` (optional): restrict the region fanout. Defaults to the locations enabled for each subscription.
+- `-Threshold <int>` (optional, default `80`): usage percentage at or above which a quota row is treated as non-compliant.
+- `-OutputPath <dir>` (optional): write the wrapper envelope to disk for audit.
+
+## Azure CLI commands invoked
+
+The wrapper performs read-only fanout across `subscription x location` and shells out to:
+
+- `az account list -o json` (subscription discovery)
+- `az account list-locations --subscription <sub> -o json` (region discovery)
+- `az vm list-usage --location <region> --subscription <sub> -o json`
+- `az network list-usages --location <region> --subscription <sub> -o json`
+
+Every external call is wrapped in `Invoke-WithTimeout` (300s) and `Invoke-WithRetry` for transient throttling. No write commands and no support-ticket APIs are touched.
 
 ## Sample command
 
 ```powershell
-# Single subscription
+# Single subscription, default 80% threshold
 .\Invoke-AzureAnalyzer.ps1 -SubscriptionId "<sub-guid>" -IncludeTools 'azure-quota'
 
-# Across an MG (runs per discovered subscription)
+# Across a management group (runs per discovered subscription)
 .\Invoke-AzureAnalyzer.ps1 -ManagementGroupId "<mg-id>" -IncludeTools 'azure-quota'
+
+# Stricter capacity gate (alert at 70%)
+.\Invoke-AzureAnalyzer.ps1 -SubscriptionId "<sub-guid>" -IncludeTools 'azure-quota' `
+    -ToolParameters @{ 'azure-quota' = @{ Threshold = 70 } }
 ```
+
+## Sample output
+
+A normalized `FindingRow` from `Normalize-AzureQuotaReports` looks like:
+
+```json
+{
+  "Source": "azure-quota",
+  "EntityId": "/subscriptions/00000000-0000-0000-0000-000000000000",
+  "EntityType": "Subscription",
+  "Title": "Quota standardDSv3Family in westeurope is at 92%",
+  "RuleId": "azure-quota:vm:standardDSv3Family:westeurope",
+  "Compliant": false,
+  "Severity": "Medium",
+  "Pillar": "Reliability",
+  "Category": "Capacity",
+  "CurrentValue": 92,
+  "Limit": 100,
+  "UsagePercent": 92,
+  "Threshold": 80,
+  "Location": "westeurope",
+  "Service": "vm"
+}
+```
+
+## Severity ladder
+
+`UsagePercent` (`current / limit * 100`) drives both severity and the `Compliant` flag. The ladder is locked in `modules/normalizers/Normalize-AzureQuotaReports.ps1`:
+
+| UsagePercent | Severity | Compliant |
+|---|---|---|
+| `>= 99` | Critical | false |
+| `>= 95` | High | false |
+| `>= Threshold` (default 80) | Medium | false |
+| `< Threshold` | Info | true |
+
+Lowering `-Threshold` shifts more rows into the `Medium` band and into the non-compliant set; it does not change the `High` or `Critical` cutoffs.
 
 ## What it scans
 
-- Subscription quota usage and limits for supported resource providers.
-- Usage percentage bands to highlight approaching/exceeded capacity.
-- Region/provider/sku-level capacity pressure indicators.
+- Compute quota (`az vm list-usage`): VM family vCPUs, total regional vCPUs, availability sets, etc.
+- Networking quota (`az network list-usages`): VNets, public IPs, NSGs, load balancers, application gateways.
+- Per `subscription x region` fanout, with each row tagged with `Service`, `SkuName`, `CurrentValue`, `Limit`, and computed `UsagePercent`.
 
 ## What it does NOT do
 
 - No quota increase requests.
-- No support tickets.
+- No support ticket creation.
 - No resource writes or deployment changes.
+- No cross-tenant calls; the wrapper stays inside the signed-in `az` context.


### PR DESCRIPTION
Closes #325
Builds on #321 #322 #323 #324

## What

Finalizes consumer documentation for the `azure-quota` tool.

- `docs/consumer/permissions/azure-quota.md`: replaced the PR #328 stub with the full deep doc:
  - Exact Azure CLI commands invoked (`az account list`, `az account list-locations`, `az vm list-usage`, `az network list-usages`)
  - All wrapper parameters: `-SubscriptionId`, `-Subscriptions`, `-Locations`, `-Threshold` (default 80), `-OutputPath`
  - Sample normalized v2 `FindingRow` JSON
  - Locked severity ladder table sourced from `modules/normalizers/Normalize-AzureQuotaReports.ps1`
- `CHANGELOG.md`: Unreleased entry under 1.2.0.
- `README.md` / `PERMISSIONS.md`: already register `azure-quota` (no change needed).
- Tool catalog + permissions index regenerated via `scripts/Generate-ToolCatalog.ps1` and `scripts/Generate-PermissionsIndex.ps1`; output byte-identical to current artifacts so nothing committed.
- No `docs/tools/` deep-dive folder exists in this repo, so no extra file added there.

## Severity ladder (verified against normalizer source)

| UsagePercent | Severity | Compliant |
|---|---|---|
| `>= 99` | Critical | false |
| `>= 95` | High | false |
| `>= Threshold` (default 80) | Medium | false |
| `< Threshold` | Info | true |

## Validation

- `Invoke-Pester -Path .\tests -CI` -> **1369 passing, 0 failing** (baseline preserved).
- No em dashes in any doc surface.
- Repo conventions followed (Reader-only scope, manifest-registered tool).