### PR TITLE
fix(security): remove duplicate New-FindingError in Schema.ps1 (#671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [1.2.0 - Unreleased]
 
+### Fixed
+- Remove duplicate New-FindingError definition in modules/shared/Schema.ps1 that shadowed the canonical sanitizing version in Errors.ps1, restoring Remove-Credentials enforcement on Reason and Remediation fields. (closes #671)
+
 ### Changed
 - chore(sweep): post-sprint 3-model rubberduck audit (claude-opus-4.7 + gpt-5.4 + gpt-5.3-codex, parallel from fresh worktrees) covering workflows, retry, params, errors, schema, tests, docs, manifest, security, and hotfix-debt. 0 critical / 0 high / 6 medium 2-of-3-consensus findings shipped as tracking issues #669-#674: raw throws in `Send-FindingsToLogAnalytics` (#669), three Unreleased headers in CHANGELOG.md (#670), shadowed helpers in `Schema.ps1` (#671), `Invoke-Infracost` 60s timeout vs 300s invariant (#672), missing inline `# tracked: #NNN` markers on `continue-on-error` workflows (#673), and `tool-manifest.json` not alphabetically sorted (#674). Pester baseline confirmed green (2171 passed / 0 failed / 36 skipped). 1-of-3 findings (Retry pattern omits ECONNRESET/ETIMEDOUT errno tokens; ResilienceMap skip annotations; README em-dash backlog) deferred and logged in `.squad/decisions/inbox/sweep-final-2026-04-23T03-29-40Z.md`. Goldeneye leg returned `400 model not supported`; fell back to `gpt-5.4` per the Frontier Fallback Chain to keep three distinct legs. Sprint officially closed.
 - Remove transient maintenance banner from README, sprint closed (#668)

--- a/modules/shared/Schema.ps1
+++ b/modules/shared/Schema.ps1
@@ -99,37 +99,6 @@ function Get-SchemaValidationFailures {
     return ,$script:ValidationFailures.ToArray()
 }
 
-function New-FindingError {
-    <#
-    .SYNOPSIS
-        Build a rich, sanitized error object for finding-pipeline failures
-        (normalizers, triage, ETL closures). Mirrors New-InstallerError shape.
-    .DESCRIPTION
-        Returned object can be thrown directly. Caller-supplied Details are
-        scrubbed via Remove-Credentials (when available) before being attached.
-    #>
-    param (
-        [Parameter(Mandatory)][string] $Source,
-        [Parameter(Mandatory)][string] $Category,
-        [Parameter(Mandatory)][string] $Reason,
-        [string] $Remediation,
-        [string] $Details
-    )
-    $safeDetails = [string]$Details
-    if (Get-Command -Name Remove-Credentials -ErrorAction SilentlyContinue) {
-        $safeDetails = Remove-Credentials $safeDetails
-    }
-    return [PSCustomObject]@{
-        PSTypeName   = 'AzureAnalyzer.FindingError'
-        Source       = $Source
-        Category     = $Category
-        Reason       = $Reason
-        Remediation  = $Remediation
-        Details      = $safeDetails
-        TimestampUtc = (Get-Date).ToUniversalTime().ToString('o')
-    }
-}
-
 function Reset-SchemaValidationFailures {
     <#
     .SYNOPSIS

--- a/modules/shared/Triage/Invoke-CopilotTriage.ps1
+++ b/modules/shared/Triage/Invoke-CopilotTriage.ps1
@@ -31,16 +31,22 @@ function New-TriageError {
         [string] $Remediation,
         [string] $Details
     )
-    if (Get-Command -Name New-FindingError -ErrorAction SilentlyContinue) {
-        return New-FindingError -Source 'triage' -Category $Category -Reason $Reason -Remediation $Remediation -Details $Details
-    }
+    # Triage uses a domain-specific category vocabulary
+    # (TierUnresolved/AllModelsFailed/NoRankedModels/...) that intentionally
+    # does NOT overlap the canonical FindingErrorCategories enum in
+    # modules/shared/Errors.ps1. We therefore construct the rich error inline
+    # rather than delegating to New-FindingError, but mirror the same
+    # sanitization invariant: every free-text field passes through
+    # Remove-Credentials so the object is safe to log or throw. (See #671 for
+    # why we no longer rely on a Schema.ps1 alias of New-FindingError.)
     return [PSCustomObject]@{
-        PSTypeName  = 'AzureAnalyzer.FindingError'
-        Source      = 'triage'
-        Category    = $Category
-        Reason      = $Reason
-        Remediation = $Remediation
-        Details     = (Remove-Credentials ([string]$Details))
+        PSTypeName   = 'AzureAnalyzer.FindingError'
+        Source       = 'triage'
+        Category     = $Category
+        Reason       = (Remove-Credentials ([string]$Reason))
+        Remediation  = (Remove-Credentials ([string]$Remediation))
+        Details      = (Remove-Credentials ([string]$Details))
+        TimestampUtc = (Get-Date).ToUniversalTime().ToString('o')
     }
 }
 

--- a/tests/shared/Errors.Collision.Tests.ps1
+++ b/tests/shared/Errors.Collision.Tests.ps1
@@ -1,0 +1,60 @@
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+# Regression tests for #671: New-FindingError was previously redefined in
+# modules/shared/Schema.ps1 and (because AzureAnalyzer.psm1 dot-sources
+# modules/shared/*.ps1 in ASCII order) the broken Schema.ps1 version
+# overwrote the canonical Errors.ps1 implementation, silently bypassing
+# Remove-Credentials on Reason/Remediation and skipping Category enum
+# validation. This file pins the canonical contract.
+
+BeforeAll {
+    $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
+    . (Join-Path $repoRoot 'modules' 'shared' 'Sanitize.ps1')
+    . (Join-Path $repoRoot 'modules' 'shared' 'Errors.ps1')
+    # Schema.ps1 must NOT redefine New-FindingError. We deliberately load it
+    # AFTER Errors.ps1 here — same ASCII order the module's Get-ChildItem walk
+    # produces — so any reintroduced duplicate would shadow the canonical
+    # version and the assertions below would catch it.
+    . (Join-Path $repoRoot 'modules' 'shared' 'Schema.ps1')
+}
+
+Describe 'New-FindingError single-definition (regression #671)' {
+    It 'resolves to modules/shared/Errors.ps1, not Schema.ps1' {
+        $cmd = Get-Command New-FindingError
+        $cmd | Should -Not -BeNullOrEmpty
+        $file = $cmd.ScriptBlock.File
+        $file | Should -Not -BeNullOrEmpty
+        $file | Should -Match 'Errors\.ps1$'
+        $file | Should -Not -Match 'Schema\.ps1$'
+    }
+
+    It 'is defined exactly once across modules/shared' {
+        $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
+        $matches = @(Get-ChildItem (Join-Path $repoRoot 'modules\shared') -Filter '*.ps1' |
+            Select-String -Pattern '^function\s+New-FindingError\b')
+        $matches.Count | Should -Be 1
+        $matches[0].Path | Should -Match 'Errors\.ps1$'
+    }
+}
+
+Describe 'New-FindingError sanitization invariant (regression #671)' {
+    It 'sanitizes an AccountKey-style secret in Reason' {
+        $result = New-FindingError -Source 'test' -Category 'IOFailure' `
+            -Reason 'AccountKey=reallyasecret123' -Remediation 'rotate'
+        ($result.Reason -match 'reallyasecret123') | Should -BeFalse
+    }
+
+    It 'sanitizes a SAS-style token in Remediation' {
+        $sas = '?sig=abcDEF123ghiJKL=='
+        $result = New-FindingError -Source 'test' -Category 'IOFailure' `
+            -Reason 'boom' -Remediation "rotate via $sas"
+        ($result.Remediation -match 'abcDEF123ghiJKL') | Should -BeFalse
+    }
+}
+
+Describe 'New-FindingError Category enum enforcement (regression #671)' {
+    It 'throws on an invalid Category value' {
+        { New-FindingError -Source 'x' -Category 'NotARealCategory' -Reason 'r' } |
+            Should -Throw -ExpectedMessage '*invalid Category*'
+    }
+}

--- a/tests/shared/Triage/Triage.Frontier.Tests.ps1
+++ b/tests/shared/Triage/Triage.Frontier.Tests.ps1
@@ -116,8 +116,8 @@ Describe 'Triage Frontier Fallback Chain (bottom-fix #466)' {
             ($payload | Out-String) | Should -Match 'AllModelsFailed'
         }
 
-        It 'New-FindingError emits the documented rich-error fields' {
-            $err = New-FindingError -Source 'triage' -Category 'TestCat' -Reason 'why' `
+        It 'New-TriageError emits the documented rich-error fields' {
+            $err = New-TriageError -Category 'TestCat' -Reason 'why' `
                 -Remediation 'how' -Details 'no secrets here'
             $err.PSObject.TypeNames | Should -Contain 'AzureAnalyzer.FindingError'
             $err.Source       | Should -Be 'triage'
@@ -128,8 +128,8 @@ Describe 'Triage Frontier Fallback Chain (bottom-fix #466)' {
             $err.TimestampUtc | Should -Match '^\d{4}-\d{2}-\d{2}T'
         }
 
-        It 'New-FindingError scrubs Bearer tokens out of Details' {
-            $err = New-FindingError -Source 'triage' -Category 'TestCat' -Reason 'why' `
+        It 'New-TriageError scrubs Bearer tokens out of Details' {
+            $err = New-TriageError -Category 'TestCat' -Reason 'why' `
                 -Details 'Authorization: Bearer abc.def.ghi-jkl_mn'
             $err.Details | Should -Not -Match 'abc\.def\.ghi-jkl_mn'
             $err.Details | Should -Match '\[REDACTED\]'


### PR DESCRIPTION
Schema.ps1 redefined `New-FindingError` without `Remove-Credentials` on Reason/Remediation and without Category enum validation. ASCII dot-source order in `AzureAnalyzer.psm1` meant Schema.ps1's broken version overwrote the canonical Errors.ps1 implementation, silently bypassing the secret-redaction invariant for any caller that included a SAS token or connection string in those fields.

- Delete the duplicate function block in `modules/shared/Schema.ps1` (lines 102-131)
- Update `New-TriageError` in `modules/shared/Triage/Invoke-CopilotTriage.ps1` to construct its rich-error inline (mirroring the `Remove-Credentials` invariant on Reason/Remediation/Details) instead of delegating to canonical `New-FindingError`, since the triage category vocabulary (`TierUnresolved` / `AllModelsFailed` / ...) intentionally diverges from the canonical `FindingErrorCategories` enum
- Update `tests/shared/Triage/Triage.Frontier.Tests.ps1` to exercise the `New-TriageError` contract directly (the previous calls to a globally loaded `New-FindingError` had been relying on Schema.ps1's permissive shadow)
- Add `tests/shared/Errors.Collision.Tests.ps1` regression coverage: single-definition assertion (resolved file ends in `Errors.ps1`), Reason and Remediation sanitization, Category enum enforcement throws

Closes #671

## Verification

- `Get-Content modules\shared\Schema.ps1 | Select-String 'function New-FindingError'` -> 0 matches
- `Get-Content modules\shared\Errors.ps1 | Select-String 'function New-FindingError'` -> 1 match
- `Invoke-Pester -Path tests\shared\Errors.Collision.Tests.ps1` -> Tests Passed: 5, Failed: 0
- `Invoke-Pester -Path tests -CI` -> Tests Passed: 2176, Failed: 0, Skipped: 36 (baseline was 2171/0/36; +5 from the new regression file)
- CHANGELOG diff contains no em-dashes (U+2014) or en-dashes (U+2013) on added lines (markdown-check.yml em-dash gate clean)