### PR TITLE
docs(changelog): reset Unreleased after 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,8 @@ All notable changes to azure-analyzer will be documented here.
 
 ## [Unreleased]
 
-### Changed
-- chore: replace raw throws with rich error builders (New-FindingError, New-InstallerError) in shared/orchestrator/normalizer code (#743).
-
-### Added
-- test(e2e): wrapper coverage for the three IaC tools — `bicep-iac` (#663), `infracost` (#664), `terraform-iac` (#665). New file `tests/e2e/Batch6-IaC.E2E.Tests.ps1` plus three deterministic fixtures under `tests/e2e/fixtures/` feed per-tool wrapper output through `Invoke-E2EPipeline`, asserting results.json shape, entities.json v3.1 envelope with at least one `Repository` entity (canonicalised via `ConvertTo-CanonicalEntityId`), EntityType enum compliance, severity enum, HTML/MD render, and credential-scrub of planted GitHub PAT + Bearer JWT. Backs the `covered` status already recorded in `docs/audits/e2e-wrapper-coverage-parity.json` (E2E-032/033/034). Baseline preserved.
-
 ### Fixed
-
-- Fix zizmor exit code 2 handling and pass GITHUB_TOKEN to scorecard in live runs (#768).
-- Address 4 Copilot review concerns from #721 (#767).
 - Restore env/global state in BeforeAll/AfterAll across test suite (#746).
-* Remove 9 expired docs-restructure redirect stubs now that module version reached 1.1.0 (cleared `Check redirect stub deadline` failure that blocked all open PRs).
 
 ## [1.1.0](https://github.com/martinopedal/azure-analyzer/compare/v1.0.0...v1.1.0) (2026-04-23)
 


### PR DESCRIPTION
Removes entries duplicated in 1.1.1 release notes. Addresses Copilot review on #789. After this lands, release-please will regenerate #789 with a clean Unreleased baseline.