### PR TITLE
fix(docs): drop stranded discussions/1049 broken link

### DIFF
--- a/.squad/orchestration-log/2026-05-12T13-00-13Z-forge-gpg-fix.md
+++ b/.squad/orchestration-log/2026-05-12T13-00-13Z-forge-gpg-fix.md
@@ -43,7 +43,6 @@ Replacement validator still:
 
 - **Fix PR:** [#1051](https://github.com/martinopedal/azure-analyzer/pull/1051)
 - **Source brief:** [Sage PSGallery research](https://github.com/martinopedal/azure-analyzer/issues/963)
-- **Source brief:** [Sage PSGallery research](https://github.com/martinopedal/azure-analyzer/discussions/1049)
 - **Blockers PR:** [#1049](https://github.com/martinopedal/azure-analyzer/pull/1049)
 - **Failed run:** [25735228356](https://github.com/martinopedal/azure-analyzer/actions/runs/25735228356)
 - **Success run:** [25735618882](https://github.com/martinopedal/azure-analyzer/actions/runs/25735618882)


### PR DESCRIPTION
Drops the stranded `discussions/1049` line from `.squad/orchestration-log/2026-05-12T13-00-13Z-forge-gpg-fix.md`.

## Closes
N/A (mechanical hotfix; lychee 404 introduced by `merge=union` keeping both old + new lines when PR #1054 rescued the stranded Scribe checkpoint into the already-fixed file)

## Impact
- Lychee passes again on every PR going forward
- Unblocks PR #1057 review CI

## Verification
- Diff is single-line deletion
- `Analyze (actions)` only required check