### PR TITLE
fix(scripts): guard Backfill-ChangelogCitations against null SortedBoundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- **Backfill-ChangelogCitations null guard:** `Get-VersionForCommit` now returns 'Unreleased' early when `$SortedBoundaries` is null or empty, fixing `PropertyNotFoundException` on `.Count` in CI. Caller wraps pipeline output in `@()` to guarantee array type.
 - **HTML report determinism**: Entity-type bar chart and heatmap JSON had non-deterministic ordering across process invocations due to PowerShell `@{}` hashtable key randomization. Converted 11 hashtables feeding `ConvertTo-Json` to `[ordered]@{}`, added alphabetical tiebreaker to entity-type sort, replaced `.ContainsKey()` with `.Contains()` for `OrderedDictionary` compat. Regenerated SampleDrift fixture. Root cause existed since entity bars were introduced; exposed by SampleDrift drift canary.
 - **DocsCheck tests**: Added missing Pester assertions for `docs/design` path and other documentation path patterns (`copilot/audits`, `.squad/decisions`, `.squad/ceremonies.md`, root-level docs). PR #941 added `docs/design` to the docs-check workflow but the test file was not updated. Fixes M4 from 24h CI audit. Closes #945, #943, #942, #939, #936, #935, #934, #933.
 - **Shared helper**: Converted `modules/shared/New-WrapperEnvelope.ps1` from standalone script (with top-level `param()`) to pure function definition. Eliminates phantom object emission when dot-sourced, fixing Invoke-Maester double-return (M1) and Errors.Regression529 child-process crash (M3). (#907)

--- a/scripts/Backfill-ChangelogCitations.ps1
+++ b/scripts/Backfill-ChangelogCitations.ps1
@@ -96,6 +96,10 @@ function Get-VersionForCommit {
         [array]$SortedBoundaries   # @( @{Tag='v1.0.0'; Date=...}, ... )
     )
 
+    if (-not $SortedBoundaries -or $SortedBoundaries.Count -eq 0) {
+        return 'Unreleased'
+    }
+
     for ($i = $SortedBoundaries.Count - 1; $i -ge 0; $i--) {
         $b = $SortedBoundaries[$i]
         if ($CommitDate -le $b.Date) {
@@ -217,9 +221,9 @@ $citedPerSection = Get-CitedPRsPerSection -Lines $originalLines
 
 Write-Verbose "Collecting tag boundaries..."
 $tagDates = Get-TagDates
-$sortedBoundaries = $tagDates.GetEnumerator() |
+$sortedBoundaries = @($tagDates.GetEnumerator() |
     Sort-Object Value |
-    ForEach-Object { [PSCustomObject]@{ Tag = $_.Key; Date = $_.Value } }
+    ForEach-Object { [PSCustomObject]@{ Tag = $_.Key; Date = $_.Value } })
 
 Write-Verbose "Walking git log for PR references..."
 $commits = Get-CommitsWithPRs


### PR DESCRIPTION
Get-VersionForCommit returns 'Unreleased' early when \\\ is null or empty. Caller wraps pipeline output in \@()\ to guarantee array type.

Fixes \PropertyNotFoundException\ on \.Count\ that breaks Pester CI on ubuntu and windows.

**Root cause:** PowerShell pipeline with 0 results produces \\\, not an empty array. The \[array]\ type constraint on the parameter doesn't help when the caller passes \\\ from an empty pipeline.

**Two fixes:**
1. Callee guard: early return when \\\ is null/empty (line 99)
2. Caller wrap: \@()\ around pipeline output guarantees array type (line 220)

Fixes #959