### PR TITLE
chore(squad): triage #1056 -- Option B, consume renderers directly

### DIFF
--- a/.squad/agents/lead/history.md
+++ b/.squad/agents/lead/history.md
@@ -154,4 +154,10 @@ Docs voice directive captured: neutralize AI language + emojis (checkmarks/cross
 
 Issue #963 closed. v1.4.5 published 2026-05-12 12:55:49 UTC. Users can now Install-Module -Name AzureAnalyzer -Repository PSGallery. PR #1051 fix (lightweight-tag-tolerant validator) merged; PR #1052 (v1.4.6 follow-up) auto-merge enabled. AzureAnalyzer is distributable; corporate air-gapped mirrors can now consume via Register-PSRepository.
 
+### 2026-05-13 - Track F helper modules gap triage (#1056), Option B
 
+- **Verdict:** Option B (consume renderer outputs directly, do not extract standalone helpers).
+- **Why:** The three "missing" modules (`EdgeRelations.ps1`, `Select-ReportArchitecture.ps1`, `PolicyCoverageAnalyzer.ps1`) are a naming mismatch, not a functionality gap. EdgeRelations enum is in Schema.ps1 (line 38, `Get-EdgeRelations` at line 670). `Select-ReportArchitecture` is in ReportManifest.ps1 (line 101). Policy coverage logic is in `modules/shared/Policy/AlzMatcher.ps1` + `PolicyEnforcementRenderer.ps1`. No code duplication worth extracting.
+- **Pattern for future triage:** When a multi-track plan references modules that were never separately broken out, check (1) whether the function exists under a different file path, (2) whether cross-consumer duplication exceeds ~20 lines, (3) whether test isolation improves with extraction. If all three are "no," choose plan-refactor over module-extraction. File-name assumptions in plans are stale faster than function signatures.
+- **Decision file:** `.squad/decisions/inbox/lead-1056-trackf-helper-modules.md`
+- **Unblocks:** Track F slices 2-9 (refs #506, #1048). Atlas owns implementation.

--- a/.squad/decisions/inbox/lead-1056-trackf-helper-modules.md
+++ b/.squad/decisions/inbox/lead-1056-trackf-helper-modules.md
@@ -1,0 +1,55 @@
+# Decision: Track F helper modules gap, Option B (consume renderers directly)
+
+## Date
+2026-05-13
+
+## Context
+
+Lead plan (`.copilot/audits/lead-track-f-impl-plan-2026-04-23.md` section 2) assumed three standalone helper modules would exist on main before Track F commit 3:
+
+- `modules/shared/EdgeRelations.ps1`
+- `modules/shared/Select-ReportArchitecture.ps1`
+- `modules/shared/PolicyCoverageAnalyzer.ps1`
+
+Tracks A/B/C/V landed renderers instead of standalone helpers. Atlas's dependency gate (commit 0) correctly flagged the gap. Issue #1056 filed. Commits 1-2 proceeded unblocked (PR #1066, merged).
+
+## Options considered
+
+**Option A:** Extract helper modules from existing renderers into standalone shared files matching the Lead plan's signatures. Refactor renderers to consume the helpers. Higher upfront cost, preserves planned architecture.
+
+**Option B:** Update the Lead plan to consume existing renderer outputs directly. Adjust commit 3+ to match the as-built architecture.
+
+## Decision
+
+Option B. Consume existing renderer and schema surfaces directly. The three "missing" modules are a naming mismatch, not a functionality gap.
+
+Evidence:
+
+1. EdgeRelations enum lives in `modules/shared/Schema.ps1` lines 38-66, exposed via `Get-EdgeRelations` (line 670). Both AttackPathRenderer.ps1 (line 105) and ResilienceMapRenderer.ps1 (line 125) read the canonical values. No standalone file needed.
+2. `Select-ReportArchitecture` lives in `modules/shared/ReportManifest.ps1` line 101. Already consumed by `Invoke-AzureAnalyzer.ps1` line 1642 and `modules/shared/Viewer.ps1` line 129. No standalone file needed.
+3. PolicyCoverageAnalyzer never existed. Policy gap analysis is covered by `modules/shared/Policy/AlzMatcher.ps1` (ALZ hierarchy fuzzy-match) and `modules/shared/Policy/PolicyEnforcementRenderer.ps1` (Cytoscape graph from policy edges). `Get-AuditorPolicyCoverageSection` consumes these directly.
+
+Cross-renderer edge-filtering duplication is ~10 lines per renderer (each filters by its own relation set). Extracting a shared filter saves trivial lines while adding a dependency and test surface.
+
+## Consequences
+
+- Lead plan commits 3-9 updated: import paths point to Schema.ps1, ReportManifest.ps1, and the Policy/ modules instead of the three phantom files.
+- No new shared module PRs needed. Track F slices 2-9 unblocked immediately.
+- Atlas owns slice 2+ implementation per routing below.
+- The D1 dependency gate in any future multi-track plan must check function names, not file names. File layout may differ from the plan.
+
+## Routing
+
+| Slice | Owner | Consumes |
+|---|---|---|
+| 2 (control-domain sections) | Atlas | Schema.ps1 `New-FindingRow` ComplianceMappings |
+| 3 (attack-path / resilience / policy) | Atlas | AttackPathRenderer.ps1 `New-AttackPathModel`, ResilienceMapRenderer.ps1 `Invoke-ResilienceMapRender`, Policy/AlzMatcher.ps1 + PolicyEnforcementRenderer.ps1 |
+| 4-9 | Atlas | No coupling to the three phantom modules |
+
+## References
+
+- Issue: #1056
+- Parent epic: #506
+- Track F kickoff: #1048
+- PR #1066 (slices 0-1, merged)
+- Lead plan: `.copilot/audits/lead-track-f-impl-plan-2026-04-23.md`

--- a/.squad/skills/plan-vs-built-triage/SKILL.md
+++ b/.squad/skills/plan-vs-built-triage/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: "plan-vs-built-triage"
+description: "When a multi-track plan references unbuilt modules, decide extract vs consume-as-built"
+domain: "architecture"
+confidence: "low"
+source: "manual (first observation, issue #1056 triage 2026-05-13)"
+---
+
+## Context
+
+Multi-track implementation plans name dependency modules by expected file path. Tracks often deliver the functionality under different file names, inside existing shared modules, or embedded in renderers. The D1 dependency gate catches the mismatch but cannot decide between extracting new helpers and consuming what landed.
+
+## When to use this skill
+
+An implementation plan references N modules by file path. The dependency gate reports M of them missing. Before filing extraction work, run through the checklist below.
+
+## Checklist (all must fail to justify extraction)
+
+1. **Function-name search.** Grep the codebase for the function name (not file name) the plan expects. If the function exists in a different file, update the plan's import path. No extraction needed.
+
+2. **Cross-consumer duplication.** Count lines of logic duplicated across renderers that would collapse into the proposed helper. If total duplicated lines are under ~20, the extraction adds dependency surface without meaningful DRY benefit. Consume directly.
+
+3. **Test isolation gain.** Check whether the renderers already have isolated test files. If yes, extracting a helper does not improve test granularity. If renderers share a single monolithic test and extraction would split it meaningfully, that is a point for extraction.
+
+4. **Consumer-first layout (CON).** Does creating a new `modules/shared/FooHelper.ps1` serve any consumer besides Track F? If the helper has exactly one consumer, it is indirection, not reuse.
+
+5. **Downstream coupling count.** In the plan, count how many slices import the missing module. If only 1 slice, consume directly. If 3+, extraction may pay off.
+
+## Decision matrix
+
+| Function found elsewhere | Duplication > 20 lines | Test isolation gain | Multiple consumers | Verdict |
+|---|---|---|---|---|
+| Yes | - | - | - | Option B (update import path) |
+| No | Yes | Yes | Yes | Option A (extract) |
+| No | No | No | No | Option B (consume as-built) |
+| No | Mixed | Mixed | Mixed | Convene design review |
+
+## Anti-patterns
+
+- Assuming file-path stability across tracks. File layout decisions happen during implementation, not during planning. Plans that hard-code file paths will drift.
+- Extracting a helper that has exactly one consumer. That is a wrapper around a wrapper.
+- Blocking implementation on extraction when the as-built API is stable. The extraction can happen later if a second consumer appears.
+
+## Examples
+
+**Issue #1056:** Plan expected `EdgeRelations.ps1`, `Select-ReportArchitecture.ps1`, `PolicyCoverageAnalyzer.ps1`. Reality: EdgeRelations enum in Schema.ps1 (line 38), `Select-ReportArchitecture` in ReportManifest.ps1 (line 101), policy logic in `Policy/AlzMatcher.ps1` + `PolicyEnforcementRenderer.ps1`. Verdict: Option B, update plan import paths.
+
+## Provenance
+
+First observed during #1056 triage (Lead, 2026-05-13). Single observation. Promote confidence to "medium" if the pattern recurs in a second multi-track plan.


### PR DESCRIPTION
Triage verdict for #1056: Option B (consume existing renderers directly).

The three modules Lead plan referenced (EdgeRelations.ps1, Select-ReportArchitecture.ps1, PolicyCoverageAnalyzer.ps1) are naming mismatches, not functionality gaps. EdgeRelations enum lives in Schema.ps1 (line 38). `Select-ReportArchitecture` lives in ReportManifest.ps1 (line 101). Policy logic lives in `modules/shared/Policy/`.

Files changed:
- Decision: `.squad/decisions/inbox/lead-1056-trackf-helper-modules.md`
- History: `.squad/agents/lead/history.md` (new learning appended)
- Skill: `.squad/skills/plan-vs-built-triage/SKILL.md` (new, low confidence)

Verification: squad-only files, no code changes, no test impact.

Closes #1056