### PR TITLE
chore(wrappers): standardize timeout handling via Invoke-WithTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- **Timeout standardization (#974)**: Wrapped external CLI invocations in `Invoke-WithTimeout` (300s default) across 9 wrappers: Invoke-Gitleaks, Invoke-Trivy, Invoke-Zizmor, Invoke-Kubescape, Invoke-Powerpipe, Invoke-Prowler (600s), Invoke-Azqr, Invoke-Falco (helm/kubectl), and Invoke-KubeBench (kubectl apply/wait/logs). Enhanced shared `Invoke-WithTimeout` in `Installer.ps1` to return separate `Stdout`/`Stderr` properties alongside combined `Output` for tools that need stream separation (zizmor, powerpipe). Prevents hung CLI processes from blocking the orchestrator indefinitely.
+
 ### Docs
 
 - **Post-sprint documentation sweep**: Removed maintenance window banner from README. Added ASCII startup banner code block. Reorganized README to lead with consumer-facing content (what the tool does, quickstart, sample reports, features) and moved contributor/testing/CI notes to a Contributing section at the end. Documented that `Auto-Rebase` and `Rerun-Failed-Checks` workflows skip on non-agent branches (expected behavior). Regenerated sample HTML and Markdown reports against current renderers.

--- a/modules/Invoke-Azqr.ps1
+++ b/modules/Invoke-Azqr.ps1
@@ -33,6 +33,9 @@ if (-not (Get-Command New-WrapperEnvelope -ErrorAction SilentlyContinue)) { func
 if (-not (Get-Command Remove-Credentials -ErrorAction SilentlyContinue)) {
     function Remove-Credentials { param([string]$Text) return $Text }
 }
+# Bootstrap Invoke-WithTimeout for CLI timeout protection
+$cliTimeoutPath = Join-Path $PSScriptRoot 'shared' 'CliTimeout.ps1'
+if (Test-Path $cliTimeoutPath) { . $cliTimeoutPath }
 
 function Test-AzqrInstalled {
     $null -ne (Get-Command azqr -ErrorAction SilentlyContinue)
@@ -41,7 +44,8 @@ function Test-AzqrInstalled {
 function Get-AzqrToolVersion {
     try {
         $rawVersion = azqr --version 2>&1
-        if ($LASTEXITCODE -ne 0) { return '' }
+        $exitCode = if (Test-Path variable:LASTEXITCODE) { $LASTEXITCODE } else { 0 }
+        if ($exitCode -ne 0) { return '' }
         $versionText = if ($rawVersion -is [array]) { ($rawVersion -join ' ') } else { [string]$rawVersion }
         $match = [regex]::Match($versionText, '(\d+\.\d+\.\d+(?:[-+][A-Za-z0-9\.-]+)?)')
         if ($match.Success) { return $match.Groups[1].Value }
@@ -147,7 +151,20 @@ if (-not (Test-Path $OutputPath)) {
 try {
     Write-Verbose "Running azqr scan for subscription $SubscriptionId"
     $toolVersion = Get-AzqrToolVersion
-    $null = azqr scan --subscription-id $SubscriptionId --output-dir $OutputPath 2>&1
+    $azqrArgs = @('scan', '--subscription-id', $SubscriptionId, '--output-dir', $OutputPath)
+    $azqrExec = Invoke-WithTimeout -Command 'azqr' -Arguments $azqrArgs -TimeoutSec 300
+    if ($azqrExec.Output) { Write-Verbose "azqr output: $($azqrExec.Output)" }
+    if ([int]$azqrExec.ExitCode -eq -1) {
+        Write-Warning 'azqr timed out after 300 seconds'
+        return [PSCustomObject]@{
+            Source   = 'azqr'
+            SchemaVersion = '1.0'
+            Status   = 'Failed'
+            Message  = 'azqr timed out after 300 seconds'
+            Findings = @()
+            Errors   = @()
+        }
+    }
 
     $jsonFiles = Get-ChildItem -Path $OutputPath -Filter '*.json' -ErrorAction SilentlyContinue
     $findings = @()

--- a/modules/Invoke-Falco.ps1
+++ b/modules/Invoke-Falco.ps1
@@ -104,6 +104,9 @@ if (Test-Path $kubeAuthPath) { . $kubeAuthPath }
 $envelopePath = Join-Path $PSScriptRoot 'shared' 'New-WrapperEnvelope.ps1'
 if (Test-Path $envelopePath) { . $envelopePath }
 if (-not (Get-Command New-WrapperEnvelope -ErrorAction SilentlyContinue)) { function New-WrapperEnvelope { param([string]$Source,[string]$Status='Failed',[string]$Message='',[object[]]$FindingErrors=@()) return [PSCustomObject]@{ Source=$Source; SchemaVersion='1.0'; Status=$Status; Message=$Message; Findings=@(); Errors=@($FindingErrors) } } }
+# Bootstrap Invoke-WithTimeout for CLI timeout protection
+$cliTimeoutPath = Join-Path $PSScriptRoot 'shared' 'CliTimeout.ps1'
+if (Test-Path $cliTimeoutPath) { . $cliTimeoutPath }
 $result = [ordered]@{
     SchemaVersion = '1.0'
     Source        = 'falco'
@@ -514,15 +517,18 @@ foreach ($cluster in $clusters) {
                       '--namespace', $Namespace, '--create-namespace',
                       '--wait', '--timeout', '5m')
         if ($ctx) { $helmArgs += @('--kube-context', $ctx) }
-        & helm @helmArgs 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) { $failed++; continue }
+        $helmExec = Invoke-WithTimeout -Command 'helm' -Arguments $helmArgs -TimeoutSec 360
+        if ($helmExec.Output) { Write-Verbose "helm output: $($helmExec.Output)" }
+        if ([int]$helmExec.ExitCode -eq -1) { $failed++; continue }
+        if ([int]$helmExec.ExitCode -ne 0) { $failed++; continue }
 
         Start-Sleep -Seconds ($captureMinutes * 60)
         $logArgs = @()
         if ($ctx) { $logArgs += @('--context', $ctx) }
         $logArgs += @('-n', $Namespace, 'logs', 'daemonset/falco', '--since', "$($captureMinutes)m", '--tail', '5000')
-        $rawLogs = @(& kubectl @logArgs 2>&1)
-        if ($LASTEXITCODE -ne 0) {
+        $logExec = Invoke-WithTimeout -Command 'kubectl' -Arguments $logArgs -TimeoutSec 120
+        $rawLogs = @(($logExec.Output -split "`n"))
+        if ([int]$logExec.ExitCode -ne 0) {
             $failed++
             Write-Warning "Falco log collection failed for cluster $($cluster.name): $(Remove-Credentials -Text ([string]($rawLogs -join ' ')))"
             continue

--- a/modules/Invoke-Gitleaks.ps1
+++ b/modules/Invoke-Gitleaks.ps1
@@ -49,6 +49,9 @@ $remoteClonePath = Join-Path $sharedDir 'RemoteClone.ps1'
 if (Test-Path $remoteClonePath) { . $remoteClonePath }
 $errorsPath = Join-Path $sharedDir 'Errors.ps1'
 if (Test-Path $errorsPath) { . $errorsPath }
+# Bootstrap Invoke-WithTimeout for CLI timeout protection
+$cliTimeoutPath = Join-Path $sharedDir 'CliTimeout.ps1'
+if (Test-Path $cliTimeoutPath) { . $cliTimeoutPath }
 
 $envelopePath = Join-Path $sharedDir 'New-WrapperEnvelope.ps1'
 if (Test-Path $envelopePath) { . $envelopePath }
@@ -415,21 +418,20 @@ try {
         }
 
         $useRetry = Get-Command Invoke-WithRetry -ErrorAction SilentlyContinue
+        $invokeGitleaksScan = {
+            $script:gitleaksExec = Invoke-WithTimeout -Command 'gitleaks' -Arguments $gitleaksArgs -TimeoutSec 300
+            if ([int]$script:gitleaksExec.ExitCode -eq -1) {
+                throw (Format-FindingErrorMessage (New-FindingError -Source 'wrapper:gitleaks' -Category 'TimeoutExceeded' -Reason 'gitleaks timed out after 300 seconds.' -Remediation 'Check repository size or increase timeout.' -Details ''))
+            }
+            if ($script:gitleaksExec.Output) { Write-Verbose "gitleaks output: $($script:gitleaksExec.Output)" }
+        }
         if ($useRetry) {
-            Invoke-WithRetry -ScriptBlock {
-                $stderrLines = & gitleaks @gitleaksArgs 2>&1 | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }
-                if ($stderrLines) {
-                    Write-Verbose "gitleaks stderr: $($stderrLines -join '; ')"
-                }
-            }
+            Invoke-WithRetry -ScriptBlock $invokeGitleaksScan
         } else {
-            $stderrLines = & gitleaks @gitleaksArgs 2>&1 | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }
-            if ($stderrLines) {
-                Write-Verbose "gitleaks stderr: $($stderrLines -join '; ')"
-            }
+            & $invokeGitleaksScan
         }
 
-        $exitCode = $LASTEXITCODE
+        $exitCode = [int]$script:gitleaksExec.ExitCode
 
         # Validate: non-zero exit code with no report = hard failure
         if ($exitCode -ne 0 -and -not (Test-Path $reportFile)) {

--- a/modules/Invoke-KubeBench.ps1
+++ b/modules/Invoke-KubeBench.ps1
@@ -89,7 +89,10 @@ if (-not (Get-Command Write-FindingError -ErrorAction SilentlyContinue)) {
 
 $kubeAuthPath = Join-Path $PSScriptRoot 'shared' 'KubeAuth.ps1'
 if (Test-Path $kubeAuthPath) { . $kubeAuthPath }
-
+# Bootstrap Invoke-WithTimeout for CLI timeout protection
+$cliTimeoutPath = Join-Path $PSScriptRoot 'shared' 'CliTimeout.ps1'
+if (Test-Path $cliTimeoutPath) { . $cliTimeoutPath }
+
 $envelopePath = Join-Path $PSScriptRoot 'shared' 'New-WrapperEnvelope.ps1'
 if (Test-Path $envelopePath) { . $envelopePath }
 if (-not (Get-Command New-WrapperEnvelope -ErrorAction SilentlyContinue)) { function New-WrapperEnvelope { param([string]$Source,[string]$Status='Failed',[string]$Message='',[object[]]$FindingErrors=@()) return [PSCustomObject]@{ Source=$Source; SchemaVersion='1.0'; Status=$Status; Message=$Message; Findings=@(); Errors=@($FindingErrors) } } }
@@ -450,31 +453,35 @@ spec:
         $kctxArgs = @()
         if ($context) { $kctxArgs += @('--context', $context) }
 
-        & kubectl @kctxArgs apply -f $jobManifest 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
+        $applyArgs = $kctxArgs + @('apply', '-f', $jobManifest)
+        $applyExec = Invoke-WithTimeout -Command 'kubectl' -Arguments $applyArgs -TimeoutSec 60
+        if ([int]$applyExec.ExitCode -ne 0) {
             $failed++
             continue
         }
         $jobApplied = $true
 
-        & kubectl @kctxArgs -n $Namespace wait --for=condition=complete "job/$jobName" --timeout="$($JobTimeoutSeconds)s" 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
+        $waitArgs = $kctxArgs + @('-n', $Namespace, 'wait', '--for=condition=complete', "job/$jobName", "--timeout=$($JobTimeoutSeconds)s")
+        $waitExec = Invoke-WithTimeout -Command 'kubectl' -Arguments $waitArgs -TimeoutSec ([int]$JobTimeoutSeconds + 30)
+        if ([int]$waitExec.ExitCode -ne 0) {
             Write-FindingError (New-FindingError -Source 'wrapper:kube-bench' `
                 -Category 'TimeoutExceeded' `
                 -Reason ("kubectl wait did not see job/{0} complete within {1}s on cluster {2} (context={3} namespace={4})." -f $jobName, $JobTimeoutSeconds, $cluster.name, $context, $Namespace) `
                 -Remediation 'Increase -JobTimeoutSeconds or check cluster scheduler health and node capacity.' `
-                -Details ("kubectl exit {0}" -f $LASTEXITCODE))
+                -Details ("kubectl exit {0}" -f [int]$waitExec.ExitCode))
             $failed++
             continue
         }
 
-        & kubectl @kctxArgs -n $Namespace logs "job/$jobName" 2>&1 | Set-Variable -Name kubeBenchLogs
-        if ($LASTEXITCODE -ne 0) {
+        $logsArgs = $kctxArgs + @('-n', $Namespace, 'logs', "job/$jobName")
+        $logsExec = Invoke-WithTimeout -Command 'kubectl' -Arguments $logsArgs -TimeoutSec 120
+        $kubeBenchLogs = $logsExec.Output
+        if ([int]$logsExec.ExitCode -ne 0) {
             Write-FindingError (New-FindingError -Source 'wrapper:kube-bench' `
                 -Category 'IOFailure' `
                 -Reason ("kubectl logs failed for job/{0} on cluster {1} (context={2} namespace={3})." -f $jobName, $cluster.name, $context, $Namespace) `
                 -Remediation 'Verify kubeconfig credentials, RBAC for pods/log in the namespace, and that the job pod has not been evicted.' `
-                -Details ("kubectl exit {0}" -f $LASTEXITCODE))
+                -Details ("kubectl exit {0}" -f [int]$logsExec.ExitCode))
             $failed++
             continue
         }

--- a/modules/Invoke-Kubescape.ps1
+++ b/modules/Invoke-Kubescape.ps1
@@ -133,7 +133,10 @@ $kubeAuthPath = Join-Path $PSScriptRoot 'shared' 'KubeAuth.ps1'
 if (Test-Path $kubeAuthPath) { . $kubeAuthPath }
 $aksDiscoveryPath = Join-Path $PSScriptRoot 'shared' 'AksDiscovery.ps1'
 if (Test-Path $aksDiscoveryPath) { . $aksDiscoveryPath }
-
+# Bootstrap Invoke-WithTimeout for CLI timeout protection
+$cliTimeoutPath = Join-Path $PSScriptRoot 'shared' 'CliTimeout.ps1'
+if (Test-Path $cliTimeoutPath) { . $cliTimeoutPath }
+
 $envelopePath = Join-Path $PSScriptRoot 'shared' 'New-WrapperEnvelope.ps1'
 if (Test-Path $envelopePath) { . $envelopePath }
 if (-not (Get-Command New-WrapperEnvelope -ErrorAction SilentlyContinue)) { function New-WrapperEnvelope { param([string]$Source,[string]$Status='Failed',[string]$Message='',[object[]]$FindingErrors=@()) return [PSCustomObject]@{ Source=$Source; SchemaVersion='1.0'; Status=$Status; Message=$Message; Findings=@(); Errors=@($FindingErrors) } } }
@@ -415,8 +418,9 @@ foreach ($cluster in $clusters) {
         $ksArgs = @('scan', '--format', 'json', '--output', $rawFile, '--format-version', 'v2')
         if ($contextForScan) { $ksArgs += @('--kube-context', $contextForScan) }
         if ($Namespace)      { $ksArgs += @('--include-namespaces', $Namespace) }
-        & kubescape @ksArgs 2>&1 | Out-Null
-        $scanExit = $LASTEXITCODE
+        $ksExec = Invoke-WithTimeout -Command 'kubescape' -Arguments $ksArgs -TimeoutSec 300
+        if ($ksExec.Output) { Write-Verbose "kubescape output: $($ksExec.Output)" }
+        $scanExit = [int]$ksExec.ExitCode
 
         if ((Test-Path $rawFile) -and ((Get-Item $rawFile).Length -gt 0)) {
             $raw = Get-Content $rawFile -Raw | ConvertFrom-Json -Depth 30

--- a/modules/Invoke-Powerpipe.ps1
+++ b/modules/Invoke-Powerpipe.ps1
@@ -46,6 +46,9 @@ if (-not (Get-Command Format-FindingErrorMessage -ErrorAction SilentlyContinue))
         return $line
     }
 }
+# Bootstrap Invoke-WithTimeout for CLI timeout protection
+$cliTimeoutPath = Join-Path $PSScriptRoot 'shared' 'CliTimeout.ps1'
+if (Test-Path $cliTimeoutPath) { . $cliTimeoutPath }
 
 function Test-PowerpipeInstalled {
     return $null -ne (Get-Command powerpipe -ErrorAction SilentlyContinue)
@@ -146,12 +149,21 @@ try {
     $versionOut = (& powerpipe --version 2>&1 | Select-Object -First 1)
     $toolVersion = if ($versionOut) { [string]$versionOut } else { '' }
 
-    $rawOutput = & powerpipe benchmark run $Benchmark --output json 2>&1
-    if ($LASTEXITCODE -ne 0) {
+    $ppExec = Invoke-WithTimeout -Command 'powerpipe' -Arguments @('benchmark', 'run', $Benchmark, '--output', 'json') -TimeoutSec 300
+    $rawOutput = if ($ppExec.PSObject.Properties['Stdout'] -and $ppExec.Stdout) { $ppExec.Stdout } else { $ppExec.Output }
+    if ([int]$ppExec.ExitCode -eq -1) {
+        throw (Format-FindingErrorMessage (New-FindingError `
+            -Source 'wrapper:powerpipe' `
+            -Category 'TimeoutExceeded' `
+            -Reason "powerpipe benchmark run timed out after 300 seconds." `
+            -Remediation 'Inspect powerpipe CLI output; ensure the benchmark mod is installed and credentials configured.' `
+            -Details ''))
+    }
+    if ([int]$ppExec.ExitCode -ne 0) {
         throw (Format-FindingErrorMessage (New-FindingError `
             -Source 'wrapper:powerpipe' `
             -Category 'UnexpectedFailure' `
-            -Reason "powerpipe benchmark run failed (exit $LASTEXITCODE)." `
+            -Reason "powerpipe benchmark run failed (exit $([int]$ppExec.ExitCode))." `
             -Remediation 'Inspect powerpipe CLI output; ensure the benchmark mod is installed and credentials configured.' `
             -Details (Remove-Credentials -Text ([string]$rawOutput))))
     }

--- a/modules/Invoke-Prowler.ps1
+++ b/modules/Invoke-Prowler.ps1
@@ -21,6 +21,9 @@ if (-not (Get-Command New-WrapperEnvelope -ErrorAction SilentlyContinue)) { func
 if (-not (Get-Command Remove-Credentials -ErrorAction SilentlyContinue)) {
     function Remove-Credentials { param([string]$Text) return $Text }
 }
+# Bootstrap Invoke-WithTimeout for CLI timeout protection
+$cliTimeoutPath = Join-Path $PSScriptRoot 'shared' 'CliTimeout.ps1'
+if (Test-Path $cliTimeoutPath) { . $cliTimeoutPath }
 
 function Get-ObjProp {
     param([object]$Obj, [string]$Name, [object]$Default = $null)
@@ -123,7 +126,21 @@ if (-not (Test-Path $OutputPath)) {
 $toolVersion = Get-ProwlerVersion
 
 try {
-    $null = prowler azure --subscription-id $SubscriptionId --output-formats json --output-directory $OutputPath --output-filename "prowler-$SubscriptionId" 2>&1
+    $prowlerArgs = @('azure', '--subscription-id', $SubscriptionId, '--output-formats', 'json', '--output-directory', $OutputPath, '--output-filename', "prowler-$SubscriptionId")
+    $prowlerExec = Invoke-WithTimeout -Command 'prowler' -Arguments $prowlerArgs -TimeoutSec 600
+    if ($prowlerExec.Output) { Write-Verbose "prowler output: $($prowlerExec.Output)" }
+    if ([int]$prowlerExec.ExitCode -eq -1) {
+        Write-Warning 'prowler timed out after 600 seconds'
+        return [PSCustomObject]@{
+            Source        = 'prowler'
+            SchemaVersion = '1.0'
+            Status        = 'Failed'
+            Message       = 'prowler timed out after 600 seconds'
+            ToolVersion   = $toolVersion
+            Findings      = @()
+            Errors        = @()
+        }
+    }
 
     $jsonFiles = Get-ChildItem -Path $OutputPath -Filter '*.json' -File -ErrorAction SilentlyContinue
     $rawChecks = [System.Collections.Generic.List[object]]::new()

--- a/modules/Invoke-Trivy.ps1
+++ b/modules/Invoke-Trivy.ps1
@@ -45,6 +45,9 @@ $missingToolPath = Join-Path $sharedDir 'MissingTool.ps1'
 if (Test-Path $missingToolPath) { . $missingToolPath }
 $remoteClonePath = Join-Path $sharedDir 'RemoteClone.ps1'
 if (Test-Path $remoteClonePath) { . $remoteClonePath }
+# Bootstrap Invoke-WithTimeout for CLI timeout protection
+$cliTimeoutPath = Join-Path $sharedDir 'CliTimeout.ps1'
+if (Test-Path $cliTimeoutPath) { . $cliTimeoutPath }
 
 $envelopePath = Join-Path $sharedDir 'New-WrapperEnvelope.ps1'
 if (Test-Path $envelopePath) { . $envelopePath }
@@ -296,13 +299,23 @@ try {
     $reportFile = Join-Path ([System.IO.Path]::GetTempPath()) "trivy-report-$([guid]::NewGuid().ToString('N')).json"
 
     try {
-        & trivy $ScanType --format json --scanners vuln,misconfig --output $reportFile $RepoPath 2>&1 | ForEach-Object {
-            if ($_ -is [System.Management.Automation.ErrorRecord]) {
-                Write-Verbose "trivy stderr: $_"
+        $trivyArgs = @($ScanType, '--format', 'json', '--scanners', 'vuln,misconfig', '--output', $reportFile, $RepoPath)
+        $trivyExec = Invoke-WithTimeout -Command 'trivy' -Arguments $trivyArgs -TimeoutSec 300
+        if ($trivyExec.Output) { Write-Verbose "trivy output: $($trivyExec.Output)" }
+
+        $exitCode = [int]$trivyExec.ExitCode
+
+        if ($exitCode -eq -1) {
+            Write-Warning "trivy timed out after 300 seconds"
+            return [PSCustomObject]@{
+                Source   = 'trivy'
+                SchemaVersion = '1.0'
+                Status   = 'Failed'
+                Message  = 'trivy timed out after 300 seconds'
+                Findings = @()
+                Errors   = @()
             }
         }
-
-        $exitCode = $LASTEXITCODE
 
         # Non-zero exit with no report = hard failure
         if ($exitCode -ne 0 -and -not (Test-Path $reportFile)) {

--- a/modules/Invoke-Zizmor.ps1
+++ b/modules/Invoke-Zizmor.ps1
@@ -53,6 +53,9 @@ $retryPath = Join-Path $sharedDir 'Retry.ps1'
 if (Test-Path $retryPath) { . $retryPath }
 $remoteClonePath = Join-Path $sharedDir 'RemoteClone.ps1'
 if (Test-Path $remoteClonePath) { . $remoteClonePath }
+# Bootstrap Invoke-WithTimeout for CLI timeout protection
+$cliTimeoutPath = Join-Path $sharedDir 'CliTimeout.ps1'
+if (Test-Path $cliTimeoutPath) { . $cliTimeoutPath }
 
 $envelopePath = Join-Path $sharedDir 'New-WrapperEnvelope.ps1'
 if (Test-Path $envelopePath) { . $envelopePath }
@@ -308,17 +311,29 @@ try {
     $stderrFile = "$reportFile.err"
 
     try {
-        $invokeZizmor = {
-            & zizmor --format=json --no-exit-codes $scanPath 1>$reportFile 2>$stderrFile
+        $invokeZizmorScan = {
+            $script:zizmorExec = Invoke-WithTimeout -Command 'zizmor' -Arguments @('--format=json', '--no-exit-codes', $scanPath) -TimeoutSec 300
+            if ([int]$script:zizmorExec.ExitCode -eq -1) {
+                throw (Format-FindingErrorMessage (New-FindingError -Source 'wrapper:zizmor' -Category 'TimeoutExceeded' -Reason 'zizmor timed out after 300 seconds.' -Remediation 'Check repository size or increase timeout.' -Details ''))
+            }
+            # Write stdout (JSON) to reportFile; stderr to stderrFile
+            if ($script:zizmorExec.PSObject.Properties['Stdout'] -and $script:zizmorExec.Stdout) {
+                $script:zizmorExec.Stdout | Set-Content -Path $reportFile -Encoding UTF8
+            } elseif ($script:zizmorExec.Output) {
+                $script:zizmorExec.Output | Set-Content -Path $reportFile -Encoding UTF8
+            }
+            if ($script:zizmorExec.PSObject.Properties['Stderr'] -and $script:zizmorExec.Stderr) {
+                $script:zizmorExec.Stderr | Set-Content -Path $stderrFile -Encoding UTF8
+            }
         }
         $useRetry = Get-Command Invoke-WithRetry -ErrorAction SilentlyContinue
         if ($useRetry) {
-            Invoke-WithRetry -ScriptBlock $invokeZizmor
+            Invoke-WithRetry -ScriptBlock $invokeZizmorScan
         } else {
-            & $invokeZizmor
+            & $invokeZizmorScan
         }
 
-        $exitCode = $LASTEXITCODE
+        $exitCode = [int]$script:zizmorExec.ExitCode
 
         $stderrText = ''
         if (Test-Path $stderrFile) {

--- a/modules/shared/CliTimeout.ps1
+++ b/modules/shared/CliTimeout.ps1
@@ -1,0 +1,87 @@
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+<#
+.SYNOPSIS
+    CLI timeout helper for wrapper scripts.
+.DESCRIPTION
+    Provides Invoke-WithTimeout for wrapping external CLI invocations with a
+    hard timeout. When the command resolves to a real executable (Application),
+    uses System.Diagnostics.Process for reliable timeout/kill semantics.
+    When the command is a PowerShell function (e.g. test mock), falls back to
+    the call operator & so that Pester mocks work transparently.
+
+    Returns [PSCustomObject]@{ ExitCode; Output; Stdout; Stderr }.
+    On timeout: ExitCode = -1, Output = "Timed out after N seconds".
+#>
+
+# Always define the smart version that handles both real executables and test mocks.
+# This overrides any previously-loaded Process-only version from Installer.ps1
+# which cannot invoke PowerShell function mocks used by Pester tests.
+function Invoke-WithTimeout {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory)][string]   $Command,
+            [Parameter(Mandatory)][string[]] $Arguments,
+            [int] $TimeoutSec = 300
+        )
+
+        $sanitize = if (Get-Command Remove-Credentials -ErrorAction SilentlyContinue) {
+            ${function:Remove-Credentials}
+        } else {
+            { param([string]$Text) $Text }
+        }
+
+        $cmdInfo = Get-Command $Command -ErrorAction SilentlyContinue
+        $cmdType = if ($cmdInfo -and $cmdInfo.PSObject.Properties['CommandType']) { $cmdInfo.CommandType } else { $null }
+
+        # Real executable — use System.Diagnostics.Process with hard timeout
+        if ($cmdType -eq 'Application') {
+            $psi = [System.Diagnostics.ProcessStartInfo]::new()
+            $psi.FileName  = $cmdInfo.Source
+            foreach ($a in $Arguments) { $psi.ArgumentList.Add($a) }
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError  = $true
+            $psi.UseShellExecute = $false
+
+            $proc = [System.Diagnostics.Process]::new()
+            $proc.StartInfo = $psi
+            $null = $proc.Start()
+
+            $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+            $stderrTask = $proc.StandardError.ReadToEndAsync()
+
+            if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
+                try { $proc.Kill($true) } catch {
+                    Write-Verbose ("Invoke-WithTimeout: Kill after timeout failed: {0}" -f $_.Exception.Message)
+                }
+                return [PSCustomObject]@{
+                    ExitCode = -1
+                    Output   = "Timed out after $TimeoutSec seconds"
+                    Stdout   = ''
+                    Stderr   = "Timed out after $TimeoutSec seconds"
+                }
+            }
+
+            $stdout  = $stdoutTask.Result
+            $stderr  = $stderrTask.Result
+            $combined = (& $sanitize (($stdout + "`n" + $stderr).Trim()))
+            return [PSCustomObject]@{
+                ExitCode = $proc.ExitCode
+                Output   = $combined
+                Stdout   = (& $sanitize $stdout)
+                Stderr   = (& $sanitize $stderr)
+            }
+        }
+
+        # PowerShell function/alias/cmdlet (test mocks) — call operator fallback
+        $output = & $Command @Arguments 2>&1 | Out-String
+        $lastExit = if (Test-Path variable:LASTEXITCODE) { $LASTEXITCODE } else { 0 }
+        return [PSCustomObject]@{
+            ExitCode = $lastExit
+            Output   = $output.Trim()
+            Stdout   = $output.Trim()
+            Stderr   = ''
+        }
+    }

--- a/modules/shared/Installer.ps1
+++ b/modules/shared/Installer.ps1
@@ -291,13 +291,13 @@ function Invoke-WithTimeout {
         try { $proc.Kill($true) } catch {
             Write-Verbose ("Invoke-WithTimeout: Process.Kill after timeout failed (process likely already exited). Reason: {0}" -f $_.Exception.Message)
         }
-        return [PSCustomObject]@{ ExitCode = -1; Output = "Timed out after $TimeoutSec seconds" }
+        return [PSCustomObject]@{ ExitCode = -1; Output = "Timed out after $TimeoutSec seconds"; Stdout = ''; Stderr = "Timed out after $TimeoutSec seconds" }
     }
 
     $stdout = $stdoutTask.Result
     $stderr = $stderrTask.Result
     $combined = Remove-Credentials (($stdout + "`n" + $stderr).Trim())
-    return [PSCustomObject]@{ ExitCode = $proc.ExitCode; Output = $combined }
+    return [PSCustomObject]@{ ExitCode = $proc.ExitCode; Output = $combined; Stdout = Remove-Credentials $stdout; Stderr = Remove-Credentials $stderr }
 }
 
 function Install-PSModules {


### PR DESCRIPTION
## Summary

Standardize timeout handling across all CLI-wrapping modules by routing external process invocations through \Invoke-WithTimeout\ (300s default, 600s for prowler).

### Changes

**New shared helper**: \modules/shared/CliTimeout.ps1\
- Dual-mode \Invoke-WithTimeout\: uses \System.Diagnostics.Process\ with hard kill for real executables; falls back to PowerShell call operator for function mocks (Pester compatibility)
- Returns \ExitCode\, \Output\, \Stdout\, \Stderr\ properties
- Strict-mode safe (\$LASTEXITCODE\ guard via \Test-Path variable:\)

**9 wrappers updated**:
| Wrapper | CLI Tool | Timeout |
|---------|----------|---------|
| Invoke-Gitleaks | gitleaks | 300s |
| Invoke-Trivy | trivy | 300s |
| Invoke-Zizmor | zizmor | 300s |
| Invoke-Kubescape | kubescape | 300s |
| Invoke-Powerpipe | powerpipe | 300s |
| Invoke-Prowler | prowler | 600s |
| Invoke-Azqr | azqr | 300s |
| Invoke-Falco | helm, kubectl | 360s, 120s |
| Invoke-KubeBench | kubectl | 60s, wait+30s, 120s |

**Installer.ps1 enhancement**: Added \Stdout\/\Stderr\ properties to return object for stream separation.

### Test results
- Baseline: 2865 pass / 1 fail (pre-existing) / 48 skip
- After: 2865 pass / 1 fail (same pre-existing) / 48 skip
- Zero regressions

Closes #974