### PR TITLE
fix(tests): nest BeforeAll/AfterEach inside Describe (Pester 5 root-scope)

### DIFF
--- a/tests/wrappers/LiveTool.StateIsolation.Tests.ps1
+++ b/tests/wrappers/LiveTool.StateIsolation.Tests.ps1
@@ -19,26 +19,31 @@ BeforeAll {
     $script:RepoRoot = Resolve-Path (Join-Path $script:Here '..' '..')
     $script:GitleaksWrapper = Join-Path $script:RepoRoot 'modules' 'Invoke-Gitleaks.ps1'
     . (Join-Path $script:RepoRoot 'tests' '_helpers' 'Capture-WrapperHostOutput.ps1')
-
-    # Snapshot env vars this file deliberately mutates so AfterEach can restore
-    # the prior value (or remove the var if it was unset). Required by the
-    # test isolation guard in tests/shared/TestIsolation.Tests.ps1 (#746).
-    $script:_OrigGitleaksReportPath = if (Test-Path Env:GITLEAKS_REPORT_PATH) { $env:GITLEAKS_REPORT_PATH } else { $null }
-    $script:_OrigLastExitCode = $global:LASTEXITCODE
-}
-
-AfterEach {
-    # Restore $env:GITLEAKS_REPORT_PATH to its pre-test state.
-    if ($null -eq $script:_OrigGitleaksReportPath) {
-        Remove-Item Env:GITLEAKS_REPORT_PATH -ErrorAction SilentlyContinue
-    } else {
-        $env:GITLEAKS_REPORT_PATH = $script:_OrigGitleaksReportPath
-    }
-    # Restore $LASTEXITCODE so subsequent test files don't inherit our pollution.
-    $global:LASTEXITCODE = $script:_OrigLastExitCode
 }
 
 Describe 'LiveTool state isolation guard (#1065 regression)' -Tag 'LiveTool' {
+    BeforeAll {
+        # Snapshot env vars this file deliberately mutates so AfterEach can
+        # restore the prior value (or remove the var if it was unset). Required
+        # by tests/shared/TestIsolation.Tests.ps1 (#746).
+        $script:_OrigGitleaksReportPath = if (Test-Path Env:GITLEAKS_REPORT_PATH) { $env:GITLEAKS_REPORT_PATH } else { $null }
+        # Set-StrictMode -Version Latest throws if $global:LASTEXITCODE has never
+        # been set, so look it up via Get-Variable instead of direct access.
+        $script:_OrigLastExitCode = (Get-Variable -Name LASTEXITCODE -Scope Global -ValueOnly -ErrorAction SilentlyContinue)
+        if ($null -eq $script:_OrigLastExitCode) { $script:_OrigLastExitCode = 0 }
+    }
+
+    AfterEach {
+        # Restore $env:GITLEAKS_REPORT_PATH to its pre-test state.
+        if ($null -eq $script:_OrigGitleaksReportPath) {
+            Remove-Item Env:GITLEAKS_REPORT_PATH -ErrorAction SilentlyContinue
+        } else {
+            $env:GITLEAKS_REPORT_PATH = $script:_OrigGitleaksReportPath
+        }
+        # Restore $LASTEXITCODE so subsequent test files don't inherit our pollution.
+        $global:LASTEXITCODE = $script:_OrigLastExitCode
+    }
+
     It 'gitleaks smoke test passes even when $LASTEXITCODE is leaked from prior test' -Skip:(-not (Get-Command gitleaks -ErrorAction SilentlyContinue)) {
         # Deliberately pollute: simulate FixtureMode.Tests.ps1:23 leaking non-zero exit
         $global:LASTEXITCODE = 1


### PR DESCRIPTION
## Why

Follow-up to PR #1119: cross-OS Test job failed on Linux + macOS with:

```
RuntimeException: Each test Teardown is not supported in root (directly in the block container).
```

Pester 5 disallows `AfterEach` (and `BeforeEach`) at the script-root scope — they must live inside a `Describe` or `Context` block. Windows runners happened to skip the file (gitleaks not installed) so the local guard-only verification missed it.

## Fix

- Move the env-snapshot `BeforeAll` and the env-restore `AfterEach` **inside** the `Describe` block so Pester accepts them.
- Harden the `$LASTEXITCODE` snapshot: `Set-StrictMode -Version Latest` throws if the variable has never been set, so use `Get-Variable -Name LASTEXITCODE -Scope Global -ValueOnly -ErrorAction SilentlyContinue` instead of direct `$global:LASTEXITCODE`.
- Default to `0` if the variable is unset, so AfterEach restores a deterministic value.

## Verification

```
tests/wrappers/LiveTool.Wrappers.Tests.ps1     -> passed
tests/wrappers/LiveTool.StateIsolation.Tests.ps1 -> passed
tests/shared/TestIsolation.Tests.ps1           -> passed
Tests Passed: 7, Failed: 0, Skipped: 3
```

The 3 skips are Linux-only sentinel skips (gitleaks not on the local Windows box) — they will run on the Linux/macOS CI matrix and the AfterEach now lives in valid scope.

## Impact

Unblocks v1.7.1 PSGallery publish (release-please-action will retry on next push to main).

Refs #1065 #1117 #1119
