### PR TITLE
fix(verify): parse error on every merge + PS 7.4 native exit propagation

### DIFF
--- a/.github/workflows/issue-resolution-verify.yml
+++ b/.github/workflows/issue-resolution-verify.yml
@@ -121,7 +121,7 @@ jobs:
             try {
               $issueJson = gh issue view $n --repo $env:REPO --json number,body,labels,state 2>&1 | Out-String
               if ($LASTEXITCODE -ne 0) {
-                Write-Host "::warning::Failed to fetch issue #$n: $issueJson"
+                Write-Host "::warning::Failed to fetch issue #${n}: $issueJson"
                 Write-Host '::endgroup::'
                 continue
               }

--- a/.github/workflows/issue-resolution-verify.yml
+++ b/.github/workflows/issue-resolution-verify.yml
@@ -102,6 +102,11 @@ jobs:
 
           function Invoke-GhChecked {
               param([Parameter(Mandatory)][string] $Label, [Parameter(Mandatory)][string[]] $Args)
+              # PS 7.4+ default: $PSNativeCommandUseErrorActionPreference=$true means `& gh`
+              # throws on non-zero exit *before* our $LASTEXITCODE branch runs, collapsing
+              # all gh failures into the outer catch. Scope-local override keeps the labelled
+              # warning contract working.
+              $PSNativeCommandUseErrorActionPreference = $false
               & gh @Args 2>&1 | Out-Host
               if ($LASTEXITCODE -ne 0) {
                   Write-Host "::warning::gh $Label failed (exit $LASTEXITCODE) args=$($Args -join ' ')"

--- a/tests/workflows/IssueResolutionVerify.Tests.ps1
+++ b/tests/workflows/IssueResolutionVerify.Tests.ps1
@@ -277,6 +277,20 @@ Describe 'issue-resolution-verify.yml - workflow contract' {
         $content = Get-Content -Raw $script:WorkflowPath
         $content | Should -Match 'function Invoke-GhChecked'
         $content | Should -Match '\$LASTEXITCODE'
+        $content | Should -Match '\$PSNativeCommandUseErrorActionPreference\s*=\s*\$false'
+    }
+
+    It 'contains no ambiguous scope-qualified variable refs in the inline script' {
+        # $n: / $foo: would be parsed as scope-qualified variable refs and crash the step.
+        # $env:X is allowed because env is a well-known PS drive/scope.
+        $content = Get-Content -Raw $script:WorkflowPath
+        $matchList = [regex]::Matches($content, '\$(?!env:)[A-Za-z_][A-Za-z0-9_]*:')
+        $bad = @($matchList | Where-Object {
+            $line = $_.Value
+            # Skip GraphQL variable declarations: $owner:String!, $repo:String!, $pr:Int!
+            $line -notmatch '^\$(owner|repo|pr):$'
+        })
+        $bad.Count | Should -Be 0 -Because "PowerShell parses these as drive-qualified refs: $(( $bad | ForEach-Object Value) -join ', ')"
     }
 
     It 'gates the verify job on merged == true' {


### PR DESCRIPTION
## Summary  Two Praxis runtime fixes that landed on a branch during the PR #533 rebase window but did not make it into the merge commit. Without them, the verification workflow **crashes on every merged PR** with a PowerShell parse error, which is exactly what happened when #527 dogfooded itself (see run 24806421784).  ## Fixes  **Critical ÔÇö PowerShell parse error on every merge**  ``` Write-Host "::warning::Failed to fetch issue #$n: $issueJson" ```  PowerShell parses `$n:` as a drive-qualified variable reference (`$n:whatever`), which is a parse error because no drive named `n` exists. The step aborts before any repro runs. Fixed by delimiting with `${n}`. Added a regression test that scans the workflow for any `$<var>:` pattern other than the allow-listed `$env:X` and GraphQL parameter declarations.  **Low ÔÇö Per-label gh warnings were dead code on the runner**  PS 7.4+ defaults `$PSNativeCommandUseErrorActionPreference` to `$true`, so `& gh @Args` throws on non-zero exit before the `$LASTEXITCODE` branch inside `Invoke-GhChecked` runs. Every gh failure collapsed into the outer catch's generic "threw on issue" warning instead of the intended `::warning::gh <Label> failed (exit N) args=ÔÇª`. Scope-local override inside the wrapper restores the contract. (Originally spotted by Opus 4.7 on PR #533 but the PR was admin-merged before the fix landed.)  ## Tests  - Pester: **45/45** green on `tests/workflows/IssueResolutionVerify.Tests.ps1`. - New test: `contains no ambiguous scope-qualified variable refs in the inline script`. - Updated test: `invokes gh mutations through a wrapper that checks $LASTEXITCODE` now also asserts the `$PSNativeCommandUseErrorActionPreference = $false` line.  ## Self-review  - [x] Cherry-picked two commits clean from the previous branch; no new code - [x] Rebased directly on `origin/main` (#531 HEAD) - [x] No em dashes - [x] 45/45 green 

## Closes
N/A (fix: Praxis runtime fixes follow-up to #533 merge window; no standalone tracked issue)
