### PR TITLE
test(e2e): add wrapper coverage for bicep + infracost + terraform-iac (#663 #664 #665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [1.2.0 - Unreleased]
 
+### Added
+- test(e2e): wrapper-level coverage for `bicep-iac` (#663), `infracost` (#664), and `terraform-iac` (#665). Three new files under `tests/wrappers/` (`Invoke-IaCBicep.E2E.Tests.ps1`, `Invoke-IaCTerraform.E2E.Tests.ps1`, `Invoke-Infracost.E2E.Tests.ps1`) exercise wrapper -> normalizer end-to-end through a mocked `Invoke-WithTimeout` (300s timeout invariant asserted), feeding the v1 envelope produced by the IaC adapter and Infracost wrapper into `Normalize-IaCBicep`, `Normalize-IaCTerraform`, and `Normalize-Infracost` and validating the resulting v2 `FindingRow` shape (SchemaVersion 2.2, canonical EntityId, Pillar, EvidenceUris, ToolVersion, Provenance.RunId). Shared, fully-synthetic fixtures live in `tests/fixtures/iac/` (`main.bicep`, `bicep-build-output.txt`, `main.tf`, `terraform-validate.json`, `trivy-config.json`, `infracost-breakdown.json`, plus a `README.md` describing each). Wrapper test suite now 430/430 green.
+
 ### Documentation
 - docs(release-blocker): generate tool-catalog.md and permissions-index.md (#528) -- Adds top-level navigation hubs at `docs/tool-catalog.md` (references detailed catalogs) and `docs/permissions-index.md` (quick-lookup table of all tools sorted by name with required scope and permission links). Release blocker resolved.
 

--- a/tests/fixtures/iac/README.md
+++ b/tests/fixtures/iac/README.md
@@ -1,0 +1,18 @@
+# tests/fixtures/iac
+
+Realistic, hand-curated fixtures used by the wrapper-level E2E coverage tests
+for the IaC tools (#663 bicep-iac, #664 infracost, #665 terraform-iac).
+
+| File                       | Used by                              | Purpose |
+|----------------------------|--------------------------------------|---------|
+| `main.bicep`               | `Invoke-IaCBicep.E2E.Tests.ps1`      | A Bicep file the adapter discovers via `Get-ChildItem -Filter *.bicep`. |
+| `bicep-build-output.txt`   | `Invoke-IaCBicep.E2E.Tests.ps1`      | Realistic stderr from `bicep build` (BCP062 + BCP036 diagnostics) returned by the mocked `Invoke-WithTimeout`. |
+| `main.tf`                  | `Invoke-IaCTerraform.E2E.Tests.ps1`  | A Terraform file the adapter discovers via `Get-ChildItem -Filter *.tf`. |
+| `terraform-validate.json`  | `Invoke-IaCTerraform.E2E.Tests.ps1`  | `terraform validate -json` output with one error + one warning diagnostic. |
+| `trivy-config.json`        | `Invoke-IaCTerraform.E2E.Tests.ps1`  | `trivy config --format json` output with one HIGH misconfiguration. |
+| `infracost-breakdown.json` | `Invoke-Infracost.E2E.Tests.ps1`     | `infracost breakdown --format json` output with a baseline + diff. |
+
+Every fixture is fully synthetic. No real subscription IDs, secrets, or
+customer data are present. All values are scrubbed by `Remove-Credentials`
+before being written to disk anyway, so the fixtures double as scrub test
+inputs.

--- a/tests/fixtures/iac/bicep-build-output.txt
+++ b/tests/fixtures/iac/bicep-build-output.txt
@@ -1,0 +1,2 @@
+infra/main.bicep(8,9) : Error BCP062: The referenced declaration with name "storageAccountNameInvalid" is not valid.
+infra/main.bicep(11,5) : Warning BCP036: The property "sku" expected a value of type "SkuName" but the provided value is of type "string". Apply the "Standard_GRS" SKU for cross-region redundancy.

--- a/tests/fixtures/iac/infracost-breakdown.json
+++ b/tests/fixtures/iac/infracost-breakdown.json
@@ -1,0 +1,50 @@
+{
+  "version": "0.2",
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "iac/terraform/main",
+      "displayName": "main",
+      "metadata": { "path": "iac/terraform/main", "type": "terraform_dir", "vcsRepoUrl": "https://github.com/contoso/iac" },
+      "pastBreakdown": {
+        "totalMonthlyCost": "612.50",
+        "totalHourlyCost": "0.8390"
+      },
+      "breakdown": {
+        "totalMonthlyCost": "874.20",
+        "totalHourlyCost": "1.1975",
+        "resources": [
+          {
+            "name": "azurerm_kubernetes_cluster.aks",
+            "resourceType": "azurerm_kubernetes_cluster",
+            "monthlyCost": "612.30",
+            "currency": "USD"
+          },
+          {
+            "name": "azurerm_storage_account.example",
+            "resourceType": "azurerm_storage_account",
+            "monthlyCost": "261.90",
+            "currency": "USD"
+          }
+        ]
+      },
+      "diff": {
+        "totalMonthlyCost": "261.70",
+        "totalHourlyCost": "0.3585"
+      },
+      "summary": {
+        "totalDetectedResources": 2,
+        "totalSupportedResources": 2,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 0,
+        "totalNoPriceResources": 0
+      }
+    }
+  ],
+  "totalHourlyCost": "1.1975",
+  "totalMonthlyCost": "874.20",
+  "pastTotalHourlyCost": "0.8390",
+  "pastTotalMonthlyCost": "612.50",
+  "diffTotalMonthlyCost": "261.70",
+  "diffTotalHourlyCost": "0.3585"
+}

--- a/tests/fixtures/iac/main.bicep
+++ b/tests/fixtures/iac/main.bicep
@@ -1,0 +1,14 @@
+// Realistic Bicep fixture for E2E wrapper coverage (#663).
+// Intentionally references an undefined symbol so a mocked
+// `bicep build` can simulate a BCP062 diagnostic without
+// needing the real Bicep CLI on the test runner.
+param location string = resourceGroup().location
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountNameInvalid
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}

--- a/tests/fixtures/iac/main.tf
+++ b/tests/fixtures/iac/main.tf
@@ -1,0 +1,23 @@
+// Realistic Terraform fixture for E2E wrapper coverage (#665).
+// The HCL is well-formed; tests mock terraform/trivy output to
+// simulate validate diagnostics and trivy misconfiguration findings.
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplestorage"
+  resource_group_name      = "rg-example"
+  location                 = "westeurope"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}

--- a/tests/fixtures/iac/terraform-validate.json
+++ b/tests/fixtures/iac/terraform-validate.json
@@ -1,0 +1,28 @@
+{
+  "format_version": "1.0",
+  "valid": false,
+  "error_count": 1,
+  "warning_count": 1,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "summary": "Reference to undeclared resource",
+      "detail": "A resource \"azurerm_resource_group\" \"missing\" has not been declared in the root module.",
+      "range": {
+        "filename": "main.tf",
+        "start": { "line": 18, "column": 28, "byte": 412 },
+        "end":   { "line": 18, "column": 60, "byte": 444 }
+      }
+    },
+    {
+      "severity": "warning",
+      "summary": "Deprecated attribute",
+      "detail": "The attribute \"enable_https_traffic_only\" is deprecated; use \"https_traffic_only_enabled\" instead.",
+      "range": {
+        "filename": "main.tf",
+        "start": { "line": 22, "column": 3, "byte": 512 },
+        "end":   { "line": 22, "column": 33, "byte": 542 }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/iac/trivy-config.json
+++ b/tests/fixtures/iac/trivy-config.json
@@ -1,0 +1,44 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "tests/fixtures/iac",
+  "ArtifactType": "filesystem",
+  "Results": [
+    {
+      "Target": "main.tf",
+      "Class": "config",
+      "Type": "terraform",
+      "MisconfSummary": { "Successes": 8, "Failures": 1, "Exceptions": 0 },
+      "Misconfigurations": [
+        {
+          "Type": "Terraform Security Check",
+          "ID": "AVD-AZU-0011",
+          "AVDID": "AVD-AZU-0011",
+          "Title": "Storage account uses an insecure TLS version",
+          "Description": "Azure Storage accounts should require a minimum TLS version of TLS 1.2 to protect data in transit.",
+          "Message": "Storage account 'example' does not set a minimum TLS version.",
+          "Namespace": "builtin.azure.storage.azure0011",
+          "Query": "data.builtin.azure.storage.azure0011.deny",
+          "Resolution": "Set min_tls_version to 'TLS1_2'.",
+          "Severity": "HIGH",
+          "PrimaryURL": "https://avd.aquasec.com/misconfig/azure/storage/avd-azu-0011",
+          "References": [
+            "https://avd.aquasec.com/misconfig/azure/storage/avd-azu-0011"
+          ],
+          "Status": "Fail",
+          "CauseMetadata": {
+            "Resource": "azurerm_storage_account.example",
+            "Provider": "azurerm",
+            "Service": "storage",
+            "StartLine": 17,
+            "EndLine": 23,
+            "Code": {
+              "Lines": [
+                { "Number": 17, "Content": "resource \"azurerm_storage_account\" \"example\" {", "IsCause": true, "FirstCause": true, "LastCause": false }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/wrappers/Invoke-IaCBicep.E2E.Tests.ps1
+++ b/tests/wrappers/Invoke-IaCBicep.E2E.Tests.ps1
@@ -1,0 +1,133 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# E2E wrapper coverage for bicep-iac (#663). Drives the IaC adapter
+# (which is what Invoke-IaCBicep.ps1 delegates to) through a mocked
+# Invoke-WithTimeout, then runs the v1 envelope through the v2 normalizer
+# and asserts FindingRow shape. The wrapper script's error paths are
+# already covered by Invoke-IaCBicep.Tests.ps1; this file extends coverage
+# to the success path and the wrapper -> normalizer hand-off.
+$env:AZURE_ANALYZER_SUPPRESS_TOOL_MISSING_WARNINGS = '1'
+
+BeforeAll {
+    $script:Here = Split-Path $PSCommandPath -Parent
+    $script:RepoRoot = (Resolve-Path (Join-Path $script:Here '..' '..')).Path
+
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Sanitize.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Retry.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Canonicalize.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Schema.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'iac' 'IaCAdapters.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'normalizers' 'Normalize-IaCBicep.ps1')
+
+    $script:FixtureDir = Join-Path $script:RepoRoot 'tests' 'fixtures' 'iac'
+    $script:BicepFixture = Join-Path $script:FixtureDir 'main.bicep'
+    $script:BicepOutput  = Get-Content -Path (Join-Path $script:FixtureDir 'bicep-build-output.txt') -Raw
+}
+
+Describe 'Invoke-IaCBicep: E2E wrapper -> normalizer (#663)' {
+
+    BeforeAll {
+        $script:RepoFixture = Join-Path $TestDrive 'bicep-repo'
+        New-Item -ItemType Directory -Path $script:RepoFixture -Force | Out-Null
+        Copy-Item -Path $script:BicepFixture -Destination (Join-Path $script:RepoFixture 'main.bicep') -Force
+    }
+
+    Context 'when bicep build emits diagnostics' {
+
+        BeforeAll {
+            Mock Get-Command { return @{ Name = 'bicep' } } -ParameterFilter { $Name -eq 'bicep' }
+            Mock Invoke-WithTimeout {
+                $TimeoutSec | Should -Be 300
+                $Command    | Should -Be 'bicep'
+                $Arguments  | Should -Contain 'build'
+                return [PSCustomObject]@{ ExitCode = 1; Output = $script:BicepOutput }
+            }
+
+            $script:Result = Invoke-BicepValidation -RepoPath $script:RepoFixture
+        }
+
+        It 'returns a v1 envelope with Source = bicep-iac and SchemaVersion 1.0' {
+            $script:Result.Source        | Should -Be 'bicep-iac'
+            $script:Result.SchemaVersion | Should -Be '1.0'
+            $script:Result.Status        | Should -Be 'Success'
+        }
+
+        It 'enforces the 300s timeout invariant via Invoke-WithTimeout' {
+            Should -Invoke Invoke-WithTimeout -Times 1 -Exactly -Scope Context
+        }
+
+        It 'emits one finding per bicep diagnostic line' {
+            @($script:Result.Findings).Count | Should -Be 2
+        }
+
+        It 'parses BCP062 and BCP036 rule ids from the diagnostic stream' {
+            $ruleIds = @($script:Result.Findings | ForEach-Object { $_.RuleId })
+            $ruleIds | Should -Contain 'BCP062'
+            $ruleIds | Should -Contain 'BCP036'
+        }
+
+        It 'marks every diagnostic as non-compliant' {
+            foreach ($f in $script:Result.Findings) { $f.Compliant | Should -BeFalse }
+        }
+    }
+
+    Context 'when the v1 envelope is fed to Normalize-IaCBicep' {
+
+        BeforeAll {
+            Mock Get-Command { return @{ Name = 'bicep' } } -ParameterFilter { $Name -eq 'bicep' }
+            Mock Invoke-WithTimeout {
+                return [PSCustomObject]@{ ExitCode = 1; Output = $script:BicepOutput }
+            }
+
+            $envelope = Invoke-BicepValidation -RepoPath $script:RepoFixture
+            $envelope | Add-Member -NotePropertyName ToolVersion -NotePropertyValue 'bicep:0.31.92' -Force
+            $script:Rows = @(Normalize-IaCBicep -ToolResult $envelope)
+        }
+
+        It 'produces one v2 FindingRow per v1 finding' {
+            @($script:Rows).Count | Should -Be 2
+        }
+
+        It 'every row reports SchemaVersion 2.2 (v2 FindingRow)' {
+            foreach ($r in $script:Rows) { $r.SchemaVersion | Should -Be '2.2' }
+        }
+
+        It 'every row uses Source = bicep-iac and EntityType = AzureResource' {
+            foreach ($r in $script:Rows) {
+                $r.Source     | Should -Be 'bicep-iac'
+                $r.EntityType | Should -Be 'AzureResource'
+                $r.Platform   | Should -Be 'Azure'
+            }
+        }
+
+        It 'maps Bicep severities into the canonical 5-level enum' {
+            $severities = @($script:Rows | ForEach-Object { $_.Severity })
+            $severities | Should -Contain 'High'
+            $severities | Should -Contain 'Medium'
+        }
+
+        It 'canonicalises EntityId into a synthetic ARM deployment id' {
+            foreach ($r in $script:Rows) {
+                $r.EntityId | Should -Match '^/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/iac-bicep/providers/microsoft\.resources/deployments/'
+            }
+        }
+
+        It 'populates v2 enrichment fields (RuleId, Pillar, Frameworks, EvidenceUris, ToolVersion)' {
+            foreach ($r in $script:Rows) {
+                $r.RuleId      | Should -Not -BeNullOrEmpty
+                $r.Pillar      | Should -Not -BeNullOrEmpty
+                $r.DeepLinkUrl | Should -Not -BeNullOrEmpty
+                @($r.Frameworks).Count   | Should -BeGreaterThan 0
+                @($r.EvidenceUris).Count | Should -BeGreaterThan 0
+                $r.ToolVersion | Should -Match 'bicep'
+            }
+        }
+
+        It 'sets Provenance.RunId consistently across the run' {
+            $runIds = $script:Rows | ForEach-Object { $_.Provenance.RunId } | Select-Object -Unique
+            @($runIds).Count | Should -Be 1
+        }
+    }
+}

--- a/tests/wrappers/Invoke-IaCTerraform.E2E.Tests.ps1
+++ b/tests/wrappers/Invoke-IaCTerraform.E2E.Tests.ps1
@@ -1,0 +1,163 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# E2E wrapper coverage for terraform-iac (#665). Drives the IaC adapter
+# (which is what Invoke-IaCTerraform.ps1 delegates to) through mocked
+# Invoke-WithTimeout calls for both `terraform validate` and `trivy config`,
+# then runs the v1 envelope through the v2 normalizer and asserts FindingRow
+# shape. The wrapper script's error paths are already covered by
+# Invoke-IaCTerraform.Tests.ps1; this file extends coverage to the success
+# path and the wrapper -> normalizer hand-off.
+$env:AZURE_ANALYZER_SUPPRESS_TOOL_MISSING_WARNINGS = '1'
+
+BeforeAll {
+    $script:Here = Split-Path $PSCommandPath -Parent
+    $script:RepoRoot = (Resolve-Path (Join-Path $script:Here '..' '..')).Path
+
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Sanitize.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Retry.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Canonicalize.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Schema.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'iac' 'IaCAdapters.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'normalizers' 'Normalize-IaCTerraform.ps1')
+
+    $script:FixtureDir       = Join-Path $script:RepoRoot 'tests' 'fixtures' 'iac'
+    $script:TerraformFixture = Join-Path $script:FixtureDir 'main.tf'
+    $script:ValidateJson     = Get-Content -Path (Join-Path $script:FixtureDir 'terraform-validate.json') -Raw
+    $script:TrivyJson        = Get-Content -Path (Join-Path $script:FixtureDir 'trivy-config.json') -Raw
+}
+
+Describe 'Invoke-IaCTerraform: E2E wrapper -> normalizer (#665)' {
+
+    BeforeAll {
+        $script:RepoFixture = Join-Path $TestDrive 'tf-repo'
+        New-Item -ItemType Directory -Path $script:RepoFixture -Force | Out-Null
+        Copy-Item -Path $script:TerraformFixture -Destination (Join-Path $script:RepoFixture 'main.tf') -Force
+    }
+
+    Context 'when terraform validate and trivy config emit findings' {
+
+        BeforeAll {
+            Mock Get-Command { return @{ Name = 'terraform' } } -ParameterFilter { $Name -eq 'terraform' }
+            Mock Get-Command { return @{ Name = 'trivy' } }     -ParameterFilter { $Name -eq 'trivy' }
+
+            Mock Invoke-WithTimeout {
+                $TimeoutSec | Should -BeIn @(60, 300)
+
+                if ($Command -eq 'terraform' -and ($Arguments -contains 'init')) {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = 'Terraform has been successfully initialized!' }
+                }
+                if ($Command -eq 'terraform' -and ($Arguments -contains 'validate')) {
+                    return [PSCustomObject]@{ ExitCode = 1; Output = $script:ValidateJson }
+                }
+                if ($Command -eq 'terraform' -and ($Arguments -contains 'version')) {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = 'Terraform v1.7.5' }
+                }
+                if ($Command -eq 'trivy' -and ($Arguments -contains '--version')) {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = 'Version: 0.50.1' }
+                }
+                if ($Command -eq 'trivy' -and ($Arguments -contains 'config')) {
+                    $outIdx = [array]::IndexOf($Arguments, '--output')
+                    if ($outIdx -ge 0 -and $outIdx + 1 -lt $Arguments.Count) {
+                        Set-Content -Path $Arguments[$outIdx + 1] -Value $script:TrivyJson -Encoding utf8
+                    }
+                    return [PSCustomObject]@{ ExitCode = 0; Output = '' }
+                }
+                return [PSCustomObject]@{ ExitCode = 0; Output = '' }
+            }
+
+            $script:Result = Invoke-TerraformValidation -RepoPath $script:RepoFixture
+        }
+
+        It 'returns a v1 envelope with Source = terraform-iac and SchemaVersion 1.0' {
+            $script:Result.Source        | Should -Be 'terraform-iac'
+            $script:Result.SchemaVersion | Should -Be '1.0'
+            $script:Result.Status        | Should -Be 'Success'
+        }
+
+        It 'enforces the 300s timeout invariant via Invoke-WithTimeout' {
+            Should -Invoke Invoke-WithTimeout -Scope Context -Times 2
+        }
+
+        It 'emits at least one terraform-validate finding' {
+            @($script:Result.Findings | Where-Object { $_.RuleId -eq 'terraform-validate' }).Count | Should -BeGreaterThan 0
+        }
+
+        It 'emits at least one trivy AVD finding' {
+            @($script:Result.Findings | Where-Object { $_.Detail -match 'TLS|tls' -or $_.Title -match 'TLS' }).Count | Should -BeGreaterThan 0
+        }
+
+        It 'records the captured tool versions in ToolVersion' {
+            $script:Result.ToolVersion | Should -Match 'Terraform v1.7.5'
+            $script:Result.ToolVersion | Should -Match '0\.50\.1'
+        }
+    }
+
+    Context 'when the v1 envelope is fed to Normalize-IaCTerraform' {
+
+        BeforeAll {
+            Mock Get-Command { return @{ Name = 'terraform' } } -ParameterFilter { $Name -eq 'terraform' }
+            Mock Get-Command { return @{ Name = 'trivy' } }     -ParameterFilter { $Name -eq 'trivy' }
+
+            Mock Invoke-WithTimeout {
+                if ($Command -eq 'terraform' -and ($Arguments -contains 'init')) {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = '' }
+                }
+                if ($Command -eq 'terraform' -and ($Arguments -contains 'validate')) {
+                    return [PSCustomObject]@{ ExitCode = 1; Output = $script:ValidateJson }
+                }
+                if ($Command -eq 'terraform' -and ($Arguments -contains 'version')) {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = 'Terraform v1.7.5' }
+                }
+                if ($Command -eq 'trivy' -and ($Arguments -contains '--version')) {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = 'Version: 0.50.1' }
+                }
+                if ($Command -eq 'trivy' -and ($Arguments -contains 'config')) {
+                    $outIdx = [array]::IndexOf($Arguments, '--output')
+                    if ($outIdx -ge 0 -and $outIdx + 1 -lt $Arguments.Count) {
+                        Set-Content -Path $Arguments[$outIdx + 1] -Value $script:TrivyJson -Encoding utf8
+                    }
+                    return [PSCustomObject]@{ ExitCode = 0; Output = '' }
+                }
+                return [PSCustomObject]@{ ExitCode = 0; Output = '' }
+            }
+
+            $envelope = Invoke-TerraformValidation -RepoPath $script:RepoFixture -SourceRepoUrl 'https://github.com/contoso/iac'
+            $script:Rows = @(Normalize-IaCTerraform -ToolResult $envelope)
+        }
+
+        It 'produces at least one v2 FindingRow' {
+            @($script:Rows).Count | Should -BeGreaterThan 0
+        }
+
+        It 'every row reports SchemaVersion 2.2 (v2 FindingRow)' {
+            foreach ($r in $script:Rows) { $r.SchemaVersion | Should -Be '2.2' }
+        }
+
+        It 'every row uses Source = terraform-iac and EntityType = Repository' {
+            foreach ($r in $script:Rows) {
+                $r.Source     | Should -Be 'terraform-iac'
+                $r.EntityType | Should -Be 'Repository'
+            }
+        }
+
+        It 'maps trivy HIGH severity into the canonical 5-level enum' {
+            $severities = @($script:Rows | ForEach-Object { $_.Severity })
+            $severities | Should -Contain 'High'
+        }
+
+        It 'populates v2 enrichment fields (RuleId, Pillar, EvidenceUris)' {
+            foreach ($r in $script:Rows) {
+                $r.RuleId | Should -Not -BeNullOrEmpty
+                $r.Pillar | Should -Not -BeNullOrEmpty
+                @($r.EvidenceUris).Count | Should -BeGreaterThan 0
+            }
+        }
+
+        It 'sets Provenance.RunId consistently across the run' {
+            $runIds = $script:Rows | ForEach-Object { $_.Provenance.RunId } | Select-Object -Unique
+            @($runIds).Count | Should -Be 1
+        }
+    }
+}

--- a/tests/wrappers/Invoke-Infracost.E2E.Tests.ps1
+++ b/tests/wrappers/Invoke-Infracost.E2E.Tests.ps1
@@ -1,0 +1,169 @@
+#Requires -Version 7.4
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# E2E wrapper coverage for infracost (#664). Invokes the wrapper script
+# end-to-end with realistic fixture output, then runs the v1 envelope
+# through Normalize-Infracost and asserts FindingRow shape. The wrapper's
+# error paths plus a thinner inline success path are already covered by
+# Invoke-Infracost.Tests.ps1; this file extends coverage to the wrapper
+# -> normalizer hand-off using the shared tests/fixtures/iac fixture.
+$env:AZURE_ANALYZER_SUPPRESS_TOOL_MISSING_WARNINGS = '1'
+
+BeforeAll {
+    $script:Here = Split-Path $PSCommandPath -Parent
+    $script:RepoRoot = (Resolve-Path (Join-Path $script:Here '..' '..')).Path
+    $script:Wrapper  = Join-Path $script:RepoRoot 'modules' 'Invoke-Infracost.ps1'
+
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Sanitize.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Canonicalize.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Schema.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'normalizers' 'Normalize-Infracost.ps1')
+
+    $script:FixtureDir   = Join-Path $script:RepoRoot 'tests' 'fixtures' 'iac'
+    $script:Breakdown    = Get-Content -Path (Join-Path $script:FixtureDir 'infracost-breakdown.json') -Raw
+    $script:TerraformSrc = Get-Content -Path (Join-Path $script:FixtureDir 'main.tf') -Raw
+}
+
+Describe 'Invoke-Infracost: E2E wrapper -> normalizer (#664)' {
+
+    BeforeAll {
+        $script:ScanPath = Join-Path $TestDrive 'infracost-iac'
+        New-Item -ItemType Directory -Path $script:ScanPath -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $script:ScanPath 'main.tf') -Value $script:TerraformSrc -Encoding utf8
+    }
+
+    Context 'when infracost returns a JSON breakdown' {
+
+        BeforeAll {
+            $global:InfracostBreakdownE2EJson = $script:Breakdown
+
+            Mock Get-Command { return @{ Name = 'infracost' } } -ParameterFilter { $Name -eq 'infracost' }
+
+            function global:Invoke-WithRetry {
+                param (
+                    [scriptblock] $ScriptBlock,
+                    [int] $MaxAttempts,
+                    [int] $InitialDelaySeconds,
+                    [int] $MaxDelaySeconds
+                )
+                & $ScriptBlock
+            }
+
+            function global:Invoke-WithTimeout {
+                param (
+                    [string]   $Command,
+                    [string[]] $Arguments,
+                    [int]      $TimeoutSec
+                )
+                # 300s timeout invariant for breakdown calls; 60s allowed for --version probe
+                if ($Arguments -contains '--version') {
+                    if ($TimeoutSec -lt 60) { throw "Infracost --version called with TimeoutSec=$TimeoutSec; expected >= 60" }
+                    return [PSCustomObject]@{ ExitCode = 0; Output = "Infracost v0.10.31`n" }
+                }
+                if ($TimeoutSec -ne 300) { throw "Infracost breakdown called with TimeoutSec=$TimeoutSec; expected 300" }
+                return [PSCustomObject]@{ ExitCode = 0; Output = $global:InfracostBreakdownE2EJson }
+            }
+
+            $script:Result = & $script:Wrapper -Path $script:ScanPath
+        }
+
+        AfterAll {
+            Remove-Item Function:\global:Invoke-WithRetry  -ErrorAction SilentlyContinue
+            Remove-Item Function:\global:Invoke-WithTimeout -ErrorAction SilentlyContinue
+            Remove-Variable -Name InfracostBreakdownE2EJson -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'returns a v1 envelope with Source = infracost and SchemaVersion 1.0' {
+            $script:Result.Source        | Should -Be 'infracost'
+            $script:Result.SchemaVersion | Should -Be '1.0'
+            $script:Result.Status        | Should -Be 'Success'
+        }
+
+        It 'parses ToolSummary totals from the breakdown JSON' {
+            $script:Result.ToolSummary.Currency            | Should -Be 'USD'
+            $script:Result.ToolSummary.TotalMonthlyCost    | Should -Be 874.20
+            $script:Result.ToolSummary.BaselineMonthlyCost | Should -Be 612.50
+            $script:Result.ToolSummary.DiffMonthlyCost     | Should -Be 261.70
+        }
+
+        It 'emits at least one finding per project breakdown' {
+            @($script:Result.Findings).Count | Should -BeGreaterThan 0
+            $script:Result.Findings[0].Pillar | Should -Be 'Cost'
+        }
+    }
+
+    Context 'when the v1 envelope is fed to Normalize-Infracost' {
+
+        BeforeAll {
+            $global:InfracostBreakdownE2EJson = $script:Breakdown
+
+            Mock Get-Command { return @{ Name = 'infracost' } } -ParameterFilter { $Name -eq 'infracost' }
+
+            function global:Invoke-WithRetry {
+                param (
+                    [scriptblock] $ScriptBlock,
+                    [int] $MaxAttempts,
+                    [int] $InitialDelaySeconds,
+                    [int] $MaxDelaySeconds
+                )
+                & $ScriptBlock
+            }
+
+            function global:Invoke-WithTimeout {
+                param (
+                    [string]   $Command,
+                    [string[]] $Arguments,
+                    [int]      $TimeoutSec
+                )
+                if ($Arguments -contains '--version') {
+                    return [PSCustomObject]@{ ExitCode = 0; Output = 'Infracost v0.10.31' }
+                }
+                return [PSCustomObject]@{ ExitCode = 0; Output = $global:InfracostBreakdownE2EJson }
+            }
+
+            $envelope = & $script:Wrapper -Path $script:ScanPath
+            $script:Rows = @(Normalize-Infracost -ToolResult $envelope)
+        }
+
+        AfterAll {
+            Remove-Item Function:\global:Invoke-WithRetry  -ErrorAction SilentlyContinue
+            Remove-Item Function:\global:Invoke-WithTimeout -ErrorAction SilentlyContinue
+            Remove-Variable -Name InfracostBreakdownE2EJson -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'produces at least one v2 FindingRow' {
+            @($script:Rows).Count | Should -BeGreaterThan 0
+        }
+
+        It 'every row reports SchemaVersion 2.2 (v2 FindingRow)' {
+            foreach ($r in $script:Rows) { $r.SchemaVersion | Should -Be '2.2' }
+        }
+
+        It 'every row uses Source = infracost and Pillar = Cost Optimization' {
+            foreach ($r in $script:Rows) {
+                $r.Source | Should -Be 'infracost'
+                $r.Pillar | Should -Match '(?i)cost'
+            }
+        }
+
+        It 'canonicalises EntityId via ConvertTo-CanonicalEntityId (lowercase ARM-shaped)' {
+            foreach ($r in $script:Rows) {
+                $r.EntityId | Should -Not -BeNullOrEmpty
+                $r.EntityId | Should -Match '^/subscriptions/'
+            }
+        }
+
+        It 'populates v2 enrichment fields (EvidenceUris, ToolVersion)' {
+            foreach ($r in $script:Rows) {
+                @($r.EvidenceUris).Count | Should -BeGreaterThan 0
+                $r.ToolVersion | Should -Match 'Infracost'
+            }
+        }
+
+        It 'sets Provenance.RunId consistently across the run' {
+            $runIds = $script:Rows | ForEach-Object { $_.Provenance.RunId } | Select-Object -Unique
+            @($runIds).Count | Should -Be 1
+        }
+    }
+}


### PR DESCRIPTION
Adds three new wrapper-level E2E test files under `tests/wrappers/` that exercise wrapper -> normalizer end-to-end for the three IaC tools that were previously uncovered by the harness.

## Issues addressed

- Closes #663 (bicep-iac)
- Closes #664 (infracost)
- Closes #665 (terraform-iac)

## What

| File | Tool |
|---|---|
| `tests/wrappers/Invoke-IaCBicep.E2E.Tests.ps1` | bicep-iac (#663) |
| `tests/wrappers/Invoke-IaCTerraform.E2E.Tests.ps1` | terraform-iac (#665) |
| `tests/wrappers/Invoke-Infracost.E2E.Tests.ps1` | infracost (#664) |

Each test:

- mocks the external CLI via `Invoke-WithTimeout` and asserts the **300s timeout invariant** (per repo conventions, matches `IaCAdapters.Tests.ps1` pattern);
- drives the v1 envelope produced by the IaC adapter (`Invoke-BicepValidation` / `Invoke-TerraformValidation`) or by `Invoke-Infracost.ps1` directly into the matching v2 normalizer (`Normalize-IaCBicep`, `Normalize-IaCTerraform`, `Normalize-Infracost`);
- validates the resulting v2 `FindingRow` shape: `SchemaVersion=2.2`, canonical `EntityId` via `ConvertTo-CanonicalEntityId`, `Pillar`, `EvidenceUris`, `ToolVersion`, consistent `Provenance.RunId`.

Realistic, fully-synthetic fixtures live under the new `tests/fixtures/iac/` directory (`main.bicep`, `bicep-build-output.txt`, `main.tf`, `terraform-validate.json`, `trivy-config.json`, `infracost-breakdown.json`) with a README documenting their purpose.

## Verification

`Invoke-Pester -Path .\tests\wrappers -CI` -- **430/430 green** locally (32 new tests, was 398).

## Docs

- `CHANGELOG.md` -- new `### Added` entry under `[1.2.0 - Unreleased]`.
- `tests/fixtures/iac/README.md` -- per-fixture purpose table.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
