### PR TITLE
feat(report): Track F Commit 8 - report-manifest auditor profile extension (Refs #506)

### DIFF
--- a/.squad/agents/atlas/history.md
+++ b/.squad/agents/atlas/history.md
@@ -335,6 +335,10 @@ Full Track F dependency gate (Commit 0) blocked all implementation (3 missing mo
 - **2026-05-13** - Track F Commit 6: tier-aware rendering + citation helper (24/24 tests green, print stylesheet + workpaper-ready citations)
 
 
-## 2026-05-13 13:48:14 - Track F Commit 7 (PR #TBD)
+## 2026-05-13 13:48:14 - Track F Commit 7 (PR #1094)
 
 Implemented Build-AuditorReport orchestrator + wired into Invoke-AzureAnalyzer.ps1 via -Profile parameter + added Audit view nav chip to New-HtmlReport.ps1. Created 3 orchestrator tests (Build-AuditorReport integration + nav chip injection positive/negative). Cumulative: 27 tests (24 AuditorReportBuilder + 3 orchestrator), all passing. Decision drop: atlas-trackf-commit7-2026-05-13T13-48-05.md. Lesson: Pester scriptblock assignment doesn't propagate to outer scope - use direct assignment.
+
+## 2026-05-13 14:20:00 - Track F Commit 8 (PR #TBD)
+
+Extended New-ReportManifest with -Profile and -Sections parameters to support auditor-driven report manifests. When -Profile Auditor, appends Profile block with Name='auditor', Sections array, and filtered Degradations (Declared Degradation Contract: every degradation MUST reference a real section ID). Added 4 new tests (total 18 ReportManifest tests). Cumulative: 31 tests (24 AuditorReportBuilder + 3 orchestrator + 4 ReportManifest extensions), all passing. Decision drop: atlas-trackf-commit8-manifest-profile-2026-05-13.md. Lesson: PowerShell Set-Content with -NoNewline preserves line endings when using -Raw input; avoided line-ending flips from Commit 7 by using string replacement instead of edit tool.

--- a/.squad/decisions/inbox/atlas-trackf-commit8-manifest-profile-2026-05-13.md
+++ b/.squad/decisions/inbox/atlas-trackf-commit8-manifest-profile-2026-05-13.md
@@ -1,0 +1,117 @@
+# Atlas Decision - Track F Commit 8: Report-Manifest Profile Extension
+
+**Date:** 2026-05-13  
+**Agent:** Atlas (Squad Core Dev)  
+**Context:** Track F implementation (issue #506) - Commit 8 of 9  
+**Status:** IMPLEMENTED
+
+---
+
+## Decision: Extend New-ReportManifest with Auditor Profile Block
+
+**What:** Add `-Profile` and `-Sections` parameters to `New-ReportManifest` in `modules/shared/ReportManifest.ps1`. When `-Profile Auditor`, append a Profile block to the manifest containing section metadata and a filtered subset of degradations matching those sections (Declared Degradation Contract).
+
+**Why:** The auditor-driven report builder (`Build-AuditorReport`) needs to persist its profile metadata alongside the standard report manifest. This allows:
+1. Report consumers to detect which profile generated the report
+2. Section-specific degradation tracking (Track A/B/C data missing, tier downgrades)
+3. Contract enforcement: every degradation in the auditor profile MUST reference a real section ID
+
+This is the "manifest extension" phase of Track F, bridging the orchestrator (Commit 7) to the final documentation phase (Commit 9).
+
+---
+
+## Implementation
+
+### New Parameters
+
+Added 2 optional parameters to `New-ReportManifest`:
+- `[ValidateSet('Default', 'Auditor')] [string] $Profile = 'Default'`
+- `[object[]] $Sections = @()`
+
+### Profile Block Logic
+
+When `$Profile -eq 'Auditor'`:
+1. Extract section IDs from `$Sections` (supports both `.Id` and `.id` properties for robustness)
+2. Filter global `$degradations` array to include only degradations whose `name` property matches a section ID
+3. Construct Profile block: `@{ Name='auditor'; Sections=$Sections; Degradations=$profileDegradations }`
+4. Add Profile block to manifest via `Add-Member`
+
+When `$Profile -eq 'Default'`: no Profile block added (backward compatible)
+
+### Test Coverage
+
+Added 4 new tests in `Describe 'New-ReportManifest -Profile Auditor'`:
+1. **Appends Profile block when -Profile Auditor** - verifies Profile.Name='auditor', Sections array, and first section ID
+2. **Every section in Profile has renderingMode property** - enforces section schema contract
+3. **Every Profile.Degradations entry references a real section id (Declared Degradation Contract)** - critical contract enforcement test
+4. **Does not append Profile block when -Profile Default** - backward compatibility check
+
+Total tests: 18 (14 existing + 4 new)
+
+---
+
+## Rationale
+
+**Why add Profile to the manifest?** Per Track F design doc section 8, the auditor profile is a first-class report variant, not a post-processing transformation. The manifest is the single source of truth for "how this report was generated" - profile metadata belongs there.
+
+**Why filter degradations?** Global degradations include features that may not be in the auditor profile (e.g., standard report features). Including all degradations in the Profile block would pollute the auditor manifest with irrelevant entries. Filtering ensures the Profile.Degradations array is a precise, auditor-scoped subset.
+
+**Why the Declared Degradation Contract?** Per Lead's plan (Commit 8 spec), orphan degradations (degradations that reference non-existent section IDs) indicate a logic bug. The contract test (test #3) enforces this invariant at CI time, catching wrapper/normalizer regressions before they reach production.
+
+**Why support both `.Id` and `.id`?** PowerShell property names are case-insensitive at runtime, but explicit property checks via `.PSObject.Properties['Id']` are case-sensitive. Supporting both patterns makes the function robust against callers using either casing convention.
+
+---
+
+## Alternatives Considered
+
+**Alt 1: Store profile metadata in a separate `profile-manifest.json` file** - REJECTED because it violates the single-source-of-truth principle. The manifest already tracks tier, features, degradations, and policy metadata; profile is the same category of metadata.
+
+**Alt 2: Always include Profile block, default to Name='standard'** - REJECTED because it breaks backward compatibility. Existing consumers expect the manifest schema without a Profile property. Conditional inclusion (only when `-Profile Auditor`) preserves back-compat.
+
+**Alt 3: Omit degradations from Profile block, rely on global Degradations array** - REJECTED because it doesn't support profile-specific degradation scoping. A degradation in the global array might reference a feature that's irrelevant to the auditor profile (e.g., interactive graph canvas degrading to summary mode in Tier 4, but auditor profile uses static tables).
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Profile block schema changes break consumers | LOW | MEDIUM | Profile is new in Track F; no existing consumers yet. Schema versioning via `SchemaVersion` field already in place. |
+| Degradation filter logic bug (orphans) | MEDIUM | HIGH | Test #3 enforces contract at CI time. No orphans allowed. |
+| Case-sensitivity mismatch on section ID lookup | LOW | MEDIUM | Support both `.Id` and `.id` properties. Document convention in Track F final docs (Commit 9). |
+
+---
+
+## Acceptance Criteria
+
+- [x] New-ReportManifest accepts `-Profile` and `-Sections` parameters
+- [x] Profile block appended when `-Profile Auditor`
+- [x] Profile block omitted when `-Profile Default`
+- [x] Profile.Degradations filtered to section IDs only
+- [x] Test coverage: 18 total (14 existing + 4 new), all green
+- [x] Declared Degradation Contract test enforces no orphan degradations
+- [x] No line-ending flips (verified via `git diff --cached -w --numstat`)
+
+---
+
+## Lessons Learned
+
+**Line-ending preservation:** PowerShell `Set-Content` with `-NoNewline` preserves line endings when using `-Raw` input from `Get-Content -Raw`. The repository stores LF for `.ps1` files (verified via hex dump showing `0A` not `0D 0A`). Earlier sessions encountered CRLF-to-LF flips when using the `edit` tool; this session used PowerShell string replacement to avoid editor interference.
+
+**Property case-sensitivity:** `.PSObject.Properties['PropertyName']` is case-sensitive even though PowerShell property access (`$obj.PropertyName`) is case-insensitive. Defensive coding pattern: check both `.Id` and `.id` when the caller's casing convention is unknown.
+
+---
+
+## Next Steps
+
+**Commit 9 (final):** Documentation update (README, PERMISSIONS, CHANGELOG) + parity test + close issue #506. Profile manifest extension is now complete; orchestrator wiring (Commit 7) can pass `-Profile Auditor -Sections $sections` to `New-ReportManifest` and persist the profile metadata.
+
+---
+
+## References
+
+- Issue #506: Track F implementation (auditor-driven report redesign)
+- Lead plan: `.squad/decisions/inbox/lead-track-f-impl-plan-2026-04-23.md`
+- Design doc: `docs/design/track-f-auditor-redesign.md` section 8 (manifest extension)
+- Commit 7: Orchestrator wiring + nav chip (PR #1094)
+- Commit 9: Final documentation + parity test (pending)

--- a/modules/shared/ReportManifest.ps1
+++ b/modules/shared/ReportManifest.ps1
@@ -258,7 +258,12 @@ function New-ReportManifest {
         [object[]] $AutoUpgrades = @(),
         [object] $Timings = [pscustomobject]@{},
         [object[]] $Features = @(),
-        [object] $Policy = $null
+        [object] $Policy = $null,
+
+        [ValidateSet('Default', 'Auditor')]
+        [string] $Profile = 'Default',
+
+        [object[]] $Sections = @()
     )
 
     $degradations = @(
@@ -284,6 +289,26 @@ function New-ReportManifest {
         Features            = @($Features)
         Degradations        = @($degradations)
         Policy              = if ($Policy) { $Policy } else { $null }
+    }
+
+    if ($Profile -eq 'Auditor') {
+        $sectionIds = @($Sections | ForEach-Object {
+            if ($_.PSObject.Properties['Id']) { $_.Id }
+            elseif ($_.PSObject.Properties['id']) { $_.id }
+        })
+
+        $profileDegradations = @($degradations | Where-Object {
+            $featureId = if ($_.PSObject.Properties['name']) { $_.name } else { $null }
+            $featureId -and $sectionIds -contains $featureId
+        })
+
+        $profileBlock = [pscustomobject]@{
+            Name         = 'auditor'
+            Sections     = @($Sections)
+            Degradations = @($profileDegradations)
+        }
+
+        $manifest | Add-Member -NotePropertyName 'Profile' -NotePropertyValue $profileBlock
     }
 
     $json = $manifest | ConvertTo-Json -Depth 30

--- a/tests/shared/ReportManifest.Tests.ps1
+++ b/tests/shared/ReportManifest.Tests.ps1
@@ -153,3 +153,64 @@ Describe 'New-ReportManifest serialization' {
         $roundTrip.Policy.azAdvertizer.catalogVintage | Should -Be '2026-04-23'
     }
 }
+
+Describe 'New-ReportManifest -Profile Auditor' {
+    It 'appends Profile block when -Profile Auditor' {
+        $path = Join-Path $TestDrive 'manifest-auditor.json'
+        $sections = @(
+            [pscustomobject]@{ Id = 'ExecutiveSummary'; Title = 'Executive Summary'; renderingMode = 'full' },
+            [pscustomobject]@{ Id = 'ControlDomains'; Title = 'Control Domains'; renderingMode = 'summary' }
+        )
+        $features = @(
+            [pscustomobject]@{ name = 'ExecutiveSummary'; renderingMode = 'full'; tier1Mode = 'full' },
+            [pscustomobject]@{ name = 'ControlDomains'; renderingMode = 'summary'; tier1Mode = 'interactive' }
+        )
+
+        $manifest = New-ReportManifest -Path $path -SelectedTier 'PureJson' -Profile 'Auditor' -Sections $sections -Features $features
+
+        $manifest.PSObject.Properties['Profile'] | Should -Not -BeNullOrEmpty
+        $manifest.Profile.Name | Should -Be 'auditor'
+        @($manifest.Profile.Sections).Count | Should -Be 2
+        $manifest.Profile.Sections[0].Id | Should -Be 'ExecutiveSummary'
+    }
+
+    It 'every section in Profile has renderingMode property' {
+        $path = Join-Path $TestDrive 'manifest-auditor-modes.json'
+        $sections = @(
+            [pscustomobject]@{ Id = 'Summary'; Title = 'Summary'; renderingMode = 'full' },
+            [pscustomobject]@{ Id = 'Findings'; Title = 'Findings'; renderingMode = 'interactive' }
+        )
+
+        $manifest = New-ReportManifest -Path $path -SelectedTier 'PureJson' -Profile 'Auditor' -Sections $sections
+
+        foreach ($section in $manifest.Profile.Sections) {
+            $section.PSObject.Properties['renderingMode'] | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'every Profile.Degradations entry references a real section id (Declared Degradation Contract)' {
+        $path = Join-Path $TestDrive 'manifest-auditor-degradations.json'
+        $sections = @(
+            [pscustomobject]@{ Id = 'GraphCanvas'; Title = 'Graph Canvas'; renderingMode = 'summary' }
+        )
+        $features = @(
+            [pscustomobject]@{ name = 'GraphCanvas'; renderingMode = 'summary'; tier1Mode = 'interactive' }
+        )
+
+        $manifest = New-ReportManifest -Path $path -SelectedTier 'PureJson' -Profile 'Auditor' -Sections $sections -Features $features
+
+        $sectionIds = @($manifest.Profile.Sections | ForEach-Object { $_.Id })
+        foreach ($degradation in $manifest.Profile.Degradations) {
+            $featureName = $degradation.name
+            $sectionIds | Should -Contain $featureName
+        }
+    }
+
+    It 'does not append Profile block when -Profile Default' {
+        $path = Join-Path $TestDrive 'manifest-default.json'
+
+        $manifest = New-ReportManifest -Path $path -SelectedTier 'PureJson' -Profile 'Default'
+
+        $manifest.PSObject.Properties['Profile'] | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Track F Commit 8: Report-Manifest Auditor Profile Extension

Extends `New-ReportManifest` with `-Profile` and `-Sections` parameters to support auditor-driven report manifests. When `-Profile Auditor` is specified, appends a Profile block containing section metadata and a filtered subset of degradations (Declared Degradation Contract).

### Changes

**Code:**
- `modules/shared/ReportManifest.ps1`: +2 params (`-Profile`, `-Sections`), +Profile block logic
- `tests/shared/ReportManifest.Tests.ps1`: +4 tests (cumulative 18 ReportManifest tests)

**Documentation:**
- `.squad/decisions/inbox/atlas-trackf-commit8-manifest-profile-2026-05-13.md`: implementation decision + rationale
- `.squad/agents/atlas/history.md`: Commit 8 entry

### Profile Block Structure

When `-Profile Auditor`:
\\\json
{
  "Profile": {
    "Name": "auditor",
    "Sections": [
      { "Id": "ExecutiveSummary", "Title": "Executive Summary", "renderingMode": "full" },
      { "Id": "ControlDomains", "Title": "Control Domains", "renderingMode": "summary" }
    ],
    "Degradations": [
      { "name": "ControlDomains", "renderingMode": "summary", "tier1Mode": "interactive" }
    ]
  }
}
\\\

### Declared Degradation Contract

**Contract:** Every entry in `Profile.Degradations` MUST reference a section ID present in `Profile.Sections`.

**Enforcement:** Test #3 (`every Profile.Degradations entry references a real section id`) enforces this at CI time.

**Rationale:** Orphan degradations (degradations referencing non-existent sections) indicate a logic bug. The contract test catches wrapper/normalizer regressions before production.

### Test Coverage

- **Test 1:** Appends Profile block when `-Profile Auditor`
- **Test 2:** Every section in Profile has `renderingMode` property
- **Test 3:** Declared Degradation Contract (no orphan degradations)
- **Test 4:** Does not append Profile block when `-Profile Default` (backward compatibility)

**Total tests:** 31 (24 AuditorReportBuilder + 3 orchestrator + 4 ReportManifest extensions)  
**Status:** All passing

### Line-Ending Verification

\\\
git diff --cached --numstat
26      1       modules/shared/ReportManifest.ps1
61      0       tests/shared/ReportManifest.Tests.ps1

git diff --cached -w --numstat
26      1       modules/shared/ReportManifest.ps1
61      0       tests/shared/ReportManifest.Tests.ps1
\\\

**Result:** Identical counts → no line-ending flips (lesson from Commit 7 applied).

### Commits

1. `feat(report): Track F Commit 8 - report-manifest auditor profile extension`
2. `docs: Track F Commit 8 - decision drop + history update`

Refs #506