### PR TITLE
fix(ci): remove 9 expired redirect stubs at 1.1.0

### DIFF
--- a/AI_GOVERNANCE.md
+++ b/AI_GOVERNANCE.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page has moved to [docs/contributor/ai-governance.md](docs/contributor/ai-governance.md).
-
-The old path is preserved as a stub through the next minor release and will be removed thereafter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to azure-analyzer will be documented here.
 
+## [Unreleased]
+
+### Fixed
+
+* Remove 9 expired docs-restructure redirect stubs now that module version reached 1.1.0 (cleared `Check redirect stub deadline` failure that blocked all open PRs).
+
 ## [1.1.0](https://github.com/martinopedal/azure-analyzer/compare/v1.0.0...v1.1.0) (2026-04-23)
 
 

--- a/checks.json
+++ b/checks.json
@@ -1,0 +1,1 @@
+{"statusCheckRollup":[]}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page has moved to [docs/contributor/ARCHITECTURE.md](./contributor/ARCHITECTURE.md).
-
-The old path is preserved as a stub through the next minor release and will be removed thereafter.

--- a/docs/CONTRIBUTING-TOOLS.md
+++ b/docs/CONTRIBUTING-TOOLS.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page has moved to [docs/contributor/adding-a-tool.md](./contributor/adding-a-tool.md).
-
-The old path is preserved as a stub through the next minor release and will be removed thereafter.

--- a/docs/ai-triage.md
+++ b/docs/ai-triage.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page has moved to [docs/consumer/ai-triage.md](./consumer/ai-triage.md).
-
-The old path is preserved as a stub through the next minor release and will be removed thereafter.

--- a/docs/continuous-control.md
+++ b/docs/continuous-control.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page has moved to [docs/consumer/continuous-control.md](./consumer/continuous-control.md).
-
-The old path is preserved as a stub through the next minor release and will be removed thereafter.

--- a/docs/future-iac-drift.md
+++ b/docs/future-iac-drift.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page has moved to [docs/contributor/proposals/iac-drift.md](./contributor/proposals/iac-drift.md).
-
-The old path is preserved as a stub through the next minor release and will be removed thereafter.

--- a/docs/gitleaks-pattern-tuning.md
+++ b/docs/gitleaks-pattern-tuning.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page has moved to [docs/consumer/gitleaks-pattern-tuning.md](./consumer/gitleaks-pattern-tuning.md).
-
-The old path is preserved as a stub through the next minor release and will be removed thereafter.

--- a/docs/proposals/copilot-triage-panel.md
+++ b/docs/proposals/copilot-triage-panel.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page has moved to [docs/contributor/proposals/copilot-triage-panel.md](../contributor/proposals/copilot-triage-panel.md).
-
-The old path is preserved as a stub through the next minor release and will be removed thereafter.

--- a/docs/sinks/log-analytics.md
+++ b/docs/sinks/log-analytics.md
@@ -1,5 +1,0 @@
-# Moved
-
-This page has moved to [docs/consumer/sinks/log-analytics.md](../consumer/sinks/log-analytics.md).
-
-The old path is preserved as a stub through the next minor release and will be removed thereafter.


### PR DESCRIPTION
## Summary

The `Check redirect stub deadline` workflow flags redirect stubs whose `expiresAt` version is `<=` the current `ModuleVersion` in `AzureAnalyzer.psd1`. release-please bumped main to `1.1.0`, which expired all 9 docs-restructure redirect stubs from #243. The job now fails on every open PR — blocking 10 PRs from merging.

## Fix

Ran `scripts/Check-StubDeadline.ps1 -Mode Remove` to delete the 9 expired stub files. Registry entries are kept as historical record; the check now passes because `Exists=false` for removed stubs.

Verified locally: `Stub deadline check passed for module version 1.1.0.`

## Closes

N/A (no tracked issue, type=ci).
