### PR TITLE
ci: migrate Windows matrix legs to runner-preflight pattern (Pool W-pub)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,30 @@ permissions:
   actions: read
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Preflight (Windows): probe Pool W-pub. If >= 1 W-pub runner is online,
+  # the Windows leg of the matrix below runs on [self-hosted, alz-w-pub];
+  # otherwise it falls back to windows-latest. See
+  # martinopedal/personal-runners-infra/docs/WINDOWS-PREFLIGHT.md for details.
+  # ---------------------------------------------------------------------------
+  preflight-windows:
+    uses: martinopedal/personal-runners-infra/.github/workflows/runner-preflight.yml@main
+    with:
+      os: windows
+      desired_label: alz-w-pub
+      min_online: 1
+
   test:
     name: Test
-    runs-on: ${{ matrix.os }}
+    needs: [preflight-windows]
+    # Cross-OS dispatch:
+    #   windows-latest -> preflight-windows output (self-hosted or fallback)
+    #   ubuntu-latest  -> literal (no P1 preflight wired here yet)
+    #   macos-latest   -> literal (no self-hosted macOS pool)
+    runs-on: >-
+      ${{ matrix.os == 'windows-latest'
+          && fromJSON(needs.preflight-windows.outputs.runner_label)
+          || matrix.os }}
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,12 +21,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Preflight (Windows): probe Pool W-pub for the Windows leg of the matrix.
+  # See martinopedal/personal-runners-infra/docs/WINDOWS-PREFLIGHT.md.
+  # ---------------------------------------------------------------------------
+  preflight-windows:
+    uses: martinopedal/personal-runners-infra/.github/workflows/runner-preflight.yml@main
+    with:
+      os: windows
+      desired_label: alz-w-pub
+      min_online: 1
+
   e2e:
+    needs: [preflight-windows]
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: >-
+      ${{ matrix.os == 'windows-latest'
+          && fromJSON(needs.preflight-windows.outputs.runner_label)
+          || matrix.os }}
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,18 +345,35 @@ jobs:
             Publish-Module -Path '${{ steps.package.outputs.module_root }}' -NuGetApiKey $env:PSGALLERY_API_KEY -Repository PSGallery
 
   # ---------------------------------------------------------------------------
+  # Preflight (Windows): probe Pool W-pub for the Windows leg of the
+  # psgallery_e2e matrix below. See
+  # martinopedal/personal-runners-infra/docs/WINDOWS-PREFLIGHT.md.
+  # Runs in parallel with `publish` to avoid serial latency.
+  # ---------------------------------------------------------------------------
+  preflight-windows:
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    uses: martinopedal/personal-runners-infra/.github/workflows/runner-preflight.yml@main
+    with:
+      os: windows
+      desired_label: alz-w-pub
+      min_online: 1
+
+  # ---------------------------------------------------------------------------
   # PSGallery post-publish E2E verification (cross-platform matrix)
   # Replaces the former inline smoke step with a full 8-check gate.
   # ---------------------------------------------------------------------------
   psgallery_e2e:
     name: PSGallery E2E (${{ matrix.os }})
-    needs: publish
+    needs: [publish, preflight-windows]
     if: needs.publish.result == 'success'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: >-
+      ${{ matrix.os == 'windows-latest'
+          && fromJSON(needs.preflight-windows.outputs.runner_label)
+          || matrix.os }}
     timeout-minutes: 15
     steps:
       - name: Install module from PSGallery


### PR DESCRIPTION
## Summary

Migrates the **Windows leg** of all 3 cross-OS matrix workflows to the reusable
`runner-preflight.yml` pattern with Pool W-pub as the self-hosted target.

| Workflow | Job | Matrix shape | Change |
|---|---|---|---|
| `ci.yml` | `test` | `os: [ubuntu, windows, macos]` | Windows leg ├ö├Ñ├å preflight (P1/macOS unchanged) |
| `e2e.yml` | `e2e` | `os: [windows, ubuntu, macos]` | Same |
| `release.yml` | `psgallery_e2e` | `os: [ubuntu, windows]` | Same |

## How the cross-OS routing works

```yaml
runs-on: >-
  ${{ matrix.os == 'windows-latest'
      && fromJSON(needs.preflight-windows.outputs.runner_label)
      || matrix.os }}
```

`matrix.os` values stay as literal strings (`ubuntu-latest`, `windows-latest`,
`macos-latest`) so existing downstream conditions like
`if: matrix.os == 'ubuntu-latest'` (ci.yml L105, L195) continue to work
unchanged. Only the Windows matrix instance is rerouted through preflight.

## Status ├ö├ç├Â DRAFT

This PR is a draft and **will not be marked ready** until both of these merge:

- [ ] `martinopedal/personal-runners-infra#2` ├ö├ç├Â the reusable preflight workflow
- [ ] `alz-avm-tf-demo/alz-prod#6` ├ö├ç├Â Pool W-pub VMSS provisioning

### What happens if I merge before W-pub is deployed?

The job still runs ├ö├ç├Â preflight queries the runners endpoint, finds zero
W-pub runners, and falls back to `windows-latest` (GitHub-hosted). No
behavior change for the build itself; we just don't capture the cost saving
until W-pub is online. Once the VMSS is applied, preflight automatically
starts choosing `[self-hosted, alz-w-pub]` with no further workflow change.

## Per-OS preflight for Linux

Not in this PR. The Linux preflight for Pool P1 (`alz-p1`) would follow the
same pattern ├ö├ç├Â add a `preflight-linux` job and extend the `runs-on`
conditional. Tracked separately under the Linux migration sprint (PR #4 in
`personal-runners-infra` and the parallel agents).

## Cost projection (when W-pub is online)

azure-analyzer Windows minutes per month (estimated from current run cadence):

| Workflow | Runs/mo | Avg Windows mins/run | Total Windows mins/mo |
|---|---:|---:|---:|
| `ci.yml` test (Win leg) | ~120 | ~6 | ~720 |
| `e2e.yml` (Win leg) | ~60 | ~3 | ~180 |
| `release.yml` psgallery_e2e (Win leg) | ~4 | ~10 | ~40 |
| **Subtotal** | | | **~940 min/mo** |

At GitHub-hosted private-repo rates (`$0.016/min` Windows), `940 min Ôö£├╣ $0.016 ├ö├½├¬
$15/mo` for this repo alone. Across the org (azure-analyzer + FinOps-assessment
combined ~3,500 Win-min/mo projected), full migration captures roughly `$55/mo`
direct savings, plus ~1.7Ôö£├╣ wall-clock speed-up on Pester suites from the
`Standard_D8ds_v6` (8 vCPU vs GitHub's 4 vCPU).

## Reference

- Pattern guide: `martinopedal/personal-runners-infra/docs/WINDOWS-PREFLIGHT.md` (PR #5)
- Working template: `martinopedal/personal-runners-infra/.github/workflows/example-windows-preflight.yml.disabled`
- W-pub label source: `alz-avm-tf-demo/alz-prod/pool-w-pub/variables.tf` L233



---

Closes #1144