### PR TITLE
fix(main-red): mirror triage params in AzureAnalyzer.psm1 wrapper

### DIFF
--- a/AzureAnalyzer.psm1
+++ b/AzureAnalyzer.psm1
@@ -111,6 +111,11 @@ function Invoke-AzureAnalyzer {
         [ValidateRange(1, 365)]
         [int] $SentinelLookbackDays = 30,
         [switch] $EnableAiTriage,
+        [ValidateSet('Pro', 'Business', 'Enterprise')]
+        [string] $CopilotTier,
+        [ValidatePattern('^(?i)(Auto|Explicit:.+)$')]
+        [string] $TriageModel = 'Auto',
+        [switch] $SingleModel,
         [switch] $SinkLogAnalytics,
         [string] $LogAnalyticsConfig,
         [ValidateRange(1, 365)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to azure-analyzer will be documented here.
 ## [Unreleased]
 
 ### Fixed
+- fix(module): mirror new triage params (-CopilotTier, -TriageModel, -SingleModel) in AzureAnalyzer.psm1 wrapper so the no-parameter-drift contract from #698 stays green after #723.
 - fix(ci): grant `pull-requests: write` and `issues: write` to the `release_please` job in `.github/workflows/release.yml` so release-please can create its release PR and apply labels. The job was running with the workflow's default `contents: write` only, causing release-please v17.3.0 to fail with `Resource not accessible by integration` on PR creation. Permissions are scoped at both the workflow and job level for defense in depth (#734).
 
 ### Added
@@ -70,6 +71,7 @@ All notable changes to azure-analyzer will be documented here.
 - ci(markdown): replaced flaky `markdown-link-check.yml` with hardened `markdown-check.yml` (3 parallel jobs: markdownlint-cli2 lint + lychee links + ripgrep em-dash gate). Lychee now uses persistent 7d cache, 5 retries with 10s wait, and `nick-fields/retry` wrapper for catastrophic transients. Em-dash gate runs against changed files on PRs and emits an advisory backlog list on schedule. Ephemeral agent state (`.copilot/audits/`, `.copilot/status/`, `.squad/decisions/inbox/`, `.atlas-stash/`) and auto-generated docs (`docs/reference/permissions/`, `docs/reference/tool-catalog*.md`, `docs/consumer/permissions/`) are excluded from lint + links. New config files: `.markdownlint-cli2.jsonc`. Updated: `.lychee.toml`. New tests: `tests/workflows/MarkdownCheck.Tests.ps1` (24 invariants). New doc: `docs/contributing/markdown.md`. Watchdog + auto-approve workflow watchlists updated to track `Markdown Check` (was `Markdown Link Check`). This supersedes and reverts both interim hotfixes on `markdown-link-check.yml`: #531 (`continue-on-error` job-level bypass) and #535 (`|| true` step-level bypass + README maintenance banner)  -  the workflow file is deleted entirely and the README banner is removed in this PR. Closes #516.
 
 ### Fixed
+- fix(module): mirror new triage params (-CopilotTier, -TriageModel, -SingleModel) in AzureAnalyzer.psm1 wrapper so the no-parameter-drift contract from #698 stays green after #723.
 - fix(ci): pr-auto-rebase job name now evaluates matrix.pr.number expression (#534). Wrapped the job name in double quotes to ensure GitHub Actions interpolates the matrix variable, preventing literal `${{ matrix.pr.number }}` from appearing in the workflow run UI.
 - Reconcile README supported-tool counts to manifest (#598, DOC-002) - 36 enabled + 1 disabled.
 - Sanitize raw Infracost CLI JSON output through Remove-Credentials before write (#603, SEC-001).


### PR DESCRIPTION
## Closes

N/A (no tracked issue, type=fix) - main-red follow-up to #723.

## Summary

#723 added -CopilotTier, -TriageModel, and -SingleModel to Invoke-AzureAnalyzer.ps1. The same 5-line update to the AzureAnalyzer.psm1 typed-parameter wrapper was prepared during PR review but missed the squash-merge window.

The 'no parameter drift' Pester contract added in #698 (`tests/module/Import-AzureAnalyzer.Tests.ps1`) is therefore failing on main on all OS legs:

`Expected $null or empty, because wrapper must mirror Invoke-AzureAnalyzer.ps1; missing: CopilotTier, TriageModel, SingleModel, but got @('CopilotTier', 'TriageModel', 'SingleModel').`

## Changes

- `AzureAnalyzer.psm1`: add the 3 typed parameters with the same `[ValidateSet]` / `[ValidatePattern]` constraints as the script.
- `CHANGELOG.md`: Fixed entry under Unreleased.

## Test results

- `tests/module/Import-AzureAnalyzer.Tests.ps1`: 6/6 green locally.