### PR TITLE
fix(tests): add AfterEach env restore to LiveTool.StateIsolation guard

### DIFF
--- a/tests/wrappers/LiveTool.StateIsolation.Tests.ps1
+++ b/tests/wrappers/LiveTool.StateIsolation.Tests.ps1
@@ -19,6 +19,23 @@ BeforeAll {
     $script:RepoRoot = Resolve-Path (Join-Path $script:Here '..' '..')
     $script:GitleaksWrapper = Join-Path $script:RepoRoot 'modules' 'Invoke-Gitleaks.ps1'
     . (Join-Path $script:RepoRoot 'tests' '_helpers' 'Capture-WrapperHostOutput.ps1')
+
+    # Snapshot env vars this file deliberately mutates so AfterEach can restore
+    # the prior value (or remove the var if it was unset). Required by the
+    # test isolation guard in tests/shared/TestIsolation.Tests.ps1 (#746).
+    $script:_OrigGitleaksReportPath = if (Test-Path Env:GITLEAKS_REPORT_PATH) { $env:GITLEAKS_REPORT_PATH } else { $null }
+    $script:_OrigLastExitCode = $global:LASTEXITCODE
+}
+
+AfterEach {
+    # Restore $env:GITLEAKS_REPORT_PATH to its pre-test state.
+    if ($null -eq $script:_OrigGitleaksReportPath) {
+        Remove-Item Env:GITLEAKS_REPORT_PATH -ErrorAction SilentlyContinue
+    } else {
+        $env:GITLEAKS_REPORT_PATH = $script:_OrigGitleaksReportPath
+    }
+    # Restore $LASTEXITCODE so subsequent test files don't inherit our pollution.
+    $global:LASTEXITCODE = $script:_OrigLastExitCode
 }
 
 Describe 'LiveTool state isolation guard (#1065 regression)' -Tag 'LiveTool' {


### PR DESCRIPTION
## Why

Release workflow for v1.7.1 (run 25821388555) failed at the **Pester gate** with:

```
[-] Test isolation guard (#746).every test file that writes $env:* has lifecycle cleanup and env restore operations
Expected $null or empty, because every test file that mutates $env:* must restore it; offenders:
tests/wrappers/LiveTool.StateIsolation.Tests.ps1 (missing cleanup lifecycle block and/or env restore operation)
```

## Root cause

Atlas's #1065 regression test (added in #1117) sets `$env:GITLEAKS_REPORT_PATH` and
restores it inside a `finally` block. The guard's heuristic regex requires the env
restore to be reachable from the `finally` keyword **without crossing a `}`**:

```
\bfinally\s*\{[^}]*?(Remove-Item\s+Env:|...)
```

Atlas's `finally` opened an inner `if (Test-Path $tempRoot) { Remove-Item ... }`
**before** the env restore line, so the inner brace blocked the regex from seeing
the `Remove-Item Env:GITLEAKS_REPORT_PATH` further down.

## Fix

Pester-idiomatic refactor:

- **`BeforeAll`** snapshots pre-test `$env:GITLEAKS_REPORT_PATH` and `$LASTEXITCODE`
- **`AfterEach`** restores both to their original values (or removes the env var if it was unset)
- The guard recognises `AfterEach` as a cleanup lifecycle block, and the assignment satisfies the env-restore op

## Verification

`Invoke-Pester -Path tests/shared/TestIsolation.Tests.ps1 -CI` -> 3 passed, 0 failed locally.

## Impact

- Unblocks v1.7.1 publish to PSGallery (release-please-action will retry on next push to main)
- Hardens the regression guard: `$LASTEXITCODE` pollution from this file no longer leaks into downstream tests in the same pwsh process

Refs #1065 #1117
