### PR TITLE
fix(ci): guard sparse .user payloads in PR Review Gate (#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to azure-analyzer will be documented here.
 ## [1.2.0 - Unreleased]
 
 ### Fixed
+- Guard sparse `.user` payloads in `modules/shared/Invoke-PRReviewGate.ps1` (lines 151, 163) so PR Review Gate no longer crashes under StrictMode when GitHub REST returns a review or line-comment object without a `user` property (ghost/deleted user or sparse bot comment). `-and` short-circuit was insufficient because StrictMode raises before logical evaluation; switched to `PSObject.Properties['user']` presence checks matching the existing pattern at lines 165/170. Added regression test in `tests/shared/Invoke-PRReviewGate.Tests.ps1` (sparse-user Context, 12/12 green). Closes #584.
 - Remove duplicate New-FindingError definition in modules/shared/Schema.ps1 that shadowed the canonical sanitizing version in Errors.ps1, restoring Remove-Credentials enforcement on Reason and Remediation fields. (closes #671)
 
 ### Changed

--- a/modules/shared/Invoke-PRReviewGate.ps1
+++ b/modules/shared/Invoke-PRReviewGate.ps1
@@ -148,7 +148,7 @@ function Get-PRReviewFeedback {
     $lineCommentsRaw = Invoke-GhApiPaged -Endpoint "$basePath/comments"
 
     $reviews = foreach ($review in $reviewsRaw) {
-        $reviewer = if ($review.user -and $review.user.login) { [string]$review.user.login } else { 'unknown-reviewer' }
+        $reviewer = if ($review.PSObject.Properties['user'] -and $review.user -and $review.user.PSObject.Properties['login'] -and $review.user.login) { [string]$review.user.login } else { 'unknown-reviewer' }
         [PSCustomObject]@{
             Id          = [string]$review.id
             Reviewer    = $reviewer
@@ -160,7 +160,7 @@ function Get-PRReviewFeedback {
     }
 
     $lineComments = foreach ($comment in $lineCommentsRaw) {
-        $reviewer = if ($comment.user -and $comment.user.login) { [string]$comment.user.login } else { 'unknown-reviewer' }
+        $reviewer = if ($comment.PSObject.Properties['user'] -and $comment.user -and $comment.user.PSObject.Properties['login'] -and $comment.user.login) { [string]$comment.user.login } else { 'unknown-reviewer' }
         $inReplyToId = $null
         if ($comment.PSObject.Properties['in_reply_to_id']) {
             $inReplyToId = [string]$comment.in_reply_to_id

--- a/tests/shared/Invoke-PRReviewGate.Tests.ps1
+++ b/tests/shared/Invoke-PRReviewGate.Tests.ps1
@@ -210,4 +210,38 @@ Describe 'Invoke-PRReviewGate shared helper' {
             $consensus.ReviewerVerdict | Should -Be 'COMMENTED'
         }
     }
+
+    Context 'Get-PullRequestFeedback tolerates sparse .user payloads (regression #584)' {
+        BeforeEach {
+            function global:gh {
+                param([Parameter(ValueFromRemainingArguments = $true)] $Arguments)
+                $joined = [string]($Arguments -join ' ')
+                if ($joined -match '/pulls/584/reviews') {
+                    return '[[
+                        { "id": 9001, "state": "COMMENTED", "body": "ghost review", "submitted_at": "2026-04-23T03:00:00Z", "commit_id": "deadbeef" },
+                        { "id": 9002, "state": "APPROVED", "body": "null user", "submitted_at": "2026-04-23T03:01:00Z", "commit_id": "cafe", "user": null }
+                    ]]'
+                }
+                if ($joined -match '/pulls/584/comments') {
+                    return '[[
+                        { "id": 9101, "body": "no user property", "path": "x.ps1", "line": 1, "side": "RIGHT", "created_at": "2026-04-23T03:02:00Z" },
+                        { "id": 9102, "body": "user is null", "path": "y.ps1", "line": 2, "side": "RIGHT", "created_at": "2026-04-23T03:03:00Z", "user": null }
+                    ]]'
+                }
+                throw "Unexpected gh call: $joined"
+            }
+            . $script:ModulePath
+        }
+
+        It 'does not throw under StrictMode and falls back to unknown-reviewer' {
+            { Get-PRReviewFeedback -Repo 'martinopedal/azure-analyzer' -PRNumber 584 } | Should -Not -Throw
+            $feedback = Get-PRReviewFeedback -Repo 'martinopedal/azure-analyzer' -PRNumber 584
+            $feedback.Reviews.Count | Should -Be 2
+            $feedback.Reviews[0].Reviewer | Should -Be 'unknown-reviewer'
+            $feedback.Reviews[1].Reviewer | Should -Be 'unknown-reviewer'
+            $feedback.LineComments.Count | Should -Be 2
+            $feedback.LineComments[0].Reviewer | Should -Be 'unknown-reviewer'
+            $feedback.LineComments[1].Reviewer | Should -Be 'unknown-reviewer'
+        }
+    }
 }


### PR DESCRIPTION
## Root cause
`Set-StrictMode -Version Latest` throws on the property-access expression in `modules/shared/Invoke-PRReviewGate.ps1:151` (`.user`) and `:163` (`.user`) when the GitHub REST payload omits `user` (ghost / deleted user or sparse bot comment). The `-and` short-circuit does not help because StrictMode raises **before** logical evaluation.

Trio root-cause from Atlas-CI-Audit (unanimous):
- `claude-opus-4.6`
- `gpt-5.3-codex`
- `gpt-5.4`

Per `convention-triple-failure-rule-2026-04-23` (>=3 same-cause CI failures -> mandatory multi-model trio root-cause). 11 failures observed across 2 PR branches over the last 48h.

## Fix
Guard `.user` and `.user` with the `.PSObject.Properties['user']` presence-check pattern that the same file already uses on lines 165 and 170 for `in_reply_to_id` / `pull_request_review_id`. Default reviewer falls back to `'unknown-reviewer'`.

## Test
- New regression `Context` in `tests/shared/Invoke-PRReviewGate.Tests.ps1` mocks sparse payloads (missing `user` property + `user: null`) and asserts `Should -Not -Throw` plus `Reviewer = 'unknown-reviewer'` for both reviews and line comments.
- Targeted Pester: **12/12 green** under `Set-StrictMode -Version Latest`.

## Evidence
- Issue: #584
- Audit synthesis: `.squad/decisions/inbox/atlas-ci-48h-fix-plan.md` (Cluster E)
- Verdicts: `cluster-E-opus.md`, `cluster-E-codex.md`, `cluster-E-gpt54.md`, `cluster-E-synthesis.md` under `.copilot/audits/atlas-48h/`

## Docs
- `CHANGELOG.md` -> `[1.2.0 - Unreleased]` / `Fixed`: entry added at top of section.

Closes #584.