### PR TITLE
ci: route Linux to ACA Pool P1, drop preflight-windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,14 @@ jobs:
   # ---------------------------------------------------------------------------
   # Cross-OS dispatch:
   #   ubuntu-latest  -> ACA Pool P1 ([self-hosted, alz-p1])
-  #   windows-latest -> GitHub-hosted (VMSS Pool W-pub currently only enrolls
-  #                     personal-runners-infra; azure-analyzer multi-tenant
-  #                     enrollment tracked separately)
+  #   windows-latest -> VMSS Pool W-pub ([self-hosted, personal-windows])
   #   macos-latest   -> literal (no self-hosted macOS pool)
   # ---------------------------------------------------------------------------
   test:
     name: Test
     runs-on: >-
-      ${{ matrix.os == 'ubuntu-latest'
-          && fromJSON('["self-hosted","alz-p1"]')
+      ${{ (matrix.os == 'ubuntu-latest'  && fromJSON('["self-hosted","alz-p1"]'))
+          || (matrix.os == 'windows-latest' && fromJSON('["self-hosted","personal-windows"]'))
           || matrix.os }}
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,28 +17,18 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Preflight (Windows): probe Pool W-pub. If >= 1 W-pub runner is online,
-  # the Windows leg of the matrix below runs on [self-hosted, alz-w-pub];
-  # otherwise it falls back to windows-latest. See
-  # martinopedal/personal-runners-infra/docs/WINDOWS-PREFLIGHT.md for details.
+  # Cross-OS dispatch:
+  #   ubuntu-latest  -> ACA Pool P1 ([self-hosted, alz-p1])
+  #   windows-latest -> GitHub-hosted (VMSS Pool W-pub currently only enrolls
+  #                     personal-runners-infra; azure-analyzer multi-tenant
+  #                     enrollment tracked separately)
+  #   macos-latest   -> literal (no self-hosted macOS pool)
   # ---------------------------------------------------------------------------
-  preflight-windows:
-    uses: martinopedal/personal-runners-infra/.github/workflows/runner-preflight.yml@main
-    with:
-      os: windows
-      desired_label: personal-windows
-      min_online: 1
-
   test:
     name: Test
-    needs: [preflight-windows]
-    # Cross-OS dispatch:
-    #   windows-latest -> preflight-windows output (self-hosted or fallback)
-    #   ubuntu-latest  -> literal (no P1 preflight wired here yet)
-    #   macos-latest   -> literal (no self-hosted macOS pool)
     runs-on: >-
-      ${{ matrix.os == 'windows-latest'
-          && fromJSON(needs.preflight-windows.outputs.runner_label)
+      ${{ matrix.os == 'ubuntu-latest'
+          && fromJSON('["self-hosted","alz-p1"]')
           || matrix.os }}
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,8 +31,8 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: >-
-      ${{ matrix.os == 'ubuntu-latest'
-          && fromJSON('["self-hosted","alz-p1"]')
+      ${{ (matrix.os == 'ubuntu-latest'  && fromJSON('["self-hosted","alz-p1"]'))
+          || (matrix.os == 'windows-latest' && fromJSON('["self-hosted","personal-windows"]'))
           || matrix.os }}
     timeout-minutes: 8
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,22 +25,14 @@ jobs:
   # Preflight (Windows): probe Pool W-pub for the Windows leg of the matrix.
   # See martinopedal/personal-runners-infra/docs/WINDOWS-PREFLIGHT.md.
   # ---------------------------------------------------------------------------
-  preflight-windows:
-    uses: martinopedal/personal-runners-infra/.github/workflows/runner-preflight.yml@main
-    with:
-      os: windows
-      desired_label: personal-windows
-      min_online: 1
-
   e2e:
-    needs: [preflight-windows]
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: >-
-      ${{ matrix.os == 'windows-latest'
-          && fromJSON(needs.preflight-windows.outputs.runner_label)
+      ${{ matrix.os == 'ubuntu-latest'
+          && fromJSON('["self-hosted","alz-p1"]')
           || matrix.os }}
     timeout-minutes: 8
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,8 +359,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: >-
-      ${{ matrix.os == 'ubuntu-latest'
-          && fromJSON('["self-hosted","alz-p1"]')
+      ${{ (matrix.os == 'ubuntu-latest'  && fromJSON('["self-hosted","alz-p1"]'))
+          || (matrix.os == 'windows-latest' && fromJSON('["self-hosted","personal-windows"]'))
           || matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,29 +350,17 @@ jobs:
   # martinopedal/personal-runners-infra/docs/WINDOWS-PREFLIGHT.md.
   # Runs in parallel with `publish` to avoid serial latency.
   # ---------------------------------------------------------------------------
-  preflight-windows:
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    uses: martinopedal/personal-runners-infra/.github/workflows/runner-preflight.yml@main
-    with:
-      os: windows
-      desired_label: personal-windows
-      min_online: 1
-
-  # ---------------------------------------------------------------------------
-  # PSGallery post-publish E2E verification (cross-platform matrix)
-  # Replaces the former inline smoke step with a full 8-check gate.
-  # ---------------------------------------------------------------------------
   psgallery_e2e:
     name: PSGallery E2E (${{ matrix.os }})
-    needs: [publish, preflight-windows]
+    needs: [publish]
     if: needs.publish.result == 'success'
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: >-
-      ${{ matrix.os == 'windows-latest'
-          && fromJSON(needs.preflight-windows.outputs.runner_label)
+      ${{ matrix.os == 'ubuntu-latest'
+          && fromJSON('["self-hosted","alz-p1"]')
           || matrix.os }}
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Linux leg now uses [self-hosted, alz-p1] (ACA Pool P1, sub-5, proven working with news-fetcher run 26372671079). Windows kept on GH-hosted until VMSS multi-tenant enrollment is solved. Removes preflight-windows job from ci.yml, e2e.yml, release.yml.