### PR TITLE
fix(ci): align runner labels with repo trust boundary

### DIFF
--- a/.github/workflows/alz-queries-drift-check.yml
+++ b/.github/workflows/alz-queries-drift-check.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   drift-check:
     name: Detect ALZ query drift
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   label:
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 5
     steps:
       # no-retry: single addLabels REST call. github-script ships its own Octokit

--- a/.github/workflows/ci-failure-watchdog.yml
+++ b/.github/workflows/ci-failure-watchdog.yml
@@ -51,7 +51,7 @@ permissions:
 
 jobs:
   triage-failure:
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 10
     # Concurrency:
     # Constant group key is safe because the triage step is hash-idempotent
@@ -256,7 +256,7 @@ jobs:
   # if triage-failure is skipped. Posts a sticky issue if any past-7-day
   # watchdog run had jobs_count == 0 and conclusion == failure.
   self-health-check:
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 5
     if: always()
     permissions:

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   digest:
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   # ---------------------------------------------------------------------------
   # Cross-OS dispatch:
-  #   ubuntu-latest  -> ACA Pool P1 ([self-hosted, personal-linux])
+  #   ubuntu-latest  -> ACA Pool P1 ([self-hosted, public-linux])
   #   windows-latest -> VMSS Pool W-pub ([self-hosted, personal-win])
   #   macos-latest   -> literal (no self-hosted macOS pool)
   # ---------------------------------------------------------------------------

--- a/.github/workflows/closes-link-required.yml
+++ b/.github/workflows/closes-link-required.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   closes-link:
     name: Closes/Fixes link required
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 5
     steps:
       - name: Verify PR body has Closes/Fixes link or N/A justification

--- a/.github/workflows/copilot-agent-pr-review.yml
+++ b/.github/workflows/copilot-agent-pr-review.yml
@@ -25,7 +25,7 @@ jobs:
     # Skip drafts (Copilot review is requested when PR is marked ready) and fork PRs
     # (no write token under pull_request_target, cannot request reviewers anyway).
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 5
     steps:
       # no-retry: github-script wraps Octokit which already retries 5xx + 429.

--- a/.github/workflows/issue-resolution-verify.yml
+++ b/.github/workflows/issue-resolution-verify.yml
@@ -25,7 +25,7 @@ jobs:
   verify:
     name: Verify repro for closed issues
     if: github.event.pull_request.merged == true
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 30
     steps:
       - name: Checkout merged head (post-merge SHA)

--- a/.github/workflows/pr-advisory-gate.yml
+++ b/.github/workflows/pr-advisory-gate.yml
@@ -42,7 +42,7 @@ jobs:
       github.event.pull_request != null
       && github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.draft == false
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 5
     # justified: gate is non-blocking by design (advisory only, see #109).
     # Job-level continue-on-error ensures any uncaught failure inside the

--- a/.github/workflows/pr-auto-rebase.yml
+++ b/.github/workflows/pr-auto-rebase.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   enumerate:
     name: Enumerate conflicting agent PRs
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 10
     outputs:
       prs: ${{ steps.list.outputs.prs }}
@@ -83,7 +83,7 @@ jobs:
     name: "Auto-rebase PR #${{ matrix.pr.number }}"
     needs: enumerate
     if: needs.enumerate.outputs.count != '0' && needs.enumerate.outputs.count != ''
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-auto-rerun-on-push.yml
+++ b/.github/workflows/pr-auto-rerun-on-push.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   rerun-failed-checks:
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 10
     # Branch filter: only fire on agent-pushed branches. Manual dispatch
     # bypasses the filter so a maintainer can recover any PR.

--- a/.github/workflows/pr-auto-resolve-threads.yml
+++ b/.github/workflows/pr-auto-resolve-threads.yml
@@ -37,7 +37,7 @@ jobs:
     if: >-
       github.event.pull_request != null
       && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     # The default GITHUB_TOKEN only needs read access -- write scope is
     # carried by the GitHub App installation token minted in the
     # `app-token` step (pull_requests:write granted at install time).

--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -26,7 +26,7 @@ jobs:
       (github.event_name == 'pull_request_review' &&
       (github.event.review.state == 'CHANGES_REQUESTED' ||
       (github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' && github.event.review.state != 'APPROVED')))
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
   release_please:
     name: Release Please (main)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 20
     permissions:
       contents: write
@@ -55,7 +55,7 @@ jobs:
   publish:
     name: Publish release artifacts
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 30
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -359,7 +359,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: >-
-      ${{ (matrix.os == 'ubuntu-latest'  && fromJSON('["self-hosted","personal-linux"]'))
+      ${{ (matrix.os == 'ubuntu-latest'  && fromJSON('["self-hosted","public-linux"]'))
           || (matrix.os == 'windows-latest' && fromJSON('["self-hosted","personal-win"]'))
           || matrix.os }}
     timeout-minutes: 15

--- a/.github/workflows/scheduled-scan.yml
+++ b/.github/workflows/scheduled-scan.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   scan:
     name: Run azure-analyzer
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 60
     permissions:
       id-token: write   # OIDC federated token to Azure
@@ -261,7 +261,7 @@ jobs:
     name: Report critical findings
     needs: scan
     if: always() && needs.scan.outputs.new_critical_count != '' && needs.scan.outputs.new_critical_count != '0'
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   heartbeat:
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -16,7 +16,7 @@ jobs:
   assign-work:
     # Only trigger on squad:{member} labels (not the base "squad" label)
     if: startsWith(github.event.label.name, 'squad:')
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   triage:
     if: github.event.label.name == 'squad'
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   sync-labels:
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/tool-auto-update.yml
+++ b/.github/workflows/tool-auto-update.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   bump:
-    runs-on: [self-hosted, personal-linux]
+    runs-on: [self-hosted, public-linux]
     timeout-minutes: 15
     steps:
       # App token so PRs created by Update-ToolPins.ps1 are authored by the


### PR DESCRIPTION
Align self-hosted runner labels with repo trust boundary (canonical scheme). Public repos -> public-linux pool; private repos -> personal-linux. Public scaler enrollment updated to include agentic-alz first (cascade-safe).