### PR TITLE
wave-22: Cascade priv-pool labels

### DIFF
--- a/.github/workflows/alz-queries-drift-check.yml
+++ b/.github/workflows/alz-queries-drift-check.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   drift-check:
     name: Detect ALZ query drift
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 5
     steps:
       # no-retry: single addLabels REST call. github-script ships its own Octokit

--- a/.github/workflows/bicep-build.yml
+++ b/.github/workflows/bicep-build.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   bicep-build:
     name: Bicep build smoke test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/ci-failure-watchdog.yml
+++ b/.github/workflows/ci-failure-watchdog.yml
@@ -51,7 +51,7 @@ permissions:
 
 jobs:
   triage-failure:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     # Concurrency:
     # Constant group key is safe because the triage step is hash-idempotent
@@ -256,7 +256,7 @@ jobs:
   # if triage-failure is skipped. Posts a sticky issue if any past-7-day
   # watchdog run had jobs_count == 0 and conclusion == failure.
   self-health-check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 5
     if: always()
     permissions:

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   digest:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
 
   live-tool-tests:
     name: LiveTool wrappers (non-blocking)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 30
     # Non-blocking by design: live binaries add early integration signal without gating merges.
     # tracked: martinopedal/azure-analyzer#604
@@ -328,7 +328,7 @@ jobs:
 
   verify-install-manifest:
     name: Verify install manifest
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -397,7 +397,7 @@ jobs:
 
   generate-sbom:
     name: Generate SBOM (dry run)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -448,7 +448,7 @@ jobs:
 
   validate-module-manifest:
     name: Validate module manifest (Test-ModuleManifest)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     # PSGallery readiness gate (#963): catches manifest regressions on every PR,
     # not just at release time. Runs Test-ModuleManifest against AzureAnalyzer.psd1

--- a/.github/workflows/closes-link-required.yml
+++ b/.github/workflows/closes-link-required.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   closes-link:
     name: Closes/Fixes link required
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 5
     steps:
       - name: Verify PR body has Closes/Fixes link or N/A justification

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 30
     permissions:
       security-events: write

--- a/.github/workflows/copilot-agent-pr-review.yml
+++ b/.github/workflows/copilot-agent-pr-review.yml
@@ -25,7 +25,7 @@ jobs:
     # Skip drafts (Copilot review is requested when PR is marked ready) and fork PRs
     # (no write token under pull_request_target, cannot request reviewers anyway).
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 5
     steps:
       # no-retry: github-script wraps Octokit which already retries 5xx + 429.

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   docs-required:
     name: Documentation update check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -161,7 +161,7 @@ jobs:
 
   tool-catalog-fresh:
     name: Tool catalog fresh
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -182,7 +182,7 @@ jobs:
 
   permissions-pages-fresh:
     name: Permissions pages fresh
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -199,7 +199,7 @@ jobs:
 
   readme-facts-fresh:
     name: README facts fresh
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/issue-resolution-verify.yml
+++ b/.github/workflows/issue-resolution-verify.yml
@@ -25,7 +25,7 @@ jobs:
   verify:
     name: Verify repro for closed issues
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 30
     steps:
       - name: Checkout merged head (post-merge SHA)

--- a/.github/workflows/markdown-check.yml
+++ b/.github/workflows/markdown-check.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   lint:
     name: lint (markdownlint-cli2)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -43,7 +43,7 @@ jobs:
 
   links:
     name: links (lychee)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -139,7 +139,7 @@ jobs:
 
   em-dash:
     name: em-dash policy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pr-advisory-gate.yml
+++ b/.github/workflows/pr-advisory-gate.yml
@@ -42,7 +42,7 @@ jobs:
       github.event.pull_request != null
       && github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 5
     # justified: gate is non-blocking by design (advisory only, see #109).
     # Job-level continue-on-error ensures any uncaught failure inside the

--- a/.github/workflows/pr-auto-rebase.yml
+++ b/.github/workflows/pr-auto-rebase.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   enumerate:
     name: Enumerate conflicting agent PRs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     outputs:
       prs: ${{ steps.list.outputs.prs }}
@@ -83,7 +83,7 @@ jobs:
     name: "Auto-rebase PR #${{ matrix.pr.number }}"
     needs: enumerate
     if: needs.enumerate.outputs.count != '0' && needs.enumerate.outputs.count != ''
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-auto-rerun-on-push.yml
+++ b/.github/workflows/pr-auto-rerun-on-push.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   rerun-failed-checks:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     # Branch filter: only fire on agent-pushed branches. Manual dispatch
     # bypasses the filter so a maintainer can recover any PR.

--- a/.github/workflows/pr-auto-resolve-threads.yml
+++ b/.github/workflows/pr-auto-resolve-threads.yml
@@ -37,7 +37,7 @@ jobs:
     if: >-
       github.event.pull_request != null
       && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     # The default GITHUB_TOKEN only needs read access -- write scope is
     # carried by the GitHub App installation token minted in the
     # `app-token` step (pull_requests:write granted at install time).

--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -26,7 +26,7 @@ jobs:
       (github.event_name == 'pull_request_review' &&
       (github.event.review.state == 'CHANGES_REQUESTED' ||
       (github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' && github.event.review.state != 'APPROVED')))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
   release_please:
     name: Release Please (main)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 20
     permissions:
       contents: write
@@ -55,7 +55,7 @@ jobs:
   publish:
     name: Publish release artifacts
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 30
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/scheduled-scan.yml
+++ b/.github/workflows/scheduled-scan.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   scan:
     name: Run azure-analyzer
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 60
     permissions:
       id-token: write   # OIDC federated token to Azure
@@ -261,7 +261,7 @@ jobs:
     name: Report critical findings
     needs: scan
     if: always() && needs.scan.outputs.new_critical_count != '' && needs.scan.outputs.new_critical_count != '0'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   heartbeat:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -16,7 +16,7 @@ jobs:
   assign-work:
     # Only trigger on squad:{member} labels (not the base "squad" label)
     if: startsWith(github.event.label.name, 'squad:')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   triage:
     if: github.event.label.name == 'squad'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/stub-deadline-check.yml
+++ b/.github/workflows/stub-deadline-check.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-stub-deadline:
     name: Check redirect stub deadline
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   sync-labels:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/tool-auto-update.yml
+++ b/.github/workflows/tool-auto-update.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, personal, priv, linux]
     timeout-minutes: 15
     steps:
       # App token so PRs created by Update-ToolPins.ps1 are authored by the


### PR DESCRIPTION
## wave-22: Self-hosted private pool label cascade

Migrates 25 workflows to canonical private pool labels per **ADR 2026-05-27 (LOCKED)**.

**KEDA dual-emit**: Runners accept BOTH old and new labels during cutover. Safe to merge immediately.

Repo **3 of 10** enrolled repos. Part of org-wide priv-pool cascade.

/cc @martinopedal