### PR TITLE
test: add back-to-back meta-test for test isolation (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Wrapper fallback error shims now mirror full `modules/shared/Errors.ps1` behavior (Category validation, Remove-Credentials sanitization, TimestampUtc) so errors remain consistent/sanitized even when shared modules fail to load.
 - CON-004 ratchet test now strictly enforces `SupportsShouldProcess` enabled (rejects `=$false`) and requires an actual `$PSCmdlet.ShouldProcess(` invocation (not just a mention in a comment).
 
+### Tests
+- Add back-to-back meta-test in `tests/shared/TestIsolation.Tests.ps1` to detect cross-file state leaks. Runs a subset of the test suite twice in the same pwsh process and asserts identical PassedCount/FailedCount. Gated behind `$env:AZURE_ANALYZER_RUN_ISOLATION_META_TEST=1`. (Closes #746)
+
 # Changelog
 
 All notable changes to azure-analyzer will be documented here.

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,3 +48,48 @@ Do NOT:
 - Remove `Write-Warning` from production code to make tests quieter — those
   warnings fire correctly for real users.
 - Let `WARNING:` lines accumulate in CI test output. Treat them as regressions.
+
+## Test isolation (#746)
+
+Every test file MUST restore any environment variables, global variables, or
+module-scope state that it mutates. Shared-process test runners (macOS/Linux
+runners, local `Invoke-Pester` across multiple files) will leak state from
+earlier files into later ones, causing order-dependent flakes.
+
+**Required pattern:**
+```powershell
+BeforeAll {
+    # Capture prior state
+    $script:_origFoo = $env:FOO
+    $env:FOO = 'test-value'
+}
+
+AfterAll {
+    # Restore prior state
+    if ($null -eq $script:_origFoo) {
+        Remove-Item Env:FOO -ErrorAction SilentlyContinue
+    } else {
+        $env:FOO = $script:_origFoo
+    }
+}
+```
+
+**Guard test:** `tests/shared/TestIsolation.Tests.ps1` scans all test files
+for `$env:*` and `$global:*` writes and asserts that matching cleanup blocks
+exist. Add new exemptions to `$script:Exemptions` ONLY with written
+justification. The guard also includes a meta-test (gated behind
+`$env:AZURE_ANALYZER_RUN_ISOLATION_META_TEST=1`) that runs a subset of the
+suite twice back-to-back and asserts identical PassedCount, detecting leaks
+that the static heuristic might miss.
+
+**Common state to restore:**
+- Environment variables: `$env:*`
+- Global variables: `$global:*` (excluding `$global:LASTEXITCODE`, auto-managed)
+- Script-scope variables shared across `It` blocks
+- `$PSDefaultParameterValues`
+- Preference variables (`$ErrorActionPreference`, `$WarningPreference`, etc.)
+  set at module scope
+
+**File-scoped mutations are safe:** `Set-StrictMode -Version Latest` and
+`$ErrorActionPreference = 'Stop'` at the top of a `.Tests.ps1` file are
+automatically scoped to that file and do not leak.

--- a/tests/shared/TestIsolation.Tests.ps1
+++ b/tests/shared/TestIsolation.Tests.ps1
@@ -123,4 +123,29 @@ Describe 'Test isolation guard (#746)' -Tag 'isolation' {
 
         $offenders -join "`n" | Should -BeNullOrEmpty -Because "use [System.IO.Path]::GetTempPath() instead of literal '/tmp'; offenders:`n$($offenders -join "`n")"
     }
+
+    It 'back-to-back test runs produce identical PassedCount (detects cross-file state leaks)' -Skip:(-not ($env:AZURE_ANALYZER_RUN_ISOLATION_META_TEST -in @('1', 'true', 'yes', 'on'))) {
+        # This meta-test runs a subset of the test suite twice in the same
+        # pwsh process and asserts that PassedCount is identical. A difference
+        # signals that some test file is leaking state (env vars, globals,
+        # module-scope variables, PSDefaultParameterValues, etc.) that affects
+        # downstream tests in the second run.
+        #
+        # Gated behind AZURE_ANALYZER_RUN_ISOLATION_META_TEST=1 to avoid
+        # exploding CI time. Enable locally via:
+        #   $env:AZURE_ANALYZER_RUN_ISOLATION_META_TEST = '1'
+        #   Invoke-Pester -Path tests/shared/TestIsolation.Tests.ps1
+
+        $testPaths = @(
+            (Join-Path $script:TestsRoot 'shared')
+            (Join-Path $script:TestsRoot 'normalizers')
+            (Join-Path $script:TestsRoot 'wrappers')
+        )
+
+        $run1 = Invoke-Pester -Path $testPaths -PassThru -Output None
+        $run2 = Invoke-Pester -Path $testPaths -PassThru -Output None
+
+        $run1.PassedCount | Should -Be $run2.PassedCount -Because "back-to-back runs must have identical PassedCount; run1=$($run1.PassedCount) run2=$($run2.PassedCount). Difference signals a state leak."
+        $run1.FailedCount | Should -Be $run2.FailedCount -Because "back-to-back runs must have identical FailedCount; run1=$($run1.FailedCount) run2=$($run2.FailedCount). Difference signals a state leak."
+    }
 }


### PR DESCRIPTION
## Summary

Add meta-test in TestIsolation.Tests.ps1 that runs a subset of the test suite twice in the same pwsh process and asserts identical PassedCount/FailedCount to detect cross-file state leaks.

## Changes

1. **Enhanced TestIsolation.Tests.ps1** — Added a new gated meta-test that:
   - Runs shared/, normalizers/, and wrappers/ tests twice back-to-back in the same session
   - Asserts identical PassedCount and FailedCount between runs
   - Detects state leaks (env vars, globals, module-scope variables) that the static heuristic might miss
   - Gated behind `AZURE_ANALYZER_RUN_ISOLATION_META_TEST=1` to avoid exploding CI runtime

2. **Updated tests/README.md** — Added comprehensive test isolation documentation covering:
   - Required BeforeAll/AfterAll restore pattern
   - Common state types that must be restored (env vars, globals, preferences)
   - Reference to the TestIsolation guard test
   - Clarification that file-scoped mutations are safe

3. **Updated CHANGELOG.md** — Added entry in Unreleased/Tests section

## Verification

All existing TestIsolation guard tests pass:
- ✅ Every test file that writes `$env:*` has lifecycle cleanup
- ✅ Every test file that writes `$global:*` has lifecycle cleanup  
- ✅ No test files use literal `/tmp` path
- ✅ New meta-test skipped by default (requires gate env var)

## Notes

**Audit findings:** The comprehensive audit of all test files shows that the test isolation issues mentioned in #746 have already been addressed. All files that mutate environment or global state properly restore it in AfterAll/AfterEach blocks. The existing static guard test catches violations.

This PR adds a **runtime detection layer** on top of the static heuristic to catch edge cases where state might leak despite passing the static checks.

Closes #746
