### PR TITLE
fix(ci): hardening sweep #586 #587 #588

### DIFF
--- a/.github/workflows/ci-failure-watchdog.yml
+++ b/.github/workflows/ci-failure-watchdog.yml
@@ -109,21 +109,21 @@ jobs:
           # Detect GitHub API rate-limit errors (HTTP 403). If the watchdog
           # reporter itself is rate-limited, abort triage to prevent
           # false-positive ci-failure issues (see #548-583, root-cause tracked separately).
-          if printf '%s' "$failed_log_raw" | grep -q 'HTTP 403|rate limit exceeded'; then
+          if grep -q 'HTTP 403|rate limit exceeded' <<<"$failed_log_raw"; then
             echo "GitHub API rate-limit detected (HTTP 403) -- suppressing false-positive ci-failure issue."
             echo "Root-cause fix for reporter rate-limiting is tracked separately."
             exit 0
           fi
           
-          failed_log_head="$(printf '%s\n' "$failed_log_raw" | head -n 500)"
+          failed_log_head="$(head -n 500 <<<"$failed_log_raw")"
 
           # Prefer explicit Actions annotations first, then broader fallback patterns.
-          first_error_line="$(printf '%s\n' "$failed_log_head" | grep -Eim1 '##\[error\]|::error::' || true)"
+          first_error_line="$(grep -Eim1 '##\[error\]|::error::' <<<"$failed_log_head" || true)"
           if [ -z "${first_error_line}" ]; then
-            first_error_line="$(printf '%s\n' "$failed_log_head" | grep -Eim1 '(^|[^[:alpha:]])(error|failed|fatal)(:|[[:space:]])' || true)"
+            first_error_line="$(grep -Eim1 '(^|[^[:alpha:]])(error|failed|fatal)(:|[[:space:]])' <<<"$failed_log_head" || true)"
           fi
           if [ -z "${first_error_line}" ]; then
-            first_error_line="$(printf '%s\n' "$failed_log_head" | grep -Eim1 '(Exception|Traceback|exit code [1-9]|exited with code)' || true)"
+            first_error_line="$(grep -Eim1 '(Exception|Traceback|exit code [1-9]|exited with code)' <<<"$failed_log_head" || true)"
           fi
           if [ -z "${first_error_line}" ]; then
             first_error_line="No explicit error line found in failed log output."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Fixed
 - fix(runtime): add -Help switch to Invoke-AzureAnalyzer (#545, reported by external user)
+- Silence Frameworks property warning noise in FrameworkMapper.ps1 Get-FrameworkCoverage by adding PSObject.Properties presence check before dereferencing $f.Frameworks (line 257). Prevents warning on every run for findings lacking the property. Closes #586.
+- Harden watchdog printf|head pipes against SIGPIPE by replacing `printf '%s\n' "$var" | head -n N` patterns with here-string redirects `head -n 500 <<<"$var"` and `grep -Eim1 <<<"$var"` in .github/workflows/ci-failure-watchdog.yml (lines 112, 118, 121, 123, 126). Eliminates SIGPIPE propagation under set -euo pipefail when head closes stdin early. Follow-up to #526. Closes #587.
+- Replace exit 1 with throw in modules/shared/Resolve-PRReviewThreads.ps1 (line 545) so workflow try/catch can catch FORBIDDEN errors from GitHub GraphQL resolveReviewThread bot-vs-bot limit and convert to warning annotation rather than error. Makes #487 non-fatal path fully reachable. Closes #588.
 - Guard sparse `.user` payloads in `modules/shared/Invoke-PRReviewGate.ps1` (lines 151, 163) so PR Review Gate no longer crashes under StrictMode when GitHub REST returns a review or line-comment object without a `user` property (ghost/deleted user or sparse bot comment). `-and` short-circuit was insufficient because StrictMode raises before logical evaluation; switched to `PSObject.Properties['user']` presence checks matching the existing pattern at lines 165/170. Added regression test in `tests/shared/Invoke-PRReviewGate.Tests.ps1` (sparse-user Context, 12/12 green). Closes #584.
 - Remove duplicate New-FindingError definition in modules/shared/Schema.ps1 that shadowed the canonical sanitizing version in Errors.ps1, restoring Remove-Credentials enforcement on Reason and Remediation fields. (closes #671)
 

--- a/modules/shared/FrameworkMapper.ps1
+++ b/modules/shared/FrameworkMapper.ps1
@@ -254,6 +254,7 @@ function Get-FrameworkCoverage {
     # Count controls actually touched by current findings.
     $touched = @{}
     foreach ($f in $Findings) {
+        if (-not $f.PSObject.Properties['Frameworks']) { continue }
         if (-not $f.Frameworks) { continue }
         foreach ($block in $f.Frameworks) {
             if (-not $touched.ContainsKey($block.framework)) { $touched[$block.framework] = @{} }

--- a/modules/shared/Resolve-PRReviewThreads.ps1
+++ b/modules/shared/Resolve-PRReviewThreads.ps1
@@ -542,5 +542,5 @@ if ($MyInvocation.InvocationName -ne '.') {
     }
     $result = Invoke-AutoResolveThreads -PRNumber $PRNumber -Repo $Repo -DryRun:$DryRun
     $result | ConvertTo-Json -Depth 5
-    if ($result.Status -eq 'Failed') { exit 1 }
+    if ($result.Status -eq 'Failed') { throw $result.ErrorMessage }
 }


### PR DESCRIPTION
Closes #586
Closes #587
Closes #588

## Summary

CI hardening sweep addressing 3 remaining Atlas 48h audit issues (#586, #587, #588). Issue #585 was already fixed by merged PR #589 and has been closed with reference.

## Changes

### #586 - FrameworkMapper.ps1
Added property existence check before dereferencing `$f.Frameworks` in Get-FrameworkCoverage (line 257):
- Guard: `if (-not $f.PSObject.Properties[''Frameworks'']) { continue }`
- Prevents warning on every CI run for findings lacking the property

### #587 - ci-failure-watchdog.yml  
Replaced `printf | head` patterns with here-string redirects (lines 112, 118, 121, 123, 126):
- Before: `printf ''%s\n'' "$var" | head -n 500`
- After: `head -n 500 <<<"$var"`
- Eliminates SIGPIPE under set -euo pipefail when head closes stdin early
- Follow-up to #526 sanitize_text fix

### #588 - Resolve-PRReviewThreads.ps1
Replaced `exit 1` with `throw` (line 545):
- Changed: `if ($result.Status -eq ''Failed'') { throw $result.ErrorMessage }`
- Makes workflow try/catch reachable for FORBIDDEN errors
- Completes #487 non-fatal path implementation

## CHANGELOG

3 entries added to `[1.2.0 - Unreleased]` Fixed section.
