### PR TITLE
feat: LLM-assisted triage with rubberduck + tier-aware (scaffold) (#433)

### DIFF
--- a/.squad/decisions/inbox/nova-triage-433.md
+++ b/.squad/decisions/inbox/nova-triage-433.md
@@ -1,0 +1,37 @@
+# nova-triage / Track E scaffold (#433)
+
+**Branch:** `feat/triage-433`
+**PR:** draft (Phase 2 hold)
+
+## Summary
+
+Scaffolded Track E (LLM-assisted triage with rubberduck + tier-aware model selection):
+
+- `docs/design/llm-triage.md` — design doc with both locked rules, frontier-only invariant scope clarification (internal maintainer agents vs end-user triage), model discovery flow (`gh copilot status`, no `gh api user`, no silent fallback), CLI surface, trio composition algorithm with provider-diversity tie-break, sanitization contract, and explicit in/out of scope.
+- `config/triage-model-ranking.json` — capability ranking template with `_header` block reserving a SHA-256 slot reviewed quarterly.
+- `modules/shared/Triage/Invoke-CopilotTriage.ps1` — signatures only for `Invoke-CopilotTriage`, `Get-AvailableModelsFromCopilotPlan`, `Select-TriageTrio`, `Invoke-PromptSanitization`, `Invoke-ResponseSanitization`. All bodies throw `NotImplementedException`.
+- `tests/triage/Triage.Tests.ps1` and `Triage.Sanitization.Tests.ps1` — Pester `-Skip` placeholders for trio selection by tier, explicit-model refusal, single-model fallback warning, sub-3 model behavior, prompt and response sanitization (echo leakage is the most security-critical case).
+
+## Decisions worth recording
+
+- Frontier-only invariant scope is clarified in the design doc and intended for the README in Phase 2. Internal agents stay frontier-only; end-user triage runs on whatever models the user's Copilot plan grants.
+- Trio composition prefers provider diversity (Anthropic / OpenAI / Google) as a rubberduck signal-strength heuristic, not just raw rank.
+- Default behaviour when fewer than 3 models are available: refuse, with `-SingleModel` as the explicit opt-in.
+- Tier discovery: `gh copilot status` first, then required `-CopilotTier` flag or env var. No silent fallback. `gh api user` is explicitly banned because it does not expose plan info.
+- Capability ranking JSON ships with a `_header.sha256` slot. Quarterly review by maintainers.
+
+## Hot files avoided
+
+No edits to `Schema.ps1`, `Invoke-AzureAnalyzer.ps1`, `New-HtmlReport.ps1`, or `tools/tool-manifest.json`. No actual LLM calls. Foundation dependency on #435 is respected — discovery implementation deferred.
+
+## Tests
+
+`Invoke-Pester .\tests\triage -CI` → 13 skipped, 0 failed. Existing 842/842 baseline untouched (no edits outside new files).
+
+## Follow-ups for Phase 2
+
+- Implement `gh copilot status` parser + tier resolution.
+- Wire `Remove-Credentials` into `Invoke-PromptSanitization` / `Invoke-ResponseSanitization` and turn the Pester `-Skip` cases into real tests.
+- README section for end-user vs internal-maintainer roster distinction.
+- CHANGELOG entry on shipping Phase 2.
+- PERMISSIONS note that Copilot API calls are made.

--- a/config/triage-model-ranking.json
+++ b/config/triage-model-ranking.json
@@ -1,0 +1,20 @@
+{
+  "_header": {
+    "schemaVersion": "1.0",
+    "lastReviewed": "2026-04-21",
+    "sha256": "PENDING-COMPUTED-AT-COMMIT",
+    "reviewCadence": "quarterly",
+    "notes": "Capability ranking for end-user LLM triage trio composition. Maintainers review and re-pin SHA each quarter. See docs/design/llm-triage.md."
+  },
+  "schemaVersion": "1.0",
+  "lastReviewed": "2026-04-21",
+  "rankings": [
+    {"model": "claude-opus-4.6", "tier": "premium", "rank": 100, "provider": "anthropic", "notes": "Best reasoning, slowest"},
+    {"model": "gpt-5.2-codex", "tier": "standard-code", "rank": 90, "provider": "openai", "notes": "Best for code-heavy triage"},
+    {"model": "gemini-3-pro-preview", "tier": "standard-analytical", "rank": 85, "provider": "google", "notes": "Strong analytical diversity"},
+    {"model": "claude-sonnet-4.6", "tier": "standard", "rank": 80, "provider": "anthropic", "notes": ""},
+    {"model": "gpt-5.2", "tier": "standard", "rank": 75, "provider": "openai", "notes": ""},
+    {"model": "claude-haiku-4.5", "tier": "fast", "rank": 50, "provider": "anthropic", "notes": "Fallback only"},
+    {"model": "gpt-4.1", "tier": "fast", "rank": 40, "provider": "openai", "notes": "Fallback only"}
+  ]
+}

--- a/docs/design/llm-triage.md
+++ b/docs/design/llm-triage.md
@@ -1,0 +1,87 @@
+# LLM-assisted Triage (Track E) Design
+
+Status: Phase 2 design scaffold. Implementation held behind Phase 1 MVP and product validation gate (2 auditor walkthroughs, 2 architect workflows, 1 high-volume tenant dataset run). Tracks issue #433, epic #427.
+
+## Two locked rules
+
+### Rule 1: Rubberduck is the default
+
+The default invocation for every LLM-assisted analysis (prioritized remediation plans, cross-finding correlation, remediation sequencing, narrative tenant summaries) is the multi-model rubberduck trio with 2-of-3 consensus.
+
+A single model will confidently hallucinate a remediation that breaks production. Two models agreeing is a meaningful signal; three models with consensus catches model-specific blindspots.
+
+Single-model mode is opt-in via `-SingleModel` (for speed or cost). The trio is always the default.
+
+### Rule 2: Tier-aware model selection
+
+GitHub Copilot plans gate which models a user can invoke. The CLI must respect this. End-users cannot be forced onto models their plan does not grant.
+
+## Frontier-only invariant: scope clarification
+
+The frontier-only roster (`opus-4.7`, `opus-4.6-1m`, `gpt-5.3-codex`, `gpt-5.4`, `goldeneye`) applies to **internal maintainer agents that run on the azure-analyzer codebase**: code review gates, rubberduck gates on PRs, scaffolding agents, sub-agents spawned by the coordinator. These run on the maintainer's plan and ship quality-affecting output.
+
+**End-user LLM triage (this feature) is a declared exception.** The triage trio is composed from whatever models the running user's Copilot plan grants. This exception is documented in the README so users are not surprised that their Pro-tier triage trio differs from the frontier-only roster used internally.
+
+## Model discovery flow
+
+1. Probe `gh copilot status`. Recent `gh` CLI versions surface the user's Copilot plan.
+2. If unsupported or unparseable, require an explicit `-CopilotTier {Pro|Business|Enterprise}` flag (or `$env:AZURE_ANALYZER_COPILOT_TIER`).
+3. **No silent fallback.** A misdetected tier could cause the CLI to attempt models the user cannot invoke.
+4. **Never use `gh api user`.** That endpoint does not expose Copilot plan info; the original Round 1 design was wrong on this point.
+
+## CLI surface
+
+| Flag | Values | Purpose |
+|---|---|---|
+| `-TriageModel` | `Auto` (default) or `Explicit:<model-id>` | Auto picks the trio; Explicit forces one model and must be in the user's available roster |
+| `-CopilotTier` | `Pro|Business|Enterprise` | Required if `gh copilot status` cannot resolve the plan |
+| `-SingleModel` | switch | Opt out of rubberduck trio |
+| `$env:AZURE_ANALYZER_COPILOT_TIER` | `Pro|Business|Enterprise` | Environment override equivalent to `-CopilotTier` |
+
+Refusing cross-tier picks: if the user passes `-TriageModel Explicit:<id>` and `<id>` is not in their tier roster, the cmdlet refuses with a clear error message naming the model and the user's available roster.
+
+## Trio composition algorithm
+
+1. Resolve the user's tier (discovery flow above).
+2. Enumerate the user's available models for that tier.
+3. Rank each model against `config/triage-model-ranking.json`.
+4. Pick the top three by rank.
+5. Tie-break by **provider diversity**: prefer mixing providers (Anthropic, OpenAI, Google) over three models from the same provider, because rubberduck consensus across providers catches more blindspots.
+6. If fewer than three models are available:
+   - Default: refuse to run with a clear error pointing at single-model fallback.
+   - Configurable: `-SingleModel` opts in to fallback mode with a stderr warning.
+
+## Sanitization
+
+`Remove-Credentials` from `modules/shared/Sanitize.ps1` is applied to:
+
+- Every prompt before it leaves the cmdlet.
+- Every response before it is rendered or logged.
+
+Belt-and-braces. LLMs have echoed prompt content verbatim in the past, so the response pass is non-negotiable. A negative Pester test asserts that a poisoned finding field (e.g. an embedded fake token) cannot leak through model echo into rendered output.
+
+## Triage scope
+
+In scope:
+
+- Prioritized remediation plan with ranked "fix in this order because" narrative.
+- Cross-finding correlation ("findings 12, 47, 89 all point to the same misconfiguration in subscription X").
+- Remediation sequencing ("fix SPN permissions before secret rotation, or rotation will fail").
+- Narrative tenant summary: executive-readable one-pager describing posture, severity trend, top risks.
+
+Out of scope:
+
+- Single-finding remediation text (Track D, sourced from the tool itself).
+- Auto-apply fixes. Forever out of scope. azure-analyzer is read-only.
+
+## Capability ranking table
+
+Lives at `config/triage-model-ranking.json`. Reviewed by maintainers quarterly. The file commits with a SHA-256 digest in its header so any silent edit is detectable in code review.
+
+This is the only place azure-analyzer makes model-quality judgements on the end-user's behalf.
+
+## Cross references
+
+- `modules/shared/Triage/Invoke-CopilotTriage.ps1` (signatures only at Phase 2 scaffold).
+- `tests/triage/Triage.Tests.ps1`, `tests/triage/Triage.Sanitization.Tests.ps1`.
+- README "LLM triage" section: end-user vs internal-maintainer roster distinction.

--- a/modules/shared/Triage/Invoke-CopilotTriage.ps1
+++ b/modules/shared/Triage/Invoke-CopilotTriage.ps1
@@ -1,0 +1,89 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Track E LLM-assisted triage scaffold (issue #433). Signatures only.
+
+.DESCRIPTION
+    Phase 2 scaffold. Implementation is held behind Phase 1 MVP and the product
+    validation gate. See docs/design/llm-triage.md for the full design.
+
+    Two locked rules:
+      Rule 1: rubberduck (2-of-3 consensus) is the DEFAULT; -SingleModel opts out.
+      Rule 2: tier-aware model selection respects the user's Copilot plan.
+#>
+
+Set-StrictMode -Version Latest
+
+function Invoke-CopilotTriage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object[]] $Findings,
+
+        [ValidateSet('Rubberduck', 'SingleModel')]
+        [string] $Mode = 'Rubberduck',
+
+        [ValidateSet('Pro', 'Business', 'Enterprise')]
+        [string] $CopilotTier,
+
+        [string] $ExplicitModel
+    )
+    throw [System.NotImplementedException]::new(
+        'Invoke-CopilotTriage is a Phase 2 scaffold. See docs/design/llm-triage.md.'
+    )
+}
+
+function Get-AvailableModelsFromCopilotPlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('Pro', 'Business', 'Enterprise')]
+        [string] $Tier
+    )
+    throw [System.NotImplementedException]::new(
+        'Get-AvailableModelsFromCopilotPlan is a Phase 2 scaffold.'
+    )
+}
+
+function Select-TriageTrio {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]] $AvailableModels,
+
+        [Parameter(Mandatory)]
+        [object] $RankingTable
+    )
+    throw [System.NotImplementedException]::new(
+        'Select-TriageTrio is a Phase 2 scaffold.'
+    )
+}
+
+function Invoke-PromptSanitization {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Prompt
+    )
+    throw [System.NotImplementedException]::new(
+        'Invoke-PromptSanitization is a Phase 2 scaffold. Will delegate to Remove-Credentials.'
+    )
+}
+
+function Invoke-ResponseSanitization {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Response
+    )
+    throw [System.NotImplementedException]::new(
+        'Invoke-ResponseSanitization is a Phase 2 scaffold. Will delegate to Remove-Credentials.'
+    )
+}
+
+Export-ModuleMember -Function `
+    Invoke-CopilotTriage, `
+    Get-AvailableModelsFromCopilotPlan, `
+    Select-TriageTrio, `
+    Invoke-PromptSanitization, `
+    Invoke-ResponseSanitization

--- a/tests/triage/Triage.Sanitization.Tests.ps1
+++ b/tests/triage/Triage.Sanitization.Tests.ps1
@@ -1,0 +1,31 @@
+#requires -Version 7.0
+#requires -Modules Pester
+
+Describe 'Track E LLM triage sanitization (#433)' {
+
+    Context 'Prompt sanitization' {
+        It 'strips secrets from a poisoned finding field before prompt assembly' -Skip {
+            # Phase 2: assert Invoke-PromptSanitization redacts known token shapes.
+        }
+
+        It 'preserves canonical entity IDs while redacting raw tenant identifiers where possible' -Skip {
+            # Phase 2.
+        }
+    }
+
+    Context 'Response sanitization (echo leakage)' {
+        It 'redacts a model response that echoes a prompt secret verbatim' -Skip {
+            # Phase 2: most security-critical test. Belt-and-braces.
+        }
+
+        It 'redacts a model response that paraphrases or partially echoes a secret' -Skip {
+            # Phase 2.
+        }
+    }
+
+    Context 'End-to-end sanitization invariant' {
+        It 'never writes an unsanitized prompt or response to disk or stdout' -Skip {
+            # Phase 2: every code path through Invoke-CopilotTriage hits sanitizers.
+        }
+    }
+}

--- a/tests/triage/Triage.Tests.ps1
+++ b/tests/triage/Triage.Tests.ps1
@@ -1,0 +1,47 @@
+#requires -Version 7.0
+#requires -Modules Pester
+
+Describe 'Track E LLM triage scaffold (#433)' {
+
+    Context 'Trio selection by tier' {
+        It 'picks the top three Pro-tier models by capability rank' -Skip {
+            # Phase 2: assert Select-TriageTrio against a fixture roster.
+        }
+
+        It 'picks the top three Business-tier models with provider diversity tie-break' -Skip {
+            # Phase 2.
+        }
+
+        It 'picks the top three Enterprise-tier models' -Skip {
+            # Phase 2.
+        }
+    }
+
+    Context 'Explicit model gating' {
+        It 'refuses an explicit model that is not in the user tier roster' -Skip {
+            # Phase 2: -TriageModel Explicit:<id> must validate against tier roster.
+        }
+    }
+
+    Context 'Single-model fallback' {
+        It 'warns the user when -SingleModel is used to opt out of rubberduck' -Skip {
+            # Phase 2: assert stderr / Write-Warning emission.
+        }
+    }
+
+    Context 'Fewer than three available models' {
+        It 'refuses by default when the tier exposes fewer than three models' -Skip {
+            # Phase 2.
+        }
+
+        It 'falls back to single-model mode when -SingleModel is also set, with warning' -Skip {
+            # Phase 2.
+        }
+    }
+
+    Context 'Tier discovery' {
+        It 'requires explicit -CopilotTier when gh copilot status is unsupported' -Skip {
+            # Phase 2: never silent fallback.
+        }
+    }
+}


### PR DESCRIPTION
## Track E scaffold (Phase 2 hold)

Closes design portion of #433. Foundation dependency: #435. Implementation deferred behind Phase 1 MVP and the explicit product validation gate (2 auditor walkthroughs, 2 architect workflows, 1 high-volume tenant dataset run).

### What is in this PR
- `docs/design/llm-triage.md` design doc covering both locked rules, model discovery, CLI surface, trio composition, sanitization contract, in/out of scope.
- `config/triage-model-ranking.json` capability ranking template with SHA-256 header slot for quarterly maintainer review.
- `modules/shared/Triage/Invoke-CopilotTriage.ps1` signatures only. All bodies throw `NotImplementedException`.
- `tests/triage/*.Tests.ps1` Pester `-Skip` placeholders. Local run: 0 failed, 13 skipped.
- `.squad/decisions/inbox/nova-triage-433.md` summary.

### Frontier-only invariant scope clarification (important)
- **Internal maintainer agents** (code-review gates, rubberduck gates on PRs, scaffolding agents, sub-agents spawned by the coordinator) remain **frontier-only enforced** (`opus-4.7`, `opus-4.6-1m`, `gpt-5.3-codex`, `gpt-5.4`, `goldeneye`).
- **End-user LLM triage** is a **declared exception**. Users can only invoke the models their GitHub Copilot plan grants. The triage trio is composed at runtime from each user's available roster. This will be documented in the README in Phase 2.

### Phase 2 + validation gate
This PR ships scaffold only. No LLM calls, no edits to hot files (`Schema.ps1`, `Invoke-AzureAnalyzer.ps1`, `New-HtmlReport.ps1`, `tools/tool-manifest.json`). Implementation lands after Phase 1 MVP stabilizes and the validation gate clears.

### Out of scope (forever)
- Auto-apply fixes. azure-analyzer is read-only.

### Out of scope (this PR, lands in Phase 2)
- Real `gh copilot status` parser.
- Wiring `Remove-Credentials` into the sanitizer functions.
- Real Pester assertions in place of `-Skip` placeholders.
- README, CHANGELOG, PERMISSIONS updates.