### PR TITLE
fix(policy): address 4 PR #721 Copilot review concerns (#767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Fixed
 
+- Address 4 Copilot review concerns from #721 (#767).
 * Remove 9 expired docs-restructure redirect stubs now that module version reached 1.1.0 (cleared `Check redirect stub deadline` failure that blocked all open PRs).
 
 ## [1.1.0](https://github.com/martinopedal/azure-analyzer/compare/v1.0.0...v1.1.0) (2026-04-23)

--- a/modules/shared/Policy/AzAdvertizerLookup.ps1
+++ b/modules/shared/Policy/AzAdvertizerLookup.ps1
@@ -39,12 +39,13 @@ function Invoke-AzAdvertizerLookup {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)] [string] $PolicyId,
-        [string] $CatalogPath = (Get-PolicyCatalogPath -Leaf 'azadvertizer-catalog.json')
+        [string] $CatalogPath = (Get-PolicyCatalogPath -Leaf 'azadvertizer-catalog.json'),
+        [object] $Catalog
     )
 
     if ([string]::IsNullOrWhiteSpace($PolicyId)) { return $null }
-    $catalog = Import-PolicyCatalog -Path $CatalogPath -Name 'AzAdvertizer'
-    return ($catalog.entries | Where-Object { [string]$_.policyId -ieq [string]$PolicyId } | Select-Object -First 1)
+    if (-not $Catalog) { $Catalog = Import-PolicyCatalog -Path $CatalogPath -Name 'AzAdvertizer' }
+    return ($Catalog.entries | Where-Object { [string]$_.policyId -ieq [string]$PolicyId } | Select-Object -First 1)
 }
 
 function Get-PolicySuggestionsForFinding {
@@ -59,6 +60,12 @@ function Get-PolicySuggestionsForFinding {
         Maximum number of suggestions to return. Default 3.
     .PARAMETER AlzActivation
         Full | Partial | Fallback. Controls whether ALZ-source entries are returned.
+    .PARAMETER Map
+        Optional preloaded finding-to-policy map object (skips disk read + JSON parse).
+    .PARAMETER AlzCatalog
+        Optional preloaded ALZ policy catalog object (skips disk read + JSON parse).
+    .PARAMETER AzAdvertizerCatalog
+        Optional preloaded AzAdvertizer policy catalog object (skips disk read + JSON parse).
     .OUTPUTS
         Array of PSCustomObject { PolicyId, DisplayName, Source, ScopeHint, Url, Pill }.
     #>
@@ -67,11 +74,14 @@ function Get-PolicySuggestionsForFinding {
         [Parameter(Mandatory)] [object] $Finding,
         [string] $MapPath,
         [int] $MaxSuggestions = 3,
-        [ValidateSet('Full','Partial','Fallback')] [string] $AlzActivation = 'Fallback'
+        [ValidateSet('Full','Partial','Fallback')] [string] $AlzActivation = 'Fallback',
+        [object] $Map,
+        [object] $AlzCatalog,
+        [object] $AzAdvertizerCatalog
     )
     if ($MaxSuggestions -lt 1) { return @() }
 
-    $map = Import-FindingToPolicyMap -MapPath $MapPath
+    if (-not $Map) { $Map = Import-FindingToPolicyMap -MapPath $MapPath }
     $findingType = ''
     foreach ($candidateProp in 'FindingType', 'findingType', 'Type', 'Category') {
         if ($Finding.PSObject.Properties[$candidateProp] -and -not [string]::IsNullOrWhiteSpace([string]$Finding.$candidateProp)) {
@@ -81,7 +91,7 @@ function Get-PolicySuggestionsForFinding {
     }
     if ([string]::IsNullOrWhiteSpace($findingType)) { return @() }
 
-    $entry = @($map.entries | Where-Object { [string]$_.findingType -ieq $findingType } | Select-Object -First 1)
+    $entry = @($Map.entries | Where-Object { [string]$_.findingType -ieq $findingType } | Select-Object -First 1)
     if (-not $entry) { return @() }
 
     $allowAlz = $AlzActivation -in @('Full', 'Partial')
@@ -97,7 +107,9 @@ function Get-PolicySuggestionsForFinding {
             Select-Object -First $MaxSuggestions
     )
 
-    $alzCatalog = Import-PolicyCatalog -Path (Get-PolicyCatalogPath -Leaf 'alz-policy-catalog.json') -Name 'ALZ'
+    if (-not $AlzCatalog) {
+        $AlzCatalog = Import-PolicyCatalog -Path (Get-PolicyCatalogPath -Leaf 'alz-policy-catalog.json') -Name 'ALZ'
+    }
 
     $rows = [System.Collections.Generic.List[object]]::new()
     foreach ($s in $suggestions) {
@@ -107,13 +119,17 @@ function Get-PolicySuggestionsForFinding {
         $scopeHint = [string]$s.scopeHint
         $url = ''
         if ($source -eq 'AzAdvertizer') {
-            $catalogHit = Invoke-AzAdvertizerLookup -PolicyId $policyId
+            $catalogHit = if ($AzAdvertizerCatalog) {
+                Invoke-AzAdvertizerLookup -PolicyId $policyId -Catalog $AzAdvertizerCatalog
+            } else {
+                Invoke-AzAdvertizerLookup -PolicyId $policyId
+            }
             if ($catalogHit) {
                 if (-not [string]::IsNullOrWhiteSpace([string]$catalogHit.displayName)) { $displayName = [string]$catalogHit.displayName }
                 $url = [string]$catalogHit.url
             }
         } elseif ($source -eq 'ALZ') {
-            $catalogHit = @($alzCatalog.entries | Where-Object { [string]$_.policyId -ieq $policyId } | Select-Object -First 1)
+            $catalogHit = @($AlzCatalog.entries | Where-Object { [string]$_.policyId -ieq $policyId } | Select-Object -First 1)
             if ($catalogHit) {
                 if (-not [string]::IsNullOrWhiteSpace([string]$catalogHit.displayName)) { $displayName = [string]$catalogHit.displayName }
                 $url = [string]$catalogHit.url

--- a/tests/normalizers/Normalize-AzGovViz.Tests.ps1
+++ b/tests/normalizers/Normalize-AzGovViz.Tests.ps1
@@ -309,10 +309,12 @@ Describe 'Normalize-AzGovViz' {
 
             $exemptedFromEdge = @($edgeCollector | Where-Object { $_.Relation -eq 'ExemptedFrom' })
             $exemptedFromEdge.Count | Should -Be 1
+            $exemptedFromEdge[0].Source | Should -Be '00000000-0000-0000-0000-000000000001'
             $exemptedFromEdge[0].Target | Should -Be $assignmentLower
 
             $inheritsFromEdge = @($edgeCollector | Where-Object { $_.Relation -eq 'InheritsFrom' })
             $inheritsFromEdge.Count | Should -BeGreaterOrEqual 1
+            $inheritsFromEdge[0].Source | Should -Be '00000000-0000-0000-0000-000000000001'
             $inheritsFromEdge[0].Target | Should -Be $parentScopeLower
         }
     }

--- a/tests/policy/AzAdvertizerLookup.Tests.ps1
+++ b/tests/policy/AzAdvertizerLookup.Tests.ps1
@@ -41,4 +41,14 @@ Describe 'AzAdvertizer policy lookup' -Tag 'policy' {
         $vintage.alz.catalogVintage | Should -Be '2026-04-23'
         $vintage.alz.catalogSha | Should -Match '^[a-f0-9]{40}$'
     }
+
+    It 'accepts preloaded Map and catalog objects to avoid per-call disk I/O' {
+        $map = Import-FindingToPolicyMap
+        $alzCatalog = Import-PolicyCatalog -Path (Get-PolicyCatalogPath -Leaf 'alz-policy-catalog.json') -Name 'ALZ'
+        $azCatalog = Import-PolicyCatalog -Path (Get-PolicyCatalogPath -Leaf 'azadvertizer-catalog.json') -Name 'AzAdvertizer'
+        $finding = [pscustomobject]@{ FindingType = 'storage.publicNetworkAccess.enabled' }
+        $suggestions = Get-PolicySuggestionsForFinding -Finding $finding -AlzActivation Full -MaxSuggestions 5 `
+            -Map $map -AlzCatalog $alzCatalog -AzAdvertizerCatalog $azCatalog
+        @($suggestions).Count | Should -Be 2
+    }
 }


### PR DESCRIPTION
## Summary

Addresses the four parked Copilot review concerns from PR #721. Three of the four were already corrected in #721 itself; this PR locks them in tests and finishes the remaining ask.

- **Concern #1 (renderer dedup)** — already enforced by `\` HashSet; covered by existing test.
- **Concern #2 (fixture)** — fixture declares `policyassignment:demo` as an entity AND keeps a deliberately dangling `policyassignment:missing` edge so the renderer's `source AND target` filter is exercised.
- **Concern #3 (catalog re-parse on every call)** — script-scope caching is already in place. This PR adds optional `-Map` / `-AlzCatalog` / `-AzAdvertizerCatalog` parameters to `Get-PolicySuggestionsForFinding` so hot-loop callers can pass preloaded objects. New Pester case covers the preloaded path.
- **Concern #4 (Normalize-AzGovViz edge direction)** — policy edge test now asserts `Source` AND `Target` for all four relations (PolicyAssignedTo, PolicyEnforces, ExemptedFrom, InheritsFrom) so future direction inversions fail loudly.

## Tests

- `tests/policy/AzAdvertizerLookup.Tests.ps1` — added preloaded-objects case.
- `tests/normalizers/Normalize-AzGovViz.Tests.ps1` — added Source asserts for ExemptedFrom and InheritsFrom.
- Full Pester: 2442/2443 passing locally; single failure (`Workflow concurrency contract: codeql.yml`) is pre-existing on main and unrelated.

## Closes

Closes #767
