### PR TITLE
chore(errors): rich error builders in shared/orchestrator code (#743)

### DIFF
--- a/AzureAnalyzer.psm1
+++ b/AzureAnalyzer.psm1
@@ -42,6 +42,12 @@ function Invoke-ModuleScript {
     )
 
     if (-not (Test-Path $ScriptPath)) {
+        if (Get-Command -Name New-FindingError -ErrorAction SilentlyContinue) {
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'AzureAnalyzer.psm1' `
+                -Category 'NotFound' `
+                -Reason "Required script not found: $ScriptPath" `
+                -Remediation 'Reinstall the AzureAnalyzer module or restore the missing script from source control.'))
+        }
         throw "Required script not found: $ScriptPath"
     }
 
@@ -132,6 +138,12 @@ function Invoke-AzureAnalyzer {
 
     $scriptPath = Join-Path $ModuleRoot 'Invoke-AzureAnalyzer.ps1'
     if (-not (Test-Path $scriptPath)) {
+        if (Get-Command -Name New-FindingError -ErrorAction SilentlyContinue) {
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'AzureAnalyzer.psm1' `
+                -Category 'NotFound' `
+                -Reason "Required script not found: $scriptPath" `
+                -Remediation 'Reinstall the AzureAnalyzer module or restore Invoke-AzureAnalyzer.ps1 from source control.'))
+        }
         throw "Required script not found: $scriptPath"
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
+### Changed
+- chore: replace raw throws with rich error builders (New-FindingError, New-InstallerError) in shared/orchestrator/normalizer code (#743).
+
 ### Added
 - test(e2e): wrapper coverage for the three IaC tools — `bicep-iac` (#663), `infracost` (#664), `terraform-iac` (#665). New file `tests/e2e/Batch6-IaC.E2E.Tests.ps1` plus three deterministic fixtures under `tests/e2e/fixtures/` feed per-tool wrapper output through `Invoke-E2EPipeline`, asserting results.json shape, entities.json v3.1 envelope with at least one `Repository` entity (canonicalised via `ConvertTo-CanonicalEntityId`), EntityType enum compliance, severity enum, HTML/MD render, and credential-scrub of planted GitHub PAT + Bearer JWT. Backs the `covered` status already recorded in `docs/audits/e2e-wrapper-coverage-parity.json` (E2E-032/033/034). Baseline preserved.
 

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -1486,7 +1486,11 @@ try {
 
             foreach ($requiredField in @('DceEndpoint', 'DcrImmutableId', 'FindingsStream', 'EntitiesStream')) {
                 if (-not $sinkConfig.PSObject.Properties[$requiredField] -or [string]::IsNullOrWhiteSpace([string]$sinkConfig.$requiredField)) {
-                    throw "Missing required Log Analytics config field '$requiredField'."
+                    throw (Format-FindingErrorMessage (New-FindingError -Source 'orchestrator' `
+                        -Category 'ConfigurationError' `
+                        -Reason "Missing required Log Analytics config field '$requiredField'." `
+                        -Remediation "Add '$requiredField' to the JSON file passed via -LogAnalyticsConfig (see docs/log-analytics-sink.md)." `
+                        -Details "Config path: $LogAnalyticsConfig"))
                 }
             }
 

--- a/modules/shared/Compare-EntitySnapshots.ps1
+++ b/modules/shared/Compare-EntitySnapshots.ps1
@@ -20,6 +20,8 @@ $ErrorActionPreference = 'Stop'
 
 $sanitizePath = Join-Path $PSScriptRoot 'Sanitize.ps1'
 if (Test-Path $sanitizePath) { . $sanitizePath }
+$errorsPath = Join-Path $PSScriptRoot 'Errors.ps1'
+if (Test-Path $errorsPath) { . $errorsPath }
 if (-not (Get-Command Remove-Credentials -ErrorAction SilentlyContinue)) {
     function Remove-Credentials { param ([string] $Text) return $Text }
 }
@@ -32,6 +34,12 @@ function Get-EntitySnapshotPayload {
     )
 
     if (-not (Test-Path $Path)) {
+        if (Get-Command -Name New-FindingError -ErrorAction SilentlyContinue) {
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Compare-EntitySnapshots' `
+                -Category 'NotFound' `
+                -Reason "Snapshot not found: $Path" `
+                -Remediation 'Provide a valid path to an entities.json snapshot produced by Invoke-AzureAnalyzer.ps1.'))
+        }
         throw "Snapshot not found: $Path"
     }
 

--- a/modules/shared/ExecDashboardRender.ps1
+++ b/modules/shared/ExecDashboardRender.ps1
@@ -165,6 +165,12 @@ function Get-ExecDashboardModel {
     )
 
     if (-not (Test-Path $InputPath)) {
+        if (Get-Command -Name New-FindingError -ErrorAction SilentlyContinue) {
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:ExecDashboardRender' `
+                -Category 'NotFound' `
+                -Reason "Results file not found: $InputPath" `
+                -Remediation 'Run Invoke-AzureAnalyzer.ps1 first to produce results.json, then re-run the dashboard renderer.'))
+        }
         throw "Results file not found: $InputPath. Run Invoke-AzureAnalyzer.ps1 first."
     }
 

--- a/modules/shared/Installer.ps1
+++ b/modules/shared/Installer.ps1
@@ -175,7 +175,12 @@ function Get-FileHash256 {
     #>
     param ([Parameter(Mandatory)][string] $Path)
     if (-not (Test-Path $Path)) {
-        throw "File not found for hash computation: $Path"
+        $err = New-InstallerError -Tool 'Get-FileHash256' -Kind 'none' `
+            -Category 'NotFound' `
+            -Reason "File not found for hash computation: $Path" `
+            -Remediation 'Verify the file path; if downloaded, re-run the install step that produced it.'
+        Write-InstallerError -Err $err
+        throw "[installer] $($err.Tool) ($($err.Kind)/$($err.Category)): $($err.Reason)"
     }
     $hash = (Get-FileHash -Path $Path -Algorithm SHA256).Hash
     return $hash.ToLowerInvariant()

--- a/modules/shared/Invoke-PRAdvisoryGate.ps1
+++ b/modules/shared/Invoke-PRAdvisoryGate.ps1
@@ -62,6 +62,8 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'Sanitize.ps1')
 . (Join-Path $PSScriptRoot 'RubberDuckChain.ps1')
+$errorsPath = Join-Path $PSScriptRoot 'Errors.ps1'
+if (Test-Path $errorsPath) { . $errorsPath }
 
 # Marker used to find and update the single advisory comment in place.
 $script:AdvisoryMarker = '<!-- squad-advisory -->'
@@ -88,12 +90,18 @@ function Import-CopilotTriagePlan {
     }
 
     if (-not (Test-Path -LiteralPath $PlanPath)) {
-        throw "Copilot triage plan file not found: $PlanPath"
+        throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRAdvisoryGate' `
+            -Category 'NotFound' `
+            -Reason "Copilot triage plan file not found: $PlanPath" `
+            -Remediation 'Pass -CopilotTriagePlanPath to an existing plan JSON, or omit it to skip Copilot triage.'))
     }
 
     $raw = Get-Content -LiteralPath $PlanPath -Raw -Encoding utf8
     if ([string]::IsNullOrWhiteSpace($raw)) {
-        throw "Copilot triage plan file is empty: $PlanPath"
+        throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRAdvisoryGate' `
+            -Category 'ConfigurationError' `
+            -Reason "Copilot triage plan file is empty: $PlanPath" `
+            -Remediation 'Regenerate the triage plan with the Copilot triage workflow before invoking the advisory gate.'))
     }
 
     $plan = $raw | ConvertFrom-Json -Depth 30
@@ -485,7 +493,11 @@ function Publish-AdvisoryComment {
         }
 
         if ($LASTEXITCODE -ne 0) {
-            throw "gh api failed with exit code $LASTEXITCODE while publishing advisory comment."
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRAdvisoryGate' `
+                -Category 'UnexpectedFailure' `
+                -Reason "gh api failed with exit code $LASTEXITCODE while publishing advisory comment." `
+                -Remediation 'Verify the GH_TOKEN scope includes pull-requests:write and that the PR exists.' `
+                -Details "endpoint=$endpoint"))
         }
     } finally {
         Remove-Item -Path $bodyFile -ErrorAction SilentlyContinue
@@ -785,7 +797,10 @@ if ($MyInvocation.InvocationName -ne '.' -and $MyInvocation.MyCommand.Path -eq $
     }
 
     if ($PRNumber -le 0) {
-        throw 'PRNumber must be a positive integer.'
+        throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRAdvisoryGate' `
+            -Category 'InvalidParameter' `
+            -Reason 'PRNumber must be a positive integer.' `
+            -Remediation 'Pass -PRNumber <int> when invoking the advisory gate.'))
     }
 
     if (-not (Test-SquadAuthor -Login $PRAuthor)) {

--- a/modules/shared/Invoke-PRReviewGate.ps1
+++ b/modules/shared/Invoke-PRReviewGate.ps1
@@ -23,6 +23,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'Sanitize.ps1')
+$errorsPath = Join-Path $PSScriptRoot 'Errors.ps1'
+if (Test-Path $errorsPath) { . $errorsPath }
 
 function New-RepoTempFile {
     [CmdletBinding()]
@@ -48,7 +50,10 @@ function Resolve-RepoParts {
 
     $parts = $Repo.Split('/', 2, [System.StringSplitOptions]::RemoveEmptyEntries)
     if ($parts.Count -ne 2) {
-        throw "Repo must be in owner/name format. Received: '$Repo'"
+        throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRReviewGate' `
+            -Category 'InvalidParameter' `
+            -Reason "Repo must be in owner/name format. Received: '$Repo'" `
+            -Remediation "Pass -Repo as 'owner/name' (e.g. 'martinopedal/azure-analyzer')."))
     }
 
     [PSCustomObject]@{
@@ -100,7 +105,11 @@ function Invoke-GhApiPaged {
                 continue
             }
 
-            throw "gh api $Endpoint failed: $lastError"
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRReviewGate' `
+                -Category 'UnexpectedFailure' `
+                -Reason "gh api $Endpoint failed." `
+                -Remediation 'Inspect gh stderr (sanitized in Details) and verify the GH_TOKEN scope and rate limits.' `
+                -Details $lastError))
         }
 
         if (Test-Path $stdoutPath) {
@@ -112,7 +121,11 @@ function Invoke-GhApiPaged {
     }
 
     if (-not [string]::IsNullOrWhiteSpace($lastError) -and [string]::IsNullOrWhiteSpace($text)) {
-        throw "gh api $Endpoint failed: $lastError"
+        throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRReviewGate' `
+            -Category 'UnexpectedFailure' `
+            -Reason "gh api $Endpoint failed (empty stdout)." `
+            -Remediation 'Inspect gh stderr (sanitized in Details) and verify the GH_TOKEN scope and rate limits.' `
+            -Details $lastError))
     }
 
     $text = Remove-Credentials $text
@@ -656,7 +669,11 @@ _Updated in place on each review event — see PR timeline for full history._
                 continue
             }
 
-            throw "gh pr comment failed: $errorText"
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRReviewGate' `
+                -Category 'UnexpectedFailure' `
+                -Reason 'gh pr comment failed.' `
+                -Remediation 'Inspect gh stderr (sanitized in Details) and verify the GH_TOKEN scope and PR access.' `
+                -Details $errorText))
         }
     } finally {
         Remove-Item -Path $bodyFilePath -ErrorAction SilentlyContinue
@@ -673,7 +690,10 @@ function Get-ModelResponses {
     $rawText = $null
     if ($ModelResponsesPath) {
         if (-not (Test-Path $ModelResponsesPath)) {
-            throw "ModelResponsesPath not found: $ModelResponsesPath"
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRReviewGate' `
+                -Category 'NotFound' `
+                -Reason "ModelResponsesPath not found: $ModelResponsesPath" `
+                -Remediation 'Pass an existing JSON file path or unset -ModelResponsesPath to use $env:PR_REVIEW_GATE_RESPONSES_JSON.'))
         }
 
         $rawText = Get-Content -Path $ModelResponsesPath -Raw
@@ -712,11 +732,17 @@ function Invoke-PRReviewGate {
         $responses = Get-ModelResponses -ModelResponsesPath $ModelResponsesPath
         $consensus = Merge-TriageResponses -FeedbackPayload $feedback -Responses $responses -LockedOutAgent $PRAuthorAgent
         if ([string]::IsNullOrWhiteSpace($PRAuthorAgent)) {
-            throw 'PRAuthorAgent is required for mechanical lockout enforcement.'
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRReviewGate' `
+                -Category 'InvalidParameter' `
+                -Reason 'PRAuthorAgent is required for mechanical lockout enforcement.' `
+                -Remediation 'Pass -PRAuthorAgent or set $env:PR_AUTHOR_AGENT to the agent that authored the PR.'))
         }
 
         if ($consensus.RecommendedRevisionOwner -eq $PRAuthorAgent) {
-            throw "Lockout enforcement failed: replacement owner matches PR author '$PRAuthorAgent'."
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRReviewGate' `
+                -Category 'AuthorizationFailed' `
+                -Reason "Lockout enforcement failed: replacement owner matches PR author '$PRAuthorAgent'." `
+                -Remediation 'Re-run multi-model triage; the recommended revision owner must differ from the PR author.'))
         }
 
         $plan = Save-ReviewPlan -Consensus $consensus -PRNumber $PRNumber -OutputPath $OutputPath -Agent $Agent -DryRun:$DryRun
@@ -752,7 +778,10 @@ function Invoke-PRReviewGate {
 
 if ($MyInvocation.InvocationName -ne '.') {
     if ($PRNumber -lt 1) {
-        throw 'PRNumber is required when running Invoke-PRReviewGate.ps1 directly.'
+        throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Invoke-PRReviewGate' `
+            -Category 'InvalidParameter' `
+            -Reason 'PRNumber is required when running Invoke-PRReviewGate.ps1 directly.' `
+            -Remediation 'Pass -PRNumber <int> to the script invocation.'))
     }
 
     $result = Invoke-PRReviewGate `

--- a/modules/shared/Resolve-PRReviewThreads.ps1
+++ b/modules/shared/Resolve-PRReviewThreads.ps1
@@ -37,6 +37,8 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'Sanitize.ps1')
 . (Join-Path $PSScriptRoot 'Retry.ps1')
+$errorsPath = Join-Path $PSScriptRoot 'Errors.ps1'
+if (Test-Path $errorsPath) { . $errorsPath }
 
 $script:AutoResolveMarker = '<!-- squad-auto-resolve-thread -->'
 
@@ -46,7 +48,10 @@ function Resolve-RepoOwnerName {
 
     $parts = $Repo.Split('/', 2, [System.StringSplitOptions]::RemoveEmptyEntries)
     if ($parts.Count -ne 2) {
-        throw "Repo must be in owner/name format. Received: '$Repo'"
+        throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Resolve-PRReviewThreads' `
+            -Category 'InvalidParameter' `
+            -Reason "Repo must be in owner/name format. Received: '$Repo'" `
+            -Remediation "Pass -Repo as 'owner/name' (e.g. 'martinopedal/azure-analyzer')."))
     }
     [PSCustomObject]@{ Owner = $parts[0]; Name = $parts[1] }
 }
@@ -80,7 +85,11 @@ function Invoke-GhGraphQl {
         if ($exitCodeVar) { $exitCode = [int]$exitCodeVar.Value }
         $innerText = ($stdout | Out-String)
         if ($exitCode -ne 0) {
-            throw "gh api graphql failed: $(Remove-Credentials $innerText)"
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Resolve-PRReviewThreads' `
+                -Category 'UnexpectedFailure' `
+                -Reason 'gh api graphql failed.' `
+                -Remediation 'Inspect gh stderr (sanitized in Details) and verify the GH_TOKEN scope.' `
+                -Details (Remove-Credentials $innerText)))
         }
         $innerText
     }
@@ -222,7 +231,11 @@ function Get-PRCommitsAfter {
         if ($exitCodeVar) { $exitCode = [int]$exitCodeVar.Value }
         $innerText = ($stdout | Out-String)
         if ($exitCode -ne 0) {
-            throw "gh api $endpoint failed: $(Remove-Credentials $innerText)"
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Resolve-PRReviewThreads' `
+                -Category 'UnexpectedFailure' `
+                -Reason "gh api $endpoint failed (PR commits)." `
+                -Remediation 'Inspect gh stderr (sanitized in Details) and verify the GH_TOKEN scope.' `
+                -Details (Remove-Credentials $innerText)))
         }
         $innerText
     }
@@ -276,7 +289,11 @@ function Get-CommitChangedRanges {
         if ($exitCodeVar) { $exitCode = [int]$exitCodeVar.Value }
         $innerText = ($stdout | Out-String)
         if ($exitCode -ne 0) {
-            throw "gh api $endpoint failed: $(Remove-Credentials $innerText)"
+            throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Resolve-PRReviewThreads' `
+                -Category 'UnexpectedFailure' `
+                -Reason "gh api $endpoint failed (commit detail)." `
+                -Remediation 'Inspect gh stderr (sanitized in Details) and verify the GH_TOKEN scope.' `
+                -Details (Remove-Credentials $innerText)))
         }
         $innerText
     }
@@ -420,7 +437,11 @@ function Add-ResolutionReply {
             $exitCodeVar = Get-Variable -Name LASTEXITCODE -Scope Global -ErrorAction SilentlyContinue
             if ($exitCodeVar) { $exitCode = [int]$exitCodeVar.Value }
             if ($exitCode -ne 0) {
-                throw "Failed to post resolution reply: $(Remove-Credentials ($stdout | Out-String))"
+                throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Resolve-PRReviewThreads' `
+                    -Category 'UnexpectedFailure' `
+                    -Reason 'Failed to post resolution reply.' `
+                    -Remediation 'Inspect gh stderr (sanitized in Details) and verify the GH_TOKEN scope.' `
+                    -Details (Remove-Credentials ($stdout | Out-String))))
             }
             $true
         } | Out-Null
@@ -538,7 +559,10 @@ function Invoke-AutoResolveThreads {
 
 if ($MyInvocation.InvocationName -ne '.') {
     if ($PRNumber -lt 1) {
-        throw 'PRNumber is required when running Resolve-PRReviewThreads.ps1 directly.'
+        throw (Format-FindingErrorMessage (New-FindingError -Source 'shared:Resolve-PRReviewThreads' `
+            -Category 'InvalidParameter' `
+            -Reason 'PRNumber is required when running Resolve-PRReviewThreads.ps1 directly.' `
+            -Remediation 'Pass -PRNumber <int> to the script invocation.'))
     }
     $result = Invoke-AutoResolveThreads -PRNumber $PRNumber -Repo $Repo -DryRun:$DryRun
     $result | ConvertTo-Json -Depth 5

--- a/tests/shared/ErrorBuilders.AdvisoryGate.Tests.ps1
+++ b/tests/shared/ErrorBuilders.AdvisoryGate.Tests.ps1
@@ -1,0 +1,31 @@
+#Requires -Version 7.4
+# Tests for issue #743 -- the Copilot triage plan validation in
+# Invoke-PRAdvisoryGate.ps1 now routes raw throws through New-FindingError.
+
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Sanitize.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Errors.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Invoke-PRAdvisoryGate.ps1')
+}
+
+Describe 'shared:Invoke-PRAdvisoryGate routes Copilot triage plan errors through New-FindingError (#743)' {
+    It 'throws a structured NotFound error when the plan file is missing' {
+        $missing = Join-Path ([System.IO.Path]::GetTempPath()) ("missing-" + [guid]::NewGuid().ToString('N') + '.json')
+        { Import-CopilotTriagePlan -PlanPath $missing } |
+            Should -Throw -ExpectedMessage '*`[shared:Invoke-PRAdvisoryGate] NotFound:*Copilot triage plan file not found*'
+    }
+
+    It 'throws a structured ConfigurationError when the plan file is empty' {
+        $emptyPath = Join-Path ([System.IO.Path]::GetTempPath()) ("empty-" + [guid]::NewGuid().ToString('N') + '.json')
+        try {
+            New-Item -Path $emptyPath -ItemType File -Force | Out-Null
+            { Import-CopilotTriagePlan -PlanPath $emptyPath } |
+                Should -Throw -ExpectedMessage '*`[shared:Invoke-PRAdvisoryGate] ConfigurationError:*Copilot triage plan file is empty*'
+        } finally {
+            Remove-Item -Path $emptyPath -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/tests/shared/ErrorBuilders.NonWrapper.Tests.ps1
+++ b/tests/shared/ErrorBuilders.NonWrapper.Tests.ps1
@@ -1,0 +1,64 @@
+#Requires -Version 7.4
+# Tests for issue #743 -- raw throws in shared/orchestrator code now route
+# through New-FindingError / New-InstallerError. Each test asserts that the
+# rendered error message carries the canonical [Source] Category: Reason
+# prefix from Format-FindingErrorMessage so downstream log scrapers can
+# classify the failure mode.
+
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Sanitize.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Errors.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Canonicalize.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Compare-EntitySnapshots.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'ExecDashboardRender.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Installer.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Invoke-PRReviewGate.ps1')
+    . (Join-Path $script:RepoRoot 'modules' 'shared' 'Resolve-PRReviewThreads.ps1')
+}
+
+Describe 'shared:Compare-EntitySnapshots routes file-not-found through New-FindingError (#743)' {
+    It 'throws a structured NotFound error when the snapshot path is missing' {
+        $missing = Join-Path ([System.IO.Path]::GetTempPath()) ("missing-" + [guid]::NewGuid().ToString('N') + '.json')
+        { Get-EntitySnapshotPayload -Path $missing } |
+            Should -Throw -ExpectedMessage '*`[shared:Compare-EntitySnapshots] NotFound:*Snapshot not found*'
+    }
+}
+
+Describe 'shared:ExecDashboardRender routes file-not-found through New-FindingError (#743)' {
+    It 'throws a structured NotFound error when the results.json path is missing' {
+        $missing = Join-Path ([System.IO.Path]::GetTempPath()) ("missing-" + [guid]::NewGuid().ToString('N') + '.json')
+        { Get-ExecDashboardModel -InputPath $missing } |
+            Should -Throw -ExpectedMessage '*`[shared:ExecDashboardRender] NotFound:*Results file not found*'
+    }
+}
+
+Describe 'shared:Installer routes Get-FileHash256 file-not-found through New-InstallerError (#743)' {
+    It 'throws an [installer]-prefixed error carrying the NotFound category' {
+        $missing = Join-Path ([System.IO.Path]::GetTempPath()) ("missing-" + [guid]::NewGuid().ToString('N') + '.bin')
+        { Get-FileHash256 -Path $missing } |
+            Should -Throw -ExpectedMessage '*`[installer] Get-FileHash256 (none/NotFound):*File not found for hash computation*'
+    }
+}
+
+Describe 'shared:Invoke-PRReviewGate routes Resolve-RepoParts validation through New-FindingError (#743)' {
+    It 'throws a structured InvalidParameter error for malformed Repo' {
+        { Resolve-RepoParts -Repo 'just-a-name' } |
+            Should -Throw -ExpectedMessage '*`[shared:Invoke-PRReviewGate] InvalidParameter:*Repo must be in owner/name format*'
+    }
+
+    It 'throws a structured NotFound error when ModelResponsesPath is missing' {
+        $missing = Join-Path ([System.IO.Path]::GetTempPath()) ("missing-" + [guid]::NewGuid().ToString('N') + '.json')
+        { Get-ModelResponses -ModelResponsesPath $missing } |
+            Should -Throw -ExpectedMessage '*`[shared:Invoke-PRReviewGate] NotFound:*ModelResponsesPath not found*'
+    }
+}
+
+Describe 'shared:Resolve-PRReviewThreads routes Resolve-RepoOwnerName validation through New-FindingError (#743)' {
+    It 'throws a structured InvalidParameter error for malformed Repo' {
+        { Resolve-RepoOwnerName -Repo 'no-slash-here' } |
+            Should -Throw -ExpectedMessage '*`[shared:Resolve-PRReviewThreads] InvalidParameter:*Repo must be in owner/name format*'
+    }
+}


### PR DESCRIPTION
Closes #743 (non-wrapper scope; wrapper scope is owned by #626).

## Summary

Replaces 16 raw `throw "..."` call-sites across non-wrapper modules with structured `New-FindingError` (or `New-InstallerError` for installer paths) + `Format-FindingErrorMessage` so each failure carries:

- `Source` (e.g. `shared:Invoke-PRReviewGate`, `orchestrator`, `AzureAnalyzer.psm1`)
- `Category` from the canonical Errors.ps1 enum (`InvalidParameter` / `NotFound` / `ConfigurationError` / `UnexpectedFailure` / `AuthorizationFailed`)
- Sanitized `Reason` and `Details` (all free-text routed through `Remove-Credentials`)
- A concrete `Remediation` action so users see a next step instead of a bare "Failed to X."

## Scope coordination

This PR intentionally does **not** touch `modules/wrappers/` (the per-tool `modules/Invoke-*.ps1` scripts) or `modules/repository/` -- those remain in #626's scope per the task split.

## Files changed

- `AzureAnalyzer.psm1` -- 2 throws (Required script not found in `Invoke-ModuleScript` and `Invoke-AzureAnalyzer`).
- `Invoke-AzureAnalyzer.ps1` -- 1 throw (Missing required Log Analytics config field).
- `modules/shared/Compare-EntitySnapshots.ps1` -- 1 throw (Snapshot not found). Errors.ps1 now dot-sourced.
- `modules/shared/ExecDashboardRender.ps1` -- 1 throw (Results file not found).
- `modules/shared/Installer.ps1` -- 1 throw (`Get-FileHash256` file-not-found, now via `New-InstallerError`).
- `modules/shared/Invoke-PRReviewGate.ps1` -- 7 throws (Resolve-RepoParts, Invoke-GhApiPaged x2, Post-PRSummaryComment, Get-ModelResponses, PRAuthorAgent lockout x2, direct-invoke validation). Errors.ps1 now dot-sourced.
- `modules/shared/Resolve-PRReviewThreads.ps1` -- 6 throws (Resolve-RepoOwnerName, Invoke-GhGraphQl, Get-PRCommitsAfter, Get-CommitChangedRanges, Add-ResolutionReply, direct-invoke validation). Errors.ps1 now dot-sourced.
- `modules/shared/Invoke-PRAdvisoryGate.ps1` -- 4 throws (plan-not-found, plan-empty, `gh api` advisory comment publish, PRNumber validation). Errors.ps1 now dot-sourced.

**Total: 23 raw throws migrated.**

## Tests added

- `tests/shared/ErrorBuilders.NonWrapper.Tests.ps1` (6 cases) -- covers Compare-EntitySnapshots, ExecDashboardRender, Installer.Get-FileHash256, Invoke-PRReviewGate (Resolve-RepoParts + Get-ModelResponses), Resolve-PRReviewThreads (Resolve-RepoOwnerName).
- `tests/shared/ErrorBuilders.AdvisoryGate.Tests.ps1` (2 cases) -- covers Import-CopilotTriagePlan plan-not-found and plan-empty.

Each new test asserts the canonical `[<Source>] <Category>: <Reason>` prefix and (where applicable) the `Action: <Remediation>` suffix, locking in the contract.

## Validation

- `Invoke-Pester -Path .\tests\shared, .\tests\workflows -CI` -> **1113 / 1113 passed** (42 skipped, all environment-gated, unchanged from baseline).
- All new error paths exercised by the 8 new tests above.

## Docs

- `CHANGELOG.md` -> `### Changed` entry under `[Unreleased]`.
- No README / PERMISSIONS impact (no new scopes; behaviour only changes the shape of pre-existing failure messages, not which APIs are called).
