### PR TITLE
fix(ci): markdown-link-check continue-on-error hotfix (unblock PR merges)

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -17,6 +17,9 @@ jobs:
   markdown-link-check:
     name: markdown-link-check
     runs-on: ubuntu-latest
+    # HOTFIX 2026-04-23: continue-on-error until PR #525 (hardened lychee+markdownlint split) lands.
+    # Current impl red-crosses ~every PR due to branch-unstable .squad/** + .copilot/** docs.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
P0 hotfix. Every open PR was red-crossed by this workflow. Adds continue-on-error: true at job scope so it cannot block merges while PR #525 (proper lychee+markdownlint-cli2 split) lands.

Root cause confirmed by trio (Hawkeye + Cipher + Oracle): workflow scans branch-unstable .squad and .copilot markdown, producing deterministic false reds unrelated to external link health.

- Workflow still runs and reports in job summary
- Weekly cron still fires
- Revert when #525 merges

Closes #516