### PR TITLE
fix(framework-mapper): repair parse error from #716 (CI hotfix)

### DIFF
--- a/modules/shared/FrameworkMapper.ps1
+++ b/modules/shared/FrameworkMapper.ps1
@@ -254,9 +254,6 @@ function Get-FrameworkCoverage {
     # Count controls actually touched by current findings.
     $touched = @{}
     foreach ($f in $Findings) {
-        if (-not $f.PSObject.Properties['Frameworks']) { continue }
-        if (-not $f.Frameworks) { continue }
-        foreach ($block in $f.Frameworks) {
         $frameworksProp = $f.PSObject.Properties['Frameworks']
         if (-not $frameworksProp -or -not $frameworksProp.Value) { continue }
         foreach ($block in @($frameworksProp.Value)) {


### PR DESCRIPTION
Hotfix for the parse error introduced when union-merging #716. The duplicate `foreach` opener in `Get-FrameworkCoverage` blocked all Test+e2e jobs across ubuntu/macos/windows on every downstream PR (#732, #698, #735, #737, etc.).

**Validated:** 11/11 `tests/shared/FrameworkMapper.Tests.ps1` green locally.

Refs: discovered by `opus-e2e-wave-c-ado` agent during E2E rebase, confirmed in failing CI logs of #698 and #732.