### PR TITLE
feat(report): Track F Commit 7 - auditor profile wiring + nav chip (Refs #506)

### DIFF
--- a/.squad/agents/atlas/history.md
+++ b/.squad/agents/atlas/history.md
@@ -334,3 +334,7 @@ Full Track F dependency gate (Commit 0) blocked all implementation (3 missing mo
 
 - **2026-05-13** - Track F Commit 6: tier-aware rendering + citation helper (24/24 tests green, print stylesheet + workpaper-ready citations)
 
+
+## 2026-05-13 13:48:14 - Track F Commit 7 (PR #TBD)
+
+Implemented Build-AuditorReport orchestrator + wired into Invoke-AzureAnalyzer.ps1 via -Profile parameter + added Audit view nav chip to New-HtmlReport.ps1. Created 3 orchestrator tests (Build-AuditorReport integration + nav chip injection positive/negative). Cumulative: 27 tests (24 AuditorReportBuilder + 3 orchestrator), all passing. Decision drop: atlas-trackf-commit7-2026-05-13T13-48-05.md. Lesson: Pester scriptblock assignment doesn't propagate to outer scope - use direct assignment.

--- a/.squad/decisions/inbox/atlas-trackf-commit7-2026-05-13T13-48-05.md
+++ b/.squad/decisions/inbox/atlas-trackf-commit7-2026-05-13T13-48-05.md
@@ -1,0 +1,135 @@
+# Track F Commit 7 - Auditor Profile Wiring + Nav Chip
+
+**Date**: 2026-05-13 13:48:05  
+**Author**: Atlas (Squad Core Dev)  
+**Context**: Track F (issue #506) - Auditor-driven report builder
+
+## Decision
+
+Wired Build-AuditorReport orchestrator into Invoke-AzureAnalyzer.ps1 via new `-Profile` parameter and added "Audit view" nav chip to New-HtmlReport.ps1.
+
+## Implementation Details
+
+### 1. Build-AuditorReport Orchestrator (lines 44-163)
+
+Replaced NotImplementedException stub with full orchestration logic:
+
+- Calls Resolve-AuditorContext to load inputs (results.json, entities.json, report-manifest.json, optional triage.json)
+- Calls Get-AuditorExecutiveSummary for severity counts + framework coverage
+- Calls Get-AuditorControlDomainSections to group findings by CIS/NIST/MCSB/ISO27001 control IDs
+- Calls Get-AuditorAttackPathSection (Track A consumer) with -Tier parameter
+- Calls Get-AuditorResilienceSection (Track B consumer) with -Tier parameter
+- Calls Get-AuditorPolicyCoverageSection (Track C consumer) with -Tier parameter
+- Calls Get-AuditorTriageAnnotations (Track E consumer) to join optional triage verdicts
+- Calls Get-AuditorRemediationAppendix to group by exact Remediation text
+- Calls Get-AuditorEvidenceExport to write CSV/JSON/XLSX with Remove-Credentials
+- Calls Write-AuditorRenderTier to produce audit-report.html + audit-report.md
+- Returns hashtable with HtmlPath, MdPath, EvidencePath, Manifest, SectionErrors when -PassThru specified
+
+**Defensive degradation**: Each sub-function call wrapped in try/catch. Section errors logged to SectionErrors array but do not stop execution (declared degradation contract). Write-AuditorRenderTier failure is caught but function continues to return paths.
+
+**Pipeline fix**: Assigned Write-AuditorRenderTier result to `` to prevent hashtable leakage into pipeline (function was returning both Write-AuditorRenderTier's hashtable AND Build-AuditorReport's hashtable as Object[]).
+
+### 2. Invoke-AzureAnalyzer.ps1 Wiring
+
+**Parameter addition** (lines 183-184):
+- Added `-Profile` parameter with ValidateSet('Default','Auditor'), default 'Default'
+- Placed after existing `-FixturePath` parameter in param block
+
+**Dot-sourcing** (line 197):
+- Added 'AuditorReportBuilder' to shared-module dot-source loop
+
+**Invocation** (lines 2021-2045):
+- After existing New-HtmlReport.ps1 and New-MdReport.ps1 calls
+- Conditional on `C:\Users\martinopedal\OneDrive - Microsoft\Documents\PowerShell\Microsoft.PowerShell_profile.ps1 -eq 'Auditor'`
+- Checks for Build-AuditorReport availability (Get-Command)
+- Passes InputPath (results.json), EntitiesPath (entities.json), ManifestPath (report-manifest.json), OutputDirectory, PassThru=True
+- Conditionally passes TriagePath if `` variable set
+- Logs section errors with Remove-Credentials
+- Writes `[OK] Auditor report: <path>` and `[OK] Evidence export: <path>` on success
+- Warns if Build-AuditorReport not available (defensive graceful skip)
+
+### 3. New-HtmlReport.ps1 Nav Chip Injection
+
+**Logic** (lines 707-713):
+- Checks if audit-report.html exists in same directory as report.html output
+- Sets `` to `"<a href='audit-report.html'>Audit view</a>"` if present, empty string otherwise
+- **ASCII only** - no em-dashes, en-dashes, or arrow symbols (markdown-check.yml enforcement)
+
+**Injection point** (line 849):
+- Modified `<nav class='sub'>` line to append `` variable
+- Chip appears after "Entities" link in sub-navigation row
+- Reuses existing nav link styling (no new CSS required)
+
+### 4. Orchestrator Tests (tests/orchestrator/InvokeAzureAnalyzer.Profile.Tests.ps1)
+
+Created new test file with 3 tests:
+
+**Test 1** (lines 18-57): "calls Build-AuditorReport and produces audit-report.html"
+- Loads auditor-small fixture (results.json, entities.json, report-manifest.json)
+- Calls Build-AuditorReport with -PassThru
+- Asserts result is not null/empty
+- Asserts HtmlPath and MdPath exist
+- Asserts HTML content contains "Azure Analyzer Audit Report"
+- **Lesson learned**: Cannot use `{  = Func } | Should -Not -Throw` - scriptblock assignment doesn't propagate to outer scope. Use direct assignment instead.
+
+**Test 2** (lines 61-79): "injects Audit view nav chip when audit-report.html exists"
+- Creates audit-report.html in output directory
+- Calls New-HtmlReport.ps1
+- Asserts report.html contains `href='audit-report.html'>Audit view</a>`
+
+**Test 3** (lines 81-97): "does not inject nav chip when audit-report.html is missing"
+- Does NOT create audit-report.html
+- Calls New-HtmlReport.ps1
+- Asserts report.html does NOT contain audit-report link
+
+### Test Results
+
+- AuditorReportBuilder.Tests.ps1: 24/24 tests pass (no regression)
+- InvokeAzureAnalyzer.Profile.Tests.ps1: 3/3 tests pass
+- **Cumulative total**: 27 tests (24 + 3)
+
+## Alternatives Considered
+
+**Alt 1**: Make -Profile a switch (-Auditor) instead of ValidateSet
+- Rejected: Harder to extend with future profiles (e.g., -Profile 'ComplianceOfficer', -Profile 'Developer')
+
+**Alt 2**: Always generate auditor report, toggle with -SkipAuditorReport
+- Rejected: Default behavior should be lightweight (minimal output); auditor report is opt-in heavyweight output
+
+**Alt 3**: Inject nav chip via JavaScript after page load
+- Rejected: Requires audit-report.html presence check in JS; server-side check is simpler and works without JS
+
+**Alt 4**: Use em-dash or arrow in nav chip text (e.g., "Audit view →")
+- Rejected: Violates ASCII-only repo invariant (markdown-check.yml)
+
+## Consequences
+
+**Positive**:
+- Auditor profile now fully wired and end-to-end testable
+- Users can run `Invoke-AzureAnalyzer.ps1 -Profile Auditor` to get audit-report.html + evidence export
+- Nav chip provides discoverability when auditor report exists
+- Defensive degradation allows partial success even if sub-functions fail
+
+**Negative**:
+- First orchestrator-touching commit triggers full Test/e2e matrix (~10-15 min CI run)
+- -Profile parameter adds cognitive load to param block (though default 'Default' makes it opt-in)
+
+**Next steps**:
+- Commit 8: Get-AuditorDiffSection (delta vs. previous run)
+- Commit 9: Final documentation update + close issue #506
+
+## Files Modified
+
+- `modules/shared/AuditorReportBuilder.ps1` (lines 44-163): Build-AuditorReport implementation
+- `Invoke-AzureAnalyzer.ps1` (lines 183-184, 197, 2021-2045): -Profile parameter + wiring
+- `New-HtmlReport.ps1` (lines 707-713, 849): Nav chip injection logic
+- `tests/orchestrator/InvokeAzureAnalyzer.Profile.Tests.ps1` (new): 3 orchestrator tests
+
+## References
+
+- Issue #506 (Track F epic)
+- Track F design doc: docs/design/track-f-auditor-redesign.md
+- Lesson from Commit 4: Always verify history.md staged in docs commit
+- Lesson from Commit 5: Cannot use inline if expression in Add-Member -Value parameter
+- Lesson from Commit 7: Pester scriptblock assignment doesn't propagate to outer scope

--- a/Invoke-AzureAnalyzer.ps1
+++ b/Invoke-AzureAnalyzer.ps1
@@ -179,7 +179,9 @@ param (
     [int] $ViewerPort = 4280,
     [switch] $NoBanner,
     [switch] $FixtureMode,
-    [string] $FixturePath
+    [string] $FixturePath,
+    [ValidateSet('Default','Auditor')]
+    [string] $Profile = 'Default'
 )
 
 if ($Help) {
@@ -194,7 +196,7 @@ $ErrorActionPreference = 'Stop'
 # Dot-source shared modules
 # ---------------------------------------------------------------------------
 $sharedDir = Join-Path $PSScriptRoot 'modules' 'shared'
-foreach ($sharedModule in @('Sanitize', 'Mask', 'Schema', 'Canonicalize', 'EntityStore', 'WorkerPool', 'Checkpoint', 'Installer', 'Errors', 'MissingTool', 'RemoteClone', 'FrameworkMapper', 'Retry', 'RunHistory', 'ReportDelta', 'Compare-EntitySnapshots', 'ScanState', 'MultiTenantOrchestrator', 'ReportManifest', 'PromptForMandatoryParams', 'Banner')) {
+foreach ($sharedModule in @('Sanitize', 'Mask', 'Schema', 'Canonicalize', 'EntityStore', 'WorkerPool', 'Checkpoint', 'Installer', 'Errors', 'MissingTool', 'RemoteClone', 'FrameworkMapper', 'Retry', 'RunHistory', 'ReportDelta', 'Compare-EntitySnapshots', 'ScanState', 'MultiTenantOrchestrator', 'ReportManifest', 'PromptForMandatoryParams', 'Banner', 'AuditorReportBuilder')) {
     $sharedPath = Join-Path $sharedDir "$sharedModule.ps1"
     if (Test-Path $sharedPath) { . $sharedPath }
 }
@@ -2016,6 +2018,44 @@ try {
     & "$PSScriptRoot\New-MdReport.ps1" -InputPath $outputFile -OutputPath $mdReport @triageArg @mdBaselineArg @trendArg @portfolioArg
 } catch {
     Write-Warning (Remove-Credentials "Markdown report generation failed: $_")
+}
+
+# ---------------------------------------------------------------------------
+# Generate auditor report if -Profile Auditor
+# ---------------------------------------------------------------------------
+if ($Profile -eq 'Auditor') {
+    try {
+        if (Get-Command Build-AuditorReport -ErrorAction SilentlyContinue) {
+            $auditorArgs = @{
+                InputPath = $outputFile
+                EntitiesPath = $entitiesFile
+                ManifestPath = $manifestFile
+                OutputDirectory = $OutputPath
+                PassThru = $true
+            }
+            if ($triage) {
+                $auditorArgs['TriagePath'] = $triage
+            }
+            
+            $auditorResult = Build-AuditorReport @auditorArgs
+            
+            if ($auditorResult.SectionErrors.Count -gt 0) {
+                Write-Warning "Auditor report generated with section errors:"
+                foreach ($err in $auditorResult.SectionErrors) {
+                    Write-Warning (Remove-Credentials "  $err")
+                }
+            }
+            
+            Write-Host "[OK] Auditor report: $($auditorResult.HtmlPath)"
+            if ($auditorResult.EvidencePath) {
+                Write-Host "[OK] Evidence export: $($auditorResult.EvidencePath)"
+            }
+        } else {
+            Write-Warning "Build-AuditorReport not available. Install Track F module."
+        }
+    } catch {
+        Write-Warning (Remove-Credentials "Auditor report generation failed: $_")
+    }
 }
 
 # ---------------------------------------------------------------------------

--- a/New-HtmlReport.ps1
+++ b/New-HtmlReport.ps1
@@ -706,6 +706,12 @@ $trendHtml = if (@($Trend).Count -ge 2) {
 
 $date = Get-Date -Format 'yyyy-MM-dd HH:mm UTC'
 
+$auditChip = ''
+$auditReportPath = Join-Path (Split-Path $OutputPath -Parent) 'audit-report.html'
+if (Test-Path $auditReportPath) {
+    $auditChip = "<a href='audit-report.html'>Audit view</a>"
+}
+
 $html = @"
 <!DOCTYPE html>
 <html lang='en' data-theme='light'>
@@ -842,7 +848,7 @@ button:focus-visible,a:focus-visible,input:focus-visible,select:focus-visible{ou
     <button class='theme-btn' id='themeBtn' title='Toggle theme' aria-label='Toggle dark mode'>🌓</button>
   </div>
 </header>
-<nav class='sub' aria-label='Section'><div class='sub-row'><a href='#overview' class='active'>Overview</a><a href='#triage'>Triage</a><a href='#coverage'>Tool coverage</a><a href='#heatmap'>Heatmap</a><a href='#risks'>Top risks</a><a href='#findings'>Findings</a><a href='#entities'>Entities</a></div></nav>
+<nav class='sub' aria-label='Section'><div class='sub-row'><a href='#overview' class='active'>Overview</a><a href='#triage'>Triage</a><a href='#coverage'>Tool coverage</a><a href='#heatmap'>Heatmap</a><a href='#risks'>Top risks</a><a href='#findings'>Findings</a><a href='#entities'>Entities</a>$auditChip</div></nav>
 <main id='main'>
 <section class='sec' id='overview'>
   <h2>Overview <span class='badge'>executive summary</span></h2>

--- a/modules/shared/AuditorReportBuilder.ps1
+++ b/modules/shared/AuditorReportBuilder.ps1
@@ -57,8 +57,109 @@ function Build-AuditorReport {
         [ValidateSet('inline','footnote','workpaper')] [string] $CitationStyle = 'workpaper',
         [switch]   $PassThru
     )
-    throw [System.NotImplementedException]::new(
-        'Build-AuditorReport: Track F is design-only until Tracks A-E + V land. See docs/design/track-f-auditor-redesign.md.')
+    
+    $sectionErrors = @()
+    
+    try {
+        $context = Resolve-AuditorContext `
+            -InputPath $InputPath `
+            -EntitiesPath $EntitiesPath `
+            -ManifestPath $ManifestPath `
+            -TriagePath $TriagePath `
+            -PreviousRunPath $PreviousRunPath `
+            -Tier $Tier
+    } catch {
+        $sectionErrors += "Resolve-AuditorContext failed: $_"
+        throw
+    }
+    
+    try {
+        $summary = Get-AuditorExecutiveSummary `
+            -Findings $context.Findings `
+            -PreviousFindings $context.PreviousFindings `
+            -ControlFrameworks $ControlFrameworks
+        $context['Summary'] = $summary
+    } catch {
+        $sectionErrors += "Get-AuditorExecutiveSummary failed: $_"
+    }
+    
+    try {
+        $controlSections = Get-AuditorControlDomainSections `
+            -Findings $context.Findings `
+            -Frameworks $ControlFrameworks
+        $context['ControlDomainSections'] = $controlSections
+    } catch {
+        $sectionErrors += "Get-AuditorControlDomainSections failed: $_"
+    }
+    
+    try {
+        $attackPath = Get-AuditorAttackPathSection -Entities $context.Entities -Tier $context.Tier
+        $context['AttackPathSection'] = $attackPath
+    } catch {
+        $sectionErrors += "Get-AuditorAttackPathSection failed: $_"
+    }
+    
+    try {
+        $resilience = Get-AuditorResilienceSection -Entities $context.Entities -Tier $context.Tier
+        $context['ResilienceSection'] = $resilience
+    } catch {
+        $sectionErrors += "Get-AuditorResilienceSection failed: $_"
+    }
+    
+    try {
+        $policyCoverage = Get-AuditorPolicyCoverageSection -Entities $context.Entities -Tier $context.Tier
+        $context['PolicyCoverageSection'] = $policyCoverage
+    } catch {
+        $sectionErrors += "Get-AuditorPolicyCoverageSection failed: $_"
+    }
+    
+    try {
+        $annotated = Get-AuditorTriageAnnotations `
+            -Findings $context.Findings `
+            -TriagePath $TriagePath
+        $context['Findings'] = $annotated.Findings
+        $context['TriagePresent'] = $annotated.TriagePresent
+    } catch {
+        $sectionErrors += "Get-AuditorTriageAnnotations failed: $_"
+    }
+    
+    try {
+        $remediation = Get-AuditorRemediationAppendix -Findings $context.Findings
+        $context['RemediationAppendix'] = $remediation
+    } catch {
+        $sectionErrors += "Get-AuditorRemediationAppendix failed: $_"
+    }
+    
+    $evidencePath = $null
+    try {
+        $evidence = Get-AuditorEvidenceExport `
+            -Findings $context.Findings `
+            -OutputDirectory $OutputDirectory
+        $evidencePath = $evidence.ExportPath
+    } catch {
+        $sectionErrors += "Get-AuditorEvidenceExport failed: $_"
+    }
+    
+    try {
+        $null = Write-AuditorRenderTier `
+            -Context $context `
+            -OutputDirectory $OutputDirectory `
+            -Tier $context.Tier
+    } catch {
+        $sectionErrors += "Write-AuditorRenderTier failed: $_"
+    }
+    
+    $result = @{
+        HtmlPath = Join-Path $OutputDirectory 'audit-report.html'
+        MdPath = Join-Path $OutputDirectory 'audit-report.md'
+        EvidencePath = $evidencePath
+        Manifest = $context.Manifest
+        SectionErrors = $sectionErrors
+    }
+    
+    if ($PassThru) {
+        return $result
+    }
 }
 
 function Resolve-AuditorContext {

--- a/tests/orchestrator/InvokeAzureAnalyzer.Profile.Tests.ps1
+++ b/tests/orchestrator/InvokeAzureAnalyzer.Profile.Tests.ps1
@@ -1,0 +1,112 @@
+#Requires -Version 7.4
+BeforeAll {
+    $repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $sharedDir = Join-Path $repoRoot 'modules' 'shared'
+    $fixtureDir = Join-Path $PSScriptRoot '..' 'fixtures' 'auditor-small'
+    $tempOutputDir = Join-Path $env:TEMP "aa-profile-test-$(Get-Date -Format 'yyyyMMddHHmmss')"
+    
+    . (Join-Path $sharedDir 'Sanitize.ps1')
+    . (Join-Path $sharedDir 'AuditorReportBuilder.ps1')
+    
+    if (-not (Test-Path $fixtureDir)) {
+        throw "Fixture directory not found: $fixtureDir"
+    }
+}
+
+Describe 'Invoke-AzureAnalyzer.ps1 -Profile parameter' {
+    Context 'When -Profile Auditor is specified' {
+        It 'calls Build-AuditorReport and produces audit-report.html' {
+            $resultsPath = Join-Path $fixtureDir 'results.json'
+            $entitiesPath = Join-Path $fixtureDir 'entities.json'
+            $manifestPath = Join-Path $fixtureDir 'report-manifest.json'
+            
+            if (-not (Test-Path $resultsPath)) {
+                Set-ItResult -Skipped -Because "Fixture results.json not found: $resultsPath"
+                return
+            }
+            if (-not (Test-Path $entitiesPath)) {
+                Set-ItResult -Skipped -Because "Fixture entities.json not found: $entitiesPath"
+                return
+            }
+            if (-not (Test-Path $manifestPath)) {
+                Set-ItResult -Skipped -Because "Fixture report-manifest.json not found: $manifestPath"
+                return
+            }
+            
+            New-Item -Path $tempOutputDir -ItemType Directory -Force | Out-Null
+            
+            $auditorArgs = @{
+                InputPath = $resultsPath
+                EntitiesPath = $entitiesPath
+                ManifestPath = $manifestPath
+                OutputDirectory = $tempOutputDir
+                PassThru = $true
+            }
+            
+            $result = Build-AuditorReport @auditorArgs
+            
+            $result | Should -Not -BeNullOrEmpty
+            $result.HtmlPath | Should -Exist
+            $result.MdPath | Should -Exist
+            
+            $htmlContent = Get-Content $result.HtmlPath -Raw
+            $htmlContent | Should -Match 'Azure Analyzer Audit Report'
+            
+            Remove-Item -Path $tempOutputDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+    
+    Context 'New-HtmlReport.ps1 nav chip injection' {
+        It 'injects Audit view nav chip when audit-report.html exists' {
+            New-Item -Path $tempOutputDir -ItemType Directory -Force | Out-Null
+            
+            $resultsPath = Join-Path $fixtureDir 'results.json'
+            if (-not (Test-Path $resultsPath)) {
+                Set-ItResult -Skipped -Because "Fixture results.json not found: $resultsPath"
+                return
+            }
+            
+            Copy-Item -Path $resultsPath -Destination (Join-Path $tempOutputDir 'results.json')
+            
+            $auditReportPath = Join-Path $tempOutputDir 'audit-report.html'
+            Set-Content -Path $auditReportPath -Value '<!DOCTYPE html><html><body>Audit Report</body></html>'
+            
+            $reportScript = Join-Path $repoRoot 'New-HtmlReport.ps1'
+            $reportOutputPath = Join-Path $tempOutputDir 'report.html'
+            
+            & $reportScript -InputPath (Join-Path $tempOutputDir 'results.json') -OutputPath $reportOutputPath
+            
+            $reportOutputPath | Should -Exist
+            
+            $reportContent = Get-Content $reportOutputPath -Raw
+            $reportContent | Should -Match "href='audit-report.html'>Audit view</a>"
+            
+            Remove-Item -Path $tempOutputDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        
+        It 'does not inject nav chip when audit-report.html is missing' {
+            New-Item -Path $tempOutputDir -ItemType Directory -Force | Out-Null
+            
+            $resultsPath = Join-Path $fixtureDir 'results.json'
+            if (-not (Test-Path $resultsPath)) {
+                Set-ItResult -Skipped -Because "Fixture results.json not found: $resultsPath"
+                return
+            }
+            
+            Copy-Item -Path $resultsPath -Destination (Join-Path $tempOutputDir 'results.json')
+            
+            $reportScript = Join-Path $repoRoot 'New-HtmlReport.ps1'
+            $reportOutputPath = Join-Path $tempOutputDir 'report.html'
+            
+            & $reportScript -InputPath (Join-Path $tempOutputDir 'results.json') -OutputPath $reportOutputPath
+            
+            $reportOutputPath | Should -Exist
+            
+            $reportContent = Get-Content $reportOutputPath -Raw
+            $reportContent | Should -Not -Match "href='audit-report.html'>Audit view</a>"
+            
+            Remove-Item -Path $tempOutputDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+


### PR DESCRIPTION
## Track F Commit 7 - Auditor Profile Wiring + Nav Chip

Refs #506 (Track F epic - only Commit 9 closes)

### Changes

1. **Build-AuditorReport orchestrator** (`modules/shared/AuditorReportBuilder.ps1` lines 44-163)
   - Replaced NotImplementedException stub with full orchestration logic
   - Calls all sub-functions in sequence: Resolve-AuditorContext → Get-AuditorExecutiveSummary → control-domain sections → Track A/B/C consumers → triage annotations → remediation appendix → evidence export → tier-aware rendering
   - Defensive degradation: each sub-function wrapped in try/catch, section errors logged to SectionErrors array but do not stop execution
   - Returns hashtable with HtmlPath, MdPath, EvidencePath, Manifest, SectionErrors when -PassThru specified
   - Pipeline fix: assigned Write-AuditorRenderTier result to \\\\\ to prevent hashtable leakage

2. **Invoke-AzureAnalyzer.ps1 wiring** (lines 183-184, 197, 2021-2045)
   - Added `-Profile` parameter with ValidateSet('Default','Auditor'), default 'Default'
   - Added 'AuditorReportBuilder' to shared-module dot-source loop
   - Conditional invocation when `\C:\Users\martinopedal\OneDrive - Microsoft\Documents\PowerShell\Microsoft.PowerShell_profile.ps1 -eq 'Auditor'`
   - Passes InputPath, EntitiesPath, ManifestPath, OutputDirectory, optional TriagePath
   - Logs section errors with Remove-Credentials, writes `[OK] Auditor report` + `[OK] Evidence export` on success

3. **New-HtmlReport.ps1 nav chip injection** (lines 707-713, 849)
   - Checks if audit-report.html exists in same directory as report.html
   - Injects `<a href='audit-report.html'>Audit view</a>` in sub-navigation (ASCII only, no em-dashes/arrows)
   - Reuses existing nav link styling

4. **Orchestrator tests** (`tests/orchestrator/InvokeAzureAnalyzer.Profile.Tests.ps1`)
   - Test 1: Build-AuditorReport integration test (uses auditor-small fixture, asserts HtmlPath/MdPath exist + content matches)
   - Test 2: Nav chip injection when audit-report.html present
   - Test 3: Nav chip NOT injected when audit-report.html missing

### Test Results

- AuditorReportBuilder.Tests.ps1: 24/24 pass (no regression)
- InvokeAzureAnalyzer.Profile.Tests.ps1: 3/3 pass
- **Cumulative**: 27 tests (24 + 3)

### Lessons Learned

- Pester scriptblock assignment (`{ \ = Func } | Should -Not -Throw`) doesn't propagate to outer scope - use direct assignment
- Write-AuditorRenderTier returns hashtable that leaks into pipeline - must assign to `\`

### Next Steps

- Commit 8: Get-AuditorDiffSection (delta vs. previous run)
- Commit 9: Final documentation + close #506

---

**Decision drop**: `.squad/decisions/inbox/atlas-trackf-commit7-2026-05-13T13-48-05.md`  
**History entry**: `.squad/agents/atlas/history.md` (appended)

---

**Note**: This is the first orchestrator-touching commit, will trigger full Test/e2e matrix (~10-15 min CI run).