### PR TITLE
fix(ci): correct release PSGallery-E2E Windows runner label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   # ---------------------------------------------------------------------------
   # Cross-OS dispatch:
   #   ubuntu-latest  -> ACA Pool P1 ([self-hosted, public-linux])
-  #   windows-latest -> VMSS Pool W-pub ([self-hosted, personal-win])
+  #   windows-latest -> VMSS Pool W-pub ([self-hosted, public-win])
   #   macos-latest   -> literal (no self-hosted macOS pool)
   # ---------------------------------------------------------------------------
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,7 +360,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: >-
       ${{ (matrix.os == 'ubuntu-latest'  && fromJSON('["self-hosted","public-linux"]'))
-          || (matrix.os == 'windows-latest' && fromJSON('["self-hosted","personal-win"]'))
+          || (matrix.os == 'windows-latest' && fromJSON('["self-hosted","public-win"]'))
           || matrix.os }}
     timeout-minutes: 15
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- **ci(release):** PSGallery E2E Windows leg pointed at the private-VNet `personal-win` pool that this public repo is not enrolled in. Would fail to acquire a runner on release tags. Corrected to `public-win` matching the verified pool enrollment from #1161.
 - **BUG-1 (HIGH):** `Build-AuditorReport` was reading the wrong return key from `Get-AuditorTriageAnnotations`, nulling findings after triage and producing empty remediation/evidence/HTML sections in `-Profile Auditor` reports. Fixed in `AuditorReportBuilder.ps1:120` (#1102).
 - **RISK-1:** Auditor HTML renderer now HTML-encodes finding fields (defense-in-depth against malicious finding content).
 - **RISK-2:** `Invoke-AzureAnalyzer.psm1` wrapper now validates `-Profile` values via `[ValidateSet('Default','Auditor')]`.

--- a/docs/operations/runners.md
+++ b/docs/operations/runners.md
@@ -1,0 +1,66 @@
+# Runner Topology
+
+Self-hosted runner pools are provisioned centrally in the external `personal-runners-infra` repository (public_linux_target_repos and public_windows_github_repo_list enrollment lists) and assigned based on repository visibility.
+
+## Trust boundary
+
+Repository visibility determines which runner pool is used:
+- Public repositories use `public-*` pools (no VNet boundary)
+- Private repositories use `personal-*` pools (private VNet)
+
+azure-analyzer is a public repository enrolled in the `public-*` pools.
+
+## Pools
+
+| Pool Label      | Platform | Infrastructure             | Enrollment Source                                    |
+|-----------------|----------|----------------------------|------------------------------------------------------|
+| `public-linux`  | Linux    | ACA Pool P1                | personal-runners-infra/public_linux_target_repos     |
+| `public-win`    | Windows  | VMSS Pool W-pub            | personal-runners-infra/public_windows_github_repo_list |
+
+## Fork PR fallback
+
+All workflow jobs that dispatch on matrix OS (ubuntu-latest / windows-latest) include a fork-PR detection expression. When the PR head repository does not match the base repository (external forks), the job falls back to GitHub-hosted runners (ubuntu-latest / windows-latest literal labels) instead of self-hosted pools. This prevents untrusted fork PRs from executing on the self-hosted infrastructure.
+
+Trust signal expression:
+```yaml
+runs-on: >-
+  ${{ github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      matrix.os
+      || (matrix.os == 'ubuntu-latest' && fromJSON('["self-hosted","public-linux"]'))
+      || (matrix.os == 'windows-latest' && fromJSON('["self-hosted","public-win"]'))
+      || matrix.os }}
+```
+
+## Workflow runner mapping
+
+| Workflow Category              | Linux Runner         | Windows Runner       | macOS Runner        |
+|--------------------------------|----------------------|----------------------|---------------------|
+| CI (test matrix)               | `public-linux`       | `public-win`         | GitHub-hosted       |
+| E2E (install matrix)           | `public-linux`       | `public-win`         | GitHub-hosted       |
+| Release (PSGallery E2E matrix) | `public-linux`       | `public-win`         | N/A                 |
+| Docs check                     | `public-linux`       | N/A                  | N/A                 |
+| Analyze (CodeQL Actions)       | `public-linux`       | N/A                  | N/A                 |
+| Dependency review              | `public-linux`       | N/A                  | N/A                 |
+
+## Non-matrix jobs
+
+Jobs that do not fork-gate (direct runner assignment without the trust expression) always run on self-hosted pools for base-repo pushes and PRs. These are single-OS jobs that have no fork-PR risk surface (typically read-only analysis or webhook-triggered jobs).
+
+Examples:
+- Docs check jobs (`docs-required`, `tool-catalog-fresh`, `permissions-pages-fresh`, `readme-facts-fresh`)
+- CodeQL Analyze workflow (Actions-language scanning only)
+- Dependency review workflow
+
+All such jobs use `public-linux` because they are Linux-only jobs.
+
+## Verification
+
+Runner label consistency is validated at PR merge gate. Any stray `personal-*` label in a workflow file under `.github/workflows/` that is not accompanied by the repo-visibility trust expression is a configuration error and will cause self-hosted runner acquisition to fail on public-repo CI.
+
+Grep command to audit:
+```pwsh
+Select-String -Path .github\workflows\*.yml -Pattern 'personal-(win|linux)'
+```
+
+Expected output: zero matches. All self-hosted jobs should reference `public-linux` or `public-win`.


### PR DESCRIPTION
Fixes the release.yml PSGallery E2E matrix job Windows leg runner label. The job was pointing at the private-VNet pool `[self-hosted, personal-win]` that this public repo is not enrolled in. On a release tag, that Windows leg would fail to acquire a runner and hang until timeout.

## Changes
- release.yml: corrected Windows leg `personal-win` → `public-win` matching the verified pool enrollment from #1161 (martinopedal/personal-runners-infra public_windows_github_repo_list)
- ci.yml: fixed stale comment documenting the old personal-win label
- docs/operations/runners.md: added runner topology docs covering the trust boundary (public repo → public-* pools; private → personal-*), pool details (public-linux ACA P1, public-win VMSS W-pub), fork-PR fallback, and workflow runner mapping table
- CHANGELOG.md: added entry under Unreleased > Fixed

## Verification
Verified no `personal-*` labels remain repo-wide in .github/workflows/ after this fix. All self-hosted jobs use `public-linux` or `public-win`.

## Closes
N/A