### PR TITLE
fix(docs): drop broken inbox link breaking Markdown Link Check on every .md PR

### DIFF
--- a/docs/audits/track-d-tool-fidelity.md
+++ b/docs/audits/track-d-tool-fidelity.md
@@ -1,7 +1,7 @@
 # Track D — tool output fidelity audit (#432)
 
 > Status: **draft**, queued behind the 8h close plan
-> ([`.squad/decisions/inbox/lead-8h-close-plan-2026-04-22.md`](../../.squad/decisions/inbox/lead-8h-close-plan-2026-04-22.md)).
+> (see `.squad/decisions/inbox/` for the lead's 8h close plan dated 2026-04-22).
 > Wave-1 audit lives in [`docs/tool-output-audit.md`](../tool-output-audit.md) (#432a, merged in PR #465).
 > This doc extends the audit to **all 36 normalizers** and proposes the first three enrichment patches (#432b).
 


### PR DESCRIPTION
Follow-up to #524: the retry-wrapper fix merged green but unmasked a pre-existing broken link on main.

`docs/audits/track-d-tool-fidelity.md` (added via #499 scaffold) referenced `.squad/decisions/inbox/lead-8h-close-plan-2026-04-22.md`, which was never committed. Lychee correctly flagged it and every PR that touched any `.md` file was failing Markdown Link Check with:

`[ERROR] file:///.../track-d-tool-fidelity.md references .squad/decisions/inbox/lead-8h-close-plan-2026-04-22.md | Cannot find file`

The `.squad/` file itself is ignored by lychee config, so only the `docs/audits/` reference needs editing. Convert the link to plain prose mentioning the inbox path — preserves the audit trail without a broken link.

Smallest possible blast radius: 1 line, 1 file, docs-only.

Fixes #524