### PR TITLE
fix(wrappers): zizmor exit 2 + scorecard token (#768)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to azure-analyzer will be documented here.
 
 ### Fixed
 
+- Fix zizmor exit code 2 handling and pass GITHUB_TOKEN to scorecard in live runs (#768).
 - Address 4 Copilot review concerns from #721 (#767).
 * Remove 9 expired docs-restructure redirect stubs now that module version reached 1.1.0 (cleared `Check redirect stub deadline` failure that blocked all open PRs).
 

--- a/tests/wrappers/Invoke-Scorecard.Tests.ps1
+++ b/tests/wrappers/Invoke-Scorecard.Tests.ps1
@@ -99,3 +99,73 @@ Describe 'scorecard wrapper: GH_HOST handling' {
     }
 }
 
+Describe 'scorecard wrapper: #768 GITHUB_TOKEN handling' {
+    BeforeEach {
+        $script:OriginalAuthToken = $env:GITHUB_AUTH_TOKEN
+        $script:OriginalGitHubToken = $env:GITHUB_TOKEN
+    }
+
+    AfterEach {
+        Remove-Item Function:\global:scorecard -ErrorAction SilentlyContinue
+        Remove-Variable -Name seenAuthToken -Scope Global -ErrorAction SilentlyContinue
+        if ($null -eq $script:OriginalAuthToken) {
+            Remove-Item Env:\GITHUB_AUTH_TOKEN -ErrorAction SilentlyContinue
+        } else {
+            $env:GITHUB_AUTH_TOKEN = $script:OriginalAuthToken
+        }
+        if ($null -eq $script:OriginalGitHubToken) {
+            Remove-Item Env:\GITHUB_TOKEN -ErrorAction SilentlyContinue
+        } else {
+            $env:GITHUB_TOKEN = $script:OriginalGitHubToken
+        }
+    }
+
+    It 'short-circuits with Status=Skipped + MissingAuthToken when no token is set (#768)' {
+        Remove-Item Env:\GITHUB_AUTH_TOKEN -ErrorAction SilentlyContinue
+        Remove-Item Env:\GITHUB_TOKEN -ErrorAction SilentlyContinue
+
+        function global:scorecard {
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]] $Args)
+            throw 'scorecard CLI must NOT be invoked when no auth token is present (#768)'
+        }
+
+        $result = & $script:wrapper -Repository 'github.com/org/repo'
+        $result.Status | Should -Be 'Skipped'
+        $result.Message | Should -Match 'GITHUB_AUTH_TOKEN|GITHUB_TOKEN'
+        @($result.Findings).Count | Should -Be 0
+        @($result.Diagnostics) | Where-Object { $_.Code -eq 'MissingAuthToken' } | Should -Not -BeNullOrEmpty
+    }
+
+    It 'propagates GITHUB_TOKEN as GITHUB_AUTH_TOKEN into the scorecard call (#768)' {
+        Remove-Item Env:\GITHUB_AUTH_TOKEN -ErrorAction SilentlyContinue
+        $env:GITHUB_TOKEN = 'gh-token-from-actions'
+
+        function global:scorecard {
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]] $Args)
+            $global:seenAuthToken = $env:GITHUB_AUTH_TOKEN
+            if ($Args -contains '--version') { return 'scorecard version: v4.13.0' }
+            return $global:scorecardCliFixtureRaw
+        }
+
+        $result = & $script:wrapper -Repository 'github.com/org/repo'
+        $result.Status | Should -Be 'Success'
+        $global:seenAuthToken | Should -Be 'gh-token-from-actions' -Because 'wrapper must propagate GITHUB_TOKEN as GITHUB_AUTH_TOKEN so scorecard runs authenticated (#768)'
+    }
+
+    It 'prefers GITHUB_AUTH_TOKEN over GITHUB_TOKEN when both are set (#768)' {
+        $env:GITHUB_AUTH_TOKEN = 'native-scorecard-token'
+        $env:GITHUB_TOKEN = 'gh-token'
+
+        function global:scorecard {
+            param([Parameter(ValueFromRemainingArguments = $true)][string[]] $Args)
+            $global:seenAuthToken = $env:GITHUB_AUTH_TOKEN
+            if ($Args -contains '--version') { return 'scorecard version: v4.13.0' }
+            return $global:scorecardCliFixtureRaw
+        }
+
+        $result = & $script:wrapper -Repository 'github.com/org/repo'
+        $result.Status | Should -Be 'Success'
+        $global:seenAuthToken | Should -Be 'native-scorecard-token'
+    }
+}
+

--- a/tests/wrappers/Invoke-Zizmor.Tests.ps1
+++ b/tests/wrappers/Invoke-Zizmor.Tests.ps1
@@ -148,6 +148,56 @@ Describe 'Invoke-Zizmor: schema 2.2 precursor fields' {
     }
 }
 
+Describe 'Invoke-Zizmor: #768 zizmor 1.x exit-code handling' {
+    BeforeAll {
+        $global:ZizmorRawFixture768 = $script:RawFixture
+        $global:ZizmorCapturedArgs = $null
+        function global:zizmor {
+            param([Parameter(ValueFromRemainingArguments = $true)][object[]]$Args)
+            if ($Args -contains '--version') {
+                $global:LASTEXITCODE = 0
+                return 'zizmor 1.8.0'
+            }
+            $global:ZizmorCapturedArgs = @($Args)
+            # Simulate zizmor 1.x: stdout JSON + non-zero severity exit code (e.g. 14).
+            # With --no-exit-codes the wrapper passes, so this asserts the wrapper
+            # never trips on a non-zero exit when stdout already has the report (#768).
+            $global:LASTEXITCODE = 14
+            return (Get-Content $global:ZizmorRawFixture768 -Raw)
+        }
+        function global:git {
+            $cmd = ($args -join ' ')
+            if ($cmd -match 'remote get-url origin') { return 'https://github.com/martinopedal/azure-analyzer.git' }
+            if ($cmd -match 'rev-parse HEAD')        { return '0123456789abcdef0123456789abcdef01234567' }
+            return ''
+        }
+    }
+
+    AfterAll {
+        Remove-Item Function:\global:zizmor -ErrorAction SilentlyContinue
+        Remove-Item Function:\global:git -ErrorAction SilentlyContinue
+        Remove-Variable -Name ZizmorRawFixture768 -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ZizmorCapturedArgs -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    It 'passes --no-exit-codes and --format=json so zizmor 1.x does not exit 2 on findings (#768)' {
+        Mock Get-Command {
+            param($Name)
+            if ($Name -eq 'zizmor') { return [pscustomobject]@{ Name = 'zizmor' } }
+            if ($Name -eq 'git')    { return [pscustomobject]@{ Name = 'git' } }
+            return $null
+        } -ParameterFilter { $Name -in @('zizmor', 'git') }
+
+        $result = & $script:Wrapper -RepoPath $script:RepoRoot
+        $result.Status | Should -Be 'Success' -Because 'zizmor non-zero exit with a populated report must NOT be treated as failure (#768)'
+        @($result.Findings).Count | Should -BeGreaterThan 0
+
+        $argString = ($global:ZizmorCapturedArgs | ForEach-Object { [string]$_ }) -join ' '
+        $argString | Should -Match '--no-exit-codes' -Because 'wrapper must pass --no-exit-codes to suppress severity exit codes 11..14 (#768)'
+        $argString | Should -Match '--format=json' -Because 'wrapper must request JSON output explicitly (#768)'
+    }
+}
+
 Describe 'Invoke-Zizmor: E2E wrapper to normalizer (#660)' {
     BeforeAll {
         . $script:Normalizer
@@ -158,12 +208,11 @@ Describe 'Invoke-Zizmor: E2E wrapper to normalizer (#660)' {
                 $global:LASTEXITCODE = 0
                 return 'zizmor 1.8.0'
             }
-            $outputIndex = [Array]::IndexOf($Args, '--output')
-            if ($outputIndex -ge 0 -and ($outputIndex + 1) -lt $Args.Count) {
-                Copy-Item -Path $global:ZizmorE2EFixture -Destination ([string]$Args[$outputIndex + 1]) -Force
-            }
-            $global:LASTEXITCODE = 1
-            return $null
+            # zizmor 1.x writes JSON to stdout (#768). Wrapper redirects 1>$reportFile.
+            # Exit code is non-zero when severity-based exits are enabled, but the
+            # wrapper passes --no-exit-codes so 0 is the expected normal-path code.
+            $global:LASTEXITCODE = 0
+            return (Get-Content $global:ZizmorE2EFixture -Raw)
         }
     }
 


### PR DESCRIPTION
Fixes #768

Locks in two wrapper contracts (zizmor --no-exit-codes / --format=json; scorecard GITHUB_TOKEN propagation + MissingAuthToken short-circuit) behind unit tests, and refreshes the #660 E2E mock to match the zizmor 1.x stdout contract.

Tests: 21 passed, 0 failed, 3 skipped (live-CLI gates).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>