### PR TITLE
fix(test): tolerate YAML comments between concurrency: and group: keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,6 +416,7 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Fixed
 
+- fix(test): tolerate YAML comment lines between `concurrency:` and `group:` keys in `tests/workflows/ConcurrencyGroups.Tests.ps1`. PR #771 added explanatory comments inside the `concurrency:` block of `.github/workflows/codeql.yml`, breaking the prior strict regex (`^concurrency:\s*\r?\n\s+group:`) across the Test (ubuntu/macos/windows) matrix on every PR rebased after #771 merged. Updated regex now allows interleaved comment / blank lines while still requiring both keys.
 - fix(ci): CodeQL concurrency now per-ref instead of global, eliminating cross-branch cancellation thrash that left `Analyze (actions)` MISSING on rebased PRs.
 
 ### Added

--- a/tests/workflows/ConcurrencyGroups.Tests.ps1
+++ b/tests/workflows/ConcurrencyGroups.Tests.ps1
@@ -51,6 +51,8 @@ Describe 'Workflow concurrency contract' {
 
         $content = Get-Content -Path $Path -Raw
 
-        $content | Should -Match '(?ms)^concurrency:\s*\r?\n\s+group:\s+\S+' -Because "$Name concurrency block must set a ``group:`` expression"
+        # Allow YAML comment lines and blank lines between `concurrency:` and `group:`,
+        # matching the pattern introduced by #771 which interleaves explanatory comments.
+        $content | Should -Match '(?ms)^concurrency:\s*\r?\n(?:\s*(?:#[^\r\n]*)?\r?\n)*\s+group:\s+\S+' -Because "$Name concurrency block must set a ``group:`` expression"
     }
 }


### PR DESCRIPTION
N/A (no tracked issue, type=ci).

PR #771 added explanatory comments between `concurrency:` and `group:` in `.github/workflows/codeql.yml`, breaking the strict regex in `tests/workflows/ConcurrencyGroups.Tests.ps1` across the Test matrix on every PR rebased after #771 merged.

Updated regex now tolerates interleaved comment/blank lines while still requiring both keys.

## Verification

`Invoke-Pester -Path .\tests\workflows\ConcurrencyGroups.Tests.ps1 -CI` -> 20/20 green.