### PR TITLE
fix(tests): raise IdentityGraphExpansion fixture perf budget 30s -> 60s

### DIFF
--- a/tests/wrappers/Invoke-IdentityGraphExpansion.Tests.ps1
+++ b/tests/wrappers/Invoke-IdentityGraphExpansion.Tests.ps1
@@ -382,6 +382,9 @@ Describe 'Invoke-IdentityGraphExpansion large fixture correctness' {
         $memberEdges.Count | Should -Be 1000
 
         # Fixture-mode has no live Graph calls; processing should be fast.
-        $elapsed.TotalSeconds | Should -BeLessThan 30
+        # Threshold tuned for slowest CI runner observed (Windows GH-hosted).
+        # 60s gives generous headroom for 1000-edge fixture processing while
+        # still catching genuine O(n^2) regressions in edge expansion.
+        $elapsed.TotalSeconds | Should -BeLessThan 60
     }
 }


### PR DESCRIPTION
Closes Sentinel audit AMBER A2 (issue #1116).

## What

Raise perf threshold at `tests/wrappers/Invoke-IdentityGraphExpansion.Tests.ps1:385` from 30s to 60s.

## Why

Fixture-mode processing of 1000 edges has no live Graph calls but still has measurable PowerShell overhead. 30s is reasonable on Linux but tight enough to flake on slow Windows GH-hosted runners under load.

60s gives 2x headroom while still catching genuine O(n^2) regressions in edge expansion logic (those would push the test well past 60s on any platform).

## Same class of fix as #1114

This is the second of two AMBER perf-bound fixes from Sentinel's pre-departure test rigor audit. After this lands, the test suite has zero known time-sensitive flakes on cross-OS CI.