### PR TITLE
feat(report): Track F Commit 5 - LLM triage annotations (Refs #506)

### DIFF
--- a/.squad/agents/atlas/history.md
+++ b/.squad/agents/atlas/history.md
@@ -329,3 +329,5 @@ Full Track F dependency gate (Commit 0) blocked all implementation (3 missing mo
 - **2026-05-13** - PR #1090 - Track F Commit 3: attack-path, resilience, policy-coverage sections (12/12 tests green)
 
 - **2026-05-13** - PR #1091 - Track F Commit 4: remediation appendix + evidence export (17/17 tests green, credential scrubbing confirmed)
+
+- **2026-05-13** - PR #1092 - Track F Commit 5: LLM triage annotations (20/20 tests green, optional Track E consumer)

--- a/.squad/decisions/inbox/atlas-trackf-commit5-2026-05-13T13-27-30.md
+++ b/.squad/decisions/inbox/atlas-trackf-commit5-2026-05-13T13-27-30.md
@@ -1,0 +1,80 @@
+# Track F Commit 5 - LLM Triage Annotations
+
+**Date:** 2026-05-13  
+**Agent:** Atlas (Squad Core Dev)  
+**PR:** #1092  
+**Epic:** #506 (Track F - Auditor-driven report builder)  
+**Plan ref:** `.copilot/audits/lead-track-f-impl-plan-2026-04-23.md` § 7
+
+## What landed
+
+Implemented `Get-AuditorTriageAnnotations` - optional Track E consumer that joins LLM triage verdicts to findings.
+
+**Function behavior:**
+- Input: `$Findings` (array), `$TriagePath` (optional string path to `triage.json`)
+- If `$TriagePath` is null/empty or file doesn't exist: returns `@{ AnnotatedFindings = $Findings; TriagePresent = $false }` (no-op, graceful degradation)
+- If `$TriagePath` resolves: reads JSON, indexes verdicts by `FindingId` (case-sensitive)
+- Joins verdicts to findings: deep-clones each finding, adds `Verdict`, `Rationale`, `SuggestedSuppression?` fields
+- Findings without triage match: `Verdict = $null` (not excluded)
+- Returns: `@{ AnnotatedFindings[], TriagePresent }`
+
+**Graceful degradation confirmed:**
+- Function does NOT throw on missing file
+- Function does NOT throw on null/empty path
+- Returns original findings unchanged when triage absent
+- `TriagePresent` flag allows downstream renderers to adapt
+
+## triage.json schema (assumed)
+
+Track E is not yet implemented. Schema shape assumed per plan spec and documented here for future Track E alignment:
+
+```json
+[
+  {
+    "FindingId": "F-001",
+    "Verdict": "confirmed",
+    "Rationale": "Key Vault purge protection is a critical security control...",
+    "SuggestedSuppression": "false_positive"  // optional
+  }
+]
+```
+
+**Schema fields:**
+- `FindingId` (string, required): Case-sensitive match to `findings[].FindingId`
+- `Verdict` (string, required): LLM verdict (e.g., 'confirmed', 'false_positive', 'needs_review')
+- `Rationale` (string, required): LLM explanation for the verdict
+- `SuggestedSuppression` (string, optional): Suppression type if LLM recommends suppression
+
+**Alignment notes:**
+- When Track E lands, it MUST emit this shape OR the function must be updated
+- If Track E uses different field names (e.g., `verdict` lowercase), update the function to match
+- Current implementation uses case-sensitive `FindingId` match per existing schema conventions
+
+## Fixture created
+
+`tests/fixtures/auditor-small/triage.json`:
+- 5 verdicts for findings F-001, F-002, F-005, F-007, F-011
+- Coverage: ~16% of fixture findings (5 of 32) - intentionally partial to test mixed scenarios
+- Verdict types: 3 confirmed, 1 false_positive with SuggestedSuppression
+- Rationales written to sound like LLM output
+
+## Tests added
+
+Three new tests in `tests/shared/AuditorReportBuilder.Tests.ps1` (numbered 18-20):
+1. **Test 18:** joins triage verdicts when present (5 with Verdict, 27 with null)
+2. **Test 19:** degrades gracefully when triage.json missing (no throw on null/empty/nonexistent paths)
+3. **Test 20:** includes suggested suppression when Track E provides it (F-005 has SuggestedSuppression='false_positive')
+
+**Result:** 20/20 tests passing (4 + 3 + 5 + 5 + 3 = 20 cumulative).
+
+## Plan deviations
+
+**None.** Track E doesn't exist yet; schema shape assumed per plan spec. Documented here for Track E alignment.
+
+## Commit
+
+`752f958` - feat(report): implement LLM triage annotations
+
+## Next steps
+
+Commit 6 (Citation helper) - blocked until Commit 5 merges. Plan ref § 8.

--- a/modules/shared/AuditorReportBuilder.ps1
+++ b/modules/shared/AuditorReportBuilder.ps1
@@ -444,7 +444,60 @@ function Get-AuditorTriageAnnotations {
         [Parameter(Mandatory)] [object[]] $Findings,
         [string] $TriagePath = ''
     )
-    throw [System.NotImplementedException]::new('Get-AuditorTriageAnnotations: requires Track E (#433/#466).')
+    
+    if ([string]::IsNullOrWhiteSpace($TriagePath) -or -not (Test-Path $TriagePath)) {
+        return @{
+            AnnotatedFindings = @($Findings)
+            TriagePresent = $false
+        }
+    }
+    
+    $triageData = Get-Content -Path $TriagePath -Raw | ConvertFrom-Json
+    $triageByFindingId = @{}
+    
+    foreach ($verdict in $triageData) {
+        if ($null -eq $verdict) { continue }
+        $findingId = if ($verdict.PSObject.Properties['FindingId']) { [string]$verdict.FindingId } else { '' }
+        if (-not [string]::IsNullOrWhiteSpace($findingId)) {
+            $triageByFindingId[$findingId] = $verdict
+        }
+    }
+    
+    $annotatedFindings = @()
+    foreach ($finding in $Findings) {
+        if ($null -eq $finding) { continue }
+        
+        $findingId = if ($finding.PSObject.Properties['FindingId']) { [string]$finding.FindingId } else { '' }
+        
+        $annotated = [PSCustomObject]@{}
+        foreach ($prop in $finding.PSObject.Properties) {
+            $annotated | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $prop.Value
+        }
+        
+        if (-not [string]::IsNullOrWhiteSpace($findingId) -and $triageByFindingId.ContainsKey($findingId)) {
+            $verdict = $triageByFindingId[$findingId]
+            
+            $verdictValue = if ($verdict.PSObject.Properties['Verdict']) { [string]$verdict.Verdict } else { $null }
+            $rationaleValue = if ($verdict.PSObject.Properties['Rationale']) { [string]$verdict.Rationale } else { $null }
+            
+            $annotated | Add-Member -MemberType NoteProperty -Name 'Verdict' -Value $verdictValue -Force
+            $annotated | Add-Member -MemberType NoteProperty -Name 'Rationale' -Value $rationaleValue -Force
+            
+            if ($verdict.PSObject.Properties['SuggestedSuppression']) {
+                $annotated | Add-Member -MemberType NoteProperty -Name 'SuggestedSuppression' -Value ([string]$verdict.SuggestedSuppression) -Force
+            }
+        } else {
+            $annotated | Add-Member -MemberType NoteProperty -Name 'Verdict' -Value $null -Force
+            $annotated | Add-Member -MemberType NoteProperty -Name 'Rationale' -Value $null -Force
+        }
+        
+        $annotatedFindings += $annotated
+    }
+    
+    return @{
+        AnnotatedFindings = @($annotatedFindings)
+        TriagePresent = $true
+    }
 }
 
 function Get-AuditorRemediationAppendix {

--- a/tests/fixtures/auditor-small/triage.json
+++ b/tests/fixtures/auditor-small/triage.json
@@ -1,0 +1,28 @@
+[
+  {
+    "FindingId": "F-001",
+    "Verdict": "confirmed",
+    "Rationale": "Key Vault purge protection is a critical security control to prevent permanent data loss."
+  },
+  {
+    "FindingId": "F-002",
+    "Verdict": "confirmed",
+    "Rationale": "HTTP access to storage accounts exposes data in transit to interception."
+  },
+  {
+    "FindingId": "F-005",
+    "Verdict": "false_positive",
+    "Rationale": "SQL auditing is enabled at the server level, not the database level. This finding is a duplicate.",
+    "SuggestedSuppression": "false_positive"
+  },
+  {
+    "FindingId": "F-007",
+    "Verdict": "confirmed",
+    "Rationale": "Microsoft Defender for Cloud provides essential threat detection and security posture management."
+  },
+  {
+    "FindingId": "F-011",
+    "Verdict": "confirmed",
+    "Rationale": "Multi-factor authentication is mandatory for privileged accounts to prevent credential theft attacks."
+  }
+]

--- a/tests/shared/AuditorReportBuilder.Tests.ps1
+++ b/tests/shared/AuditorReportBuilder.Tests.ps1
@@ -10,6 +10,7 @@ Describe 'AuditorReportBuilder' -Tag 'Unit' {
         $resultsPath = Join-Path $fixtureDir 'results.json'
         $entitiesPath = Join-Path $fixtureDir 'entities.json'
         $manifestPath = Join-Path $fixtureDir 'report-manifest.json'
+        $triagePath = Join-Path $fixtureDir 'triage.json'
     }
     
     Context 'Resolve-AuditorContext' {
@@ -269,6 +270,44 @@ Describe 'AuditorReportBuilder' -Tag 'Unit' {
             $csvContent = Get-Content $csvPath -Raw
             
             $csvContent | Should -Not -Match 'secret123' -Because 'Remove-Credentials should redact the password'
+        }
+    }
+    
+    Context 'Get-AuditorTriageAnnotations' {
+        BeforeAll {
+            $findings = Get-Content -Path $resultsPath -Raw | ConvertFrom-Json
+        }
+        
+        It 'joins triage verdicts when present' {
+            $result = Get-AuditorTriageAnnotations -Findings $findings -TriagePath $triagePath
+            
+            $result.TriagePresent | Should -Be $true
+            $result.AnnotatedFindings.Count | Should -Be $findings.Count
+            
+            $withVerdict = @($result.AnnotatedFindings | Where-Object { $null -ne $_.Verdict })
+            $withoutVerdict = @($result.AnnotatedFindings | Where-Object { $null -eq $_.Verdict })
+            
+            $withVerdict.Count | Should -Be 5
+            $withoutVerdict.Count | Should -Be ($findings.Count - 5)
+        }
+        
+        It 'degrades gracefully when triage.json missing' {
+            $result = Get-AuditorTriageAnnotations -Findings $findings -TriagePath ''
+            
+            $result.TriagePresent | Should -Be $false
+            $result.AnnotatedFindings.Count | Should -Be $findings.Count
+            
+            { Get-AuditorTriageAnnotations -Findings $findings -TriagePath $null } | Should -Not -Throw
+            { Get-AuditorTriageAnnotations -Findings $findings -TriagePath 'nonexistent.json' } | Should -Not -Throw
+        }
+        
+        It 'includes suggested suppression when Track E provides it' {
+            $result = Get-AuditorTriageAnnotations -Findings $findings -TriagePath $triagePath
+            
+            $findingWithSuppression = $result.AnnotatedFindings | Where-Object { $_.FindingId -eq 'F-005' } | Select-Object -First 1
+            
+            $findingWithSuppression | Should -Not -BeNullOrEmpty
+            $findingWithSuppression.SuggestedSuppression | Should -Be 'false_positive'
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements Track F Commit 5 per `.copilot/audits/lead-track-f-impl-plan-2026-04-23.md` § 7.

**What landed:**
- `Get-AuditorTriageAnnotations` - joins optional Track E triage verdicts to findings

**Implementation notes:**

**Triage annotations:**
- Joins optional Track E `triage.json` verdicts to findings by `FindingId` (case-sensitive)
- Degrades gracefully when `triage.json` missing, empty path, or path doesn't exist
- Returns `@{ AnnotatedFindings[], TriagePresent }`
- Each annotated finding includes: `Verdict`, `Rationale`, `SuggestedSuppression?`
- Findings without triage match keep `Verdict = $null` (not excluded)
- `TriagePresent` boolean flag indicates whether triage.json was found and processed

**triage.json schema (assumed - Track E not yet implemented):**
```json
[
  {
    "FindingId": "F-001",
    "Verdict": "confirmed",
    "Rationale": "Explanation text...",
    "SuggestedSuppression": "false_positive"  // optional
  }
]
```

Schema fields:
- `FindingId`: string, case-sensitive match to findings
- `Verdict`: string (e.g., 'confirmed', 'false_positive', 'needs_review')
- `Rationale`: string explanation from LLM
- `SuggestedSuppression`: optional string (suppression type if applicable)

**Fixture created:**
- `tests/fixtures/auditor-small/triage.json` with 5 verdicts:
  - F-001, F-002: confirmed
  - F-005: false_positive (with SuggestedSuppression)
  - F-007, F-011: confirmed
- Covers ~16% of fixture findings (5 of 32) to test partial-triage scenario

**Test delta:**
- +3 new tests (cumulative: 20 tests)
- All 20 passing (4 Commit 1 + 3 Commit 2 + 5 Commit 3 + 5 Commit 4 + 3 Commit 5)
- Test coverage: verdict join, graceful degradation, suggested suppression field

**Plan deviations:**
- None. Track E doesn't exist yet; schema shape assumed per plan guidance and documented in decision drop.

**Note:** This is the **optional Track E consumer**. Function degrades cleanly if Track E is absent. Reports can render without triage annotations.

Refs #506

## Checklist
- [x] 1 function implemented
- [x] 3 new tests added
- [x] triage.json fixture created (5 verdicts)
- [x] AuditorReportBuilder tests green (20/20)
- [x] Commit includes Co-authored-by trailer
- [x] Graceful degradation confirmed (TriagePath null/missing)
- [x] triage.json schema documented (assumed shape)
- [ ] Full baseline green (sample passed; CI will confirm)
- [ ] Decision drop committed
- [ ] History updated
