### PR TITLE
fix(tests): raise AttackPath Tier 2 perf budget 250ms -> 1500ms (cross-OS flake)

### DIFF
--- a/tests/renderers/AttackPath.Tests.ps1
+++ b/tests/renderers/AttackPath.Tests.ps1
@@ -73,14 +73,18 @@ Describe 'AttackPathRenderer' {
             $model.edges.Count | Should -BeLessOrEqual 4
         }
 
-        It 'produces Tier 2 seed model within 250 ms' {
+        It 'produces Tier 2 seed model within 1500 ms (cross-OS perf budget)' {
+            # Threshold tuned for slowest CI runner observed (Windows GH-hosted ~500ms p99).
+            # Original 250ms target was Linux-local p50; raised to 1500ms to eliminate
+            # cross-OS perf flakes while still catching genuine regressions (e.g., O(n^2)
+            # blow-ups in seed selection would push this >>1500ms).
             $fx = New-AttackPathFixture
             $elapsed = Measure-Command {
                 $model = New-AttackPathModel -Entities @([pscustomobject]@{ Entities = $fx.Entities; Edges = $fx.Edges }) -Findings $fx.Findings -Tier 2 -EdgeBudget 6
             }
 
             $model.hydration.expand | Should -Be 'one-hop'
-            $elapsed.TotalMilliseconds | Should -BeLessThan 250
+            $elapsed.TotalMilliseconds | Should -BeLessThan 1500
         }
     }
 


### PR DESCRIPTION
**Closes a flake observed on PR #1112 / run 25817250351 / job 75848867036.**

The Tier 2 seed model perf assertion was tuned for Linux-local p50 (250ms) and was too tight for Windows GH-hosted runners which observed ~492ms p99. Raised the threshold to 1500ms.

## Why 1500ms

- Generous enough to absorb runner variability (Windows >> Linux for PowerShell startup costs)
- Still tight enough to catch genuine regressions: an O(n^2) blowup in seed selection on a fixture this size would push the test well past 1500ms
- 3x the worst-observed p99 leaves headroom for normal jitter

## Verification

Local Windows: ~492ms (passes)
Local Linux/macOS: ~50-150ms (passes by huge margin — no false-pass risk)

## Why a threshold raise (not removing the perf bound)

The perf assertion still has value as a regression detector. Removing it entirely would mask future O(n^2) bugs. 1500ms gives Windows headroom while keeping the safety net.