### PR TITLE
fix: preflight desired_label personal-windows (Pool P2 label split)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     uses: martinopedal/personal-runners-infra/.github/workflows/runner-preflight.yml@main
     with:
       os: windows
-      desired_label: alz-w-pub
+      desired_label: personal-windows
       min_online: 1
 
   test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
     uses: martinopedal/personal-runners-infra/.github/workflows/runner-preflight.yml@main
     with:
       os: windows
-      desired_label: alz-w-pub
+      desired_label: personal-windows
       min_online: 1
 
   e2e:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,7 +355,7 @@ jobs:
     uses: martinopedal/personal-runners-infra/.github/workflows/runner-preflight.yml@main
     with:
       os: windows
-      desired_label: alz-w-pub
+      desired_label: personal-windows
       min_online: 1
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1150

Pool P2 VMSS Windows runners now register with personal-windows label. Updates ci.yml, e2e.yml, release.yml so preflight matches and routes to self-hosted instead of windows-latest fallback.