### PR TITLE
fix: AuditorReportBuilder triage key + HTML encoding + Profile ValidateSet (#1102)

### DIFF
--- a/AzureAnalyzer.psm1
+++ b/AzureAnalyzer.psm1
@@ -140,7 +140,8 @@ function Invoke-AzureAnalyzer {
         [switch] $NoBanner,
         [switch] $FixtureMode,
         [string] $FixturePath,
-        [string] $Profile
+        [ValidateSet('Default','Auditor')]
+        [string] $Profile = 'Default'
     )
 
     $scriptPath = Join-Path $ModuleRoot 'Invoke-AzureAnalyzer.ps1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Fixed
 
+- **BUG-1 (HIGH):** `Build-AuditorReport` was reading the wrong return key from `Get-AuditorTriageAnnotations`, nulling findings after triage and producing empty remediation/evidence/HTML sections in `-Profile Auditor` reports. Fixed in `AuditorReportBuilder.ps1:120` (#1102).
+- **RISK-1:** Auditor HTML renderer now HTML-encodes finding fields (defense-in-depth against malicious finding content).
+- **RISK-2:** `Invoke-AzureAnalyzer.psm1` wrapper now validates `-Profile` values via `[ValidateSet('Default','Auditor')]`.
+
 - **Track F Commit 10 HOTFIX**: Repaired 4 parameter/compatibility bugs blocking CI after Commit 9 merge: (1) added `-Profile` parameter to module wrapper (`AzureAnalyzer.psm1`) to match `Invoke-AzureAnalyzer.ps1`, (2) fixed `AuditorParity.Tests.ps1` to use tier architecture names (`'PureJson'`, `'EmbeddedSqlite'`) instead of integers, (3) corrected citation test fixture field names (`Source`/`RulePin` instead of `SourceTool`/`SourceToolVersion`), (4) replaced Windows-only `$env:TEMP` with cross-platform `[System.IO.Path]::GetTempPath()` in profile tests. Round 2: Fixed 4 test-side bugs (hashtable→PSCustomObject in Test 33 citation fixture, regex syntax in Test 34a, singleton `.Count` property in Test 35a/35b) and relaxed Test 32 assertions to match skeleton HTML renderer coverage only; marked Test 34b (Tier 2 sql.js embedding) as `-Pending` with follow-up issue #1098. Round 3: Relaxed Test 35 XLSX assertions to treat XLSX exports as optional (conditional on ImportExcel module availability in CI).
 
 ### Added

--- a/modules/shared/AuditorReportBuilder.ps1
+++ b/modules/shared/AuditorReportBuilder.ps1
@@ -117,7 +117,7 @@ function Build-AuditorReport {
         $annotated = Get-AuditorTriageAnnotations `
             -Findings $context.Findings `
             -TriagePath $TriagePath
-        $context['Findings'] = $annotated.Findings
+        $context['Findings'] = $annotated.AnnotatedFindings
         $context['TriagePresent'] = $annotated.TriagePresent
     } catch {
         $sectionErrors += "Get-AuditorTriageAnnotations failed: $_"
@@ -350,7 +350,9 @@ function ConvertTo-AuditorControlDomainSectionsHtml {
         [void]$html.AppendLine('<tbody>')
         
         foreach ($section in ($fwGroup.Group | Sort-Object ControlId)) {
-            [void]$html.AppendLine("<tr><td>$($section.ControlId)</td><td>$($section.FindingCount)</td></tr>")
+            $encodedControlId = ConvertTo-AuditorHtmlSafe $section.ControlId
+            $encodedCount = ConvertTo-AuditorHtmlSafe $section.FindingCount
+            [void]$html.AppendLine("<tr><td>$encodedControlId</td><td>$encodedCount</td></tr>")
         }
         
         [void]$html.AppendLine('</tbody></table>')
@@ -722,6 +724,26 @@ function Get-AuditorEvidenceExport {
     }
 }
 
+function ConvertTo-AuditorHtmlSafe {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline)] [string] $Text
+    )
+    
+    process {
+        if ([string]::IsNullOrEmpty($Text)) {
+            return ''
+        }
+        
+        # Manual HTML entity encoding (defense-in-depth)
+        $Text -replace '&', '&amp;' `
+              -replace '<', '&lt;' `
+              -replace '>', '&gt;' `
+              -replace '"', '&quot;' `
+              -replace "'", '&#39;'
+    }
+}
+
 function Write-AuditorRenderTier {
     [CmdletBinding()]
     param(
@@ -818,10 +840,10 @@ function Write-AuditorRenderTier {
             }
             $htmlContent += @"
             <tr>
-                <td>$($f.FindingId)</td>
-                <td class="$sevClass">$($f.Severity)</td>
-                <td>$($f.Title)</td>
-                <td>$($f.EntityId)</td>
+                <td>$(ConvertTo-AuditorHtmlSafe $f.FindingId)</td>
+                <td class="$sevClass">$(ConvertTo-AuditorHtmlSafe $f.Severity)</td>
+                <td>$(ConvertTo-AuditorHtmlSafe $f.Title)</td>
+                <td>$(ConvertTo-AuditorHtmlSafe $f.EntityId)</td>
             </tr>
 "@
         }
@@ -839,7 +861,9 @@ function Write-AuditorRenderTier {
         <ul>
 "@
         foreach ($f in $findings) {
-            $htmlContent += "            <li><a href='#finding-$($f.FindingId)'>$($f.Title)</a></li>`n"
+            $encodedId = ConvertTo-AuditorHtmlSafe $f.FindingId
+            $encodedTitle = ConvertTo-AuditorHtmlSafe $f.Title
+            $htmlContent += "            <li><a href='#finding-$encodedId'>$encodedTitle</a></li>`n"
         }
         $htmlContent += @"
         </ul>

--- a/tests/integration/AuditorParity.Tests.ps1
+++ b/tests/integration/AuditorParity.Tests.ps1
@@ -186,4 +186,94 @@ Describe 'Auditor Parity Tests' -Tag 'Integration' {
             }
         }
     }
+    
+    Context 'Test 36 - BUG-1 Regression: Triage Key Mismatch' {
+        It 'Should use AnnotatedFindings key after triage (not Findings)' {
+            Build-AuditorReport -InputPath $resultsPath `
+                                -EntitiesPath $entitiesPath `
+                                -ManifestPath $manifestPath `
+                                -TriagePath $triagePath `
+                                -OutputDirectory $testOutputDir `
+                                -Tier 'PureJson'
+            
+            $htmlPath = Join-Path $testOutputDir 'audit-report.html'
+            $htmlContent = Get-Content $htmlPath -Raw
+            
+            # Remediation appendix should be non-empty after triage
+            # (If the bug is present, findings become null after triage step)
+            $htmlContent | Should -MatchExactly '<table'
+            $htmlContent | Should -MatchExactly 'Finding ID'
+            
+            # Evidence export should contain data rows (not just headers)
+            $csvPath = Join-Path $testOutputDir 'audit-evidence' 'findings.csv'
+            $csvPath | Should -Exist
+            $csvContent = Get-Content $csvPath -Raw
+            $csvLines = $csvContent -split "`n" | Where-Object { $_.Trim() -ne '' }
+            $csvLines.Count | Should -BeGreaterThan 1  # Header + at least 1 data row
+            
+            # HTML should contain actual finding IDs (not ghost row from @($null))
+            $htmlContent | Should -MatchExactly 'F-\d+-F-001'
+        }
+    }
+    
+    Context 'Test 37 - RISK-1 Regression: HTML Encoding' {
+        It 'Should HTML-encode finding fields to prevent injection' {
+            $maliciousTitle = '<script>alert(1)</script>'
+            $testFinding = [pscustomobject]@{
+                FindingId = 'F-XSS-001'
+                Severity = 'Critical'
+                Title = $maliciousTitle
+                EntityId = '/subscriptions/test-sub/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-prod'
+            }
+            
+            $tempDir = Join-Path $TestDrive 'xss-test'
+            New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+            
+            $tempResultsPath = Join-Path $tempDir 'results.json'
+            @($testFinding) | ConvertTo-Json | Set-Content $tempResultsPath
+            
+            $tempEntitiesPath = Join-Path $tempDir 'entities.json'
+            '[]' | Set-Content $tempEntitiesPath
+            
+            Build-AuditorReport -InputPath $tempResultsPath `
+                                -EntitiesPath $tempEntitiesPath `
+                                -ManifestPath $manifestPath `
+                                -OutputDirectory $tempDir `
+                                -Tier 'PureJson'
+            
+            $htmlPath = Join-Path $tempDir 'audit-report.html'
+            $htmlContent = Get-Content $htmlPath -Raw
+            
+            # Verify script tag is encoded (not raw)
+            $htmlContent | Should -MatchExactly '&lt;script&gt;'
+            $htmlContent | Should -Not -MatchExactly '<script>alert\(1\)</script>'
+        }
+    }
+    
+    Context 'Test 38 - RISK-2 Regression: Profile ValidateSet' {
+        It 'Should reject invalid -Profile values' {
+            Import-Module "$PSScriptRoot\..\..\AzureAnalyzer.psd1" -Force -ErrorAction Stop
+            try {
+                { Invoke-AzureAnalyzer -Profile 'InvalidValue' -ErrorAction Stop } |
+                    Should -Throw -ExpectedMessage '*Cannot validate*'
+            } finally {
+                Remove-Module AzureAnalyzer -Force -ErrorAction SilentlyContinue
+            }
+        }
+        
+        It 'Should accept valid -Profile values' {
+            # Verify orchestrator script has ValidateSet
+            $paramMetadata = (Get-Command "$PSScriptRoot\..\..\Invoke-AzureAnalyzer.ps1").Parameters['Profile']
+            $paramMetadata.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } | Should -Not -BeNullOrEmpty
+            
+            # Verify module wrapper also has ValidateSet
+            Import-Module "$PSScriptRoot\..\..\AzureAnalyzer.psd1" -Force -ErrorAction Stop
+            try {
+                $wrapperMetadata = (Get-Command Invoke-AzureAnalyzer).Parameters['Profile']
+                $wrapperMetadata.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } | Should -Not -BeNullOrEmpty
+            } finally {
+                Remove-Module AzureAnalyzer -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #1102

## Summary

Three fixes for Track F auditor report builder, surfaced by issue #1102.

### BUG-1 (HIGH)
`Build-AuditorReport` line 120 was reading `.Findings` but `Get-AuditorTriageAnnotations` returns `.AnnotatedFindings`. This nulled findings after triage, breaking:
- Remediation appendix (empty groups)
- Evidence export (zero-row CSV/JSON/XLSX)
- HTML/MD renderer (ghost row from `@()`)

Fixed in `modules/shared/AuditorReportBuilder.ps1:120`.

### RISK-1
Added `ConvertTo-AuditorHtmlSafe` helper that HTML-encodes `& < > " '` to prevent malicious finding content (titles, IDs, entity IDs, control IDs) from injecting script tags or breaking HTML structure. Applied at every HTML interpolation site in `Write-AuditorRenderTier` and the control-domain section renderer.

### RISK-2
Added `[ValidateSet('Default','Auditor')]` to `-Profile` parameter on the `Invoke-AzureAnalyzer` module wrapper in `AzureAnalyzer.psm1` so it matches `Invoke-AzureAnalyzer.ps1` and rejects typos at parse time instead of silently degrading to Default.

## Tests

Three regression tests added to `tests/integration/AuditorParity.Tests.ps1`:
- **Test 36** — BUG-1 regression: validates non-empty remediation appendix, evidence CSV with data rows, HTML contains actual finding IDs after triage.
- **Test 37** — RISK-1 regression: injects `<script>` in Title and asserts encoded as `&lt;script&gt;`.
- **Test 38** — RISK-2 regression: validates ValidateSet exists on both the orchestrator script and the module wrapper, and that an invalid `-Profile` value throws `Cannot validate`.

All 9 tests pass locally (1 pre-existing `-Pending` Tier 2 sql.js test).

## Docs

- `CHANGELOG.md` updated under Unreleased / Fixed with entries for BUG-1, RISK-1, RISK-2.
