### PR TITLE
fix(lychee): exclude unreleased v1.1.1 compare link to unblock release PR #789

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -34,6 +34,8 @@ exclude = [
   "^https://keda\\.sh",
   # release-please compare link for v1.1.0 references non-existent v1.0.0 tag (first release)
   "^https://github\\.com/martinopedal/azure-analyzer/compare/v1\\.0\\.0",
+  # release-please compare link for v1.1.1 references not-yet-created v1.1.1 tag during release PR window
+  "^https://github\\.com/martinopedal/azure-analyzer/compare/v1\\.1\\.0\\.\\.\\.v1\\.1\\.1",
   # Loopback / placeholder hosts
   "^https?://(localhost|127\\.|0\\.0\\.0\\.0|example\\.(com|org|net))",
   "^file:///.*?/\\.copilot/skills/humanizer/url$",


### PR DESCRIPTION
## Closes

N/A (no tracked issue, type=fix)

## Summary

Excludes the not-yet-existing `v1.1.0...v1.1.1` compare URL from lychee, mirroring the existing `v1.0.0` exclusion. The release-please CHANGELOG generated for v1.1.1 references a compare link to a tag that only gets created after the release PR merges. This blocks the `links (lychee)` required check on release-please PR #789, creating a deadlock.

## Verification

- Ran `lychee` rules against the new exclusion: pattern matches the failing URL.
- Once merged, release-please will refresh PR #789 with the new `.lychee.toml` and the `links (lychee)` check will pass.

## Docs

- `.lychee.toml` updated with inline comment explaining the exclusion (matches the v1.0.0 entry's style).
- No CHANGELOG.md edit (release-please owns that file).