### PR TITLE
fix: correct azqr Windows winget id in tool-manifest.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- **azqr Windows install (#1227):** The winget package id in `tools/tool-manifest.json` was `azure-quick-review.azqr`, which no longer resolves (`winget show` reports "No package found"), so the manifest-driven installer silently skipped azqr on Windows and scans returned nothing. Updated to the current published id `Microsoft.Azure.QuickReview` (moniker `azqr`, publisher Microsoft Corporation).
 - **ci(release):** PSGallery E2E Windows leg pointed at the private-VNet `personal-win` pool that this public repo is not enrolled in. Would fail to acquire a runner on release tags. Corrected to `public-win` matching the verified pool enrollment from #1161.
 - **BUG-1 (HIGH):** `Build-AuditorReport` was reading the wrong return key from `Get-AuditorTriageAnnotations`, nulling findings after triage and producing empty remediation/evidence/HTML sections in `-Profile Auditor` reports. Fixed in `AuditorReportBuilder.ps1:120` (#1102).
 - **RISK-1:** Auditor HTML renderer now HTML-encodes finding fields (defense-in-depth against malicious finding content).

--- a/tools/tool-manifest.json
+++ b/tools/tool-manifest.json
@@ -589,7 +589,7 @@
           "brew"
         ],
         "windows": {
-          "winget": "azure-quick-review.azqr"
+          "winget": "Microsoft.Azure.QuickReview"
         },
         "macos": {
           "brew": "azure/azqr/azqr"


### PR DESCRIPTION
## Closes

Closes #1227

## Summary

On Windows the manifest-driven installer could not install `azqr`: the winget package id in
`tools/tool-manifest.json` was `azure-quick-review.azqr`, which no longer resolves. As a result
azqr was treated as not installed and skipped, so azqr scans returned nothing.

Verified locally:

- `winget show --id azure-quick-review.azqr` -> `No package found matching input criteria.`
- `winget show --id Microsoft.Azure.QuickReview` -> `Microsoft Azure Quick Review 4.0.0`, moniker `azqr`, publisher Microsoft Corporation.

Fix: update the Windows winget id to `Microsoft.Azure.QuickReview`.

## Test results

- `tests/wrappers/Invoke-Azqr.Tests.ps1` + `tests/normalizers/Normalize-Azqr.Tests.ps1`: 29 passed, 0 failed.
- `Generate-ToolCatalog.ps1 -CheckOnly`, `Generate-PermissionsIndex.ps1 -CheckOnly`, `Generate-ReadmeFacts.ps1 -CheckOnly`: all in sync (the install id is not part of any generated projection).
- CHANGELOG.md updated under Unreleased -> Fixed.

## Verification checklist

- [x] Change is limited to the manifest install id + CHANGELOG.
- [x] No customer/tenant-specific content.
- [x] Docs updated (CHANGELOG entry).
- [x] Targeted tests green; manifest generators in sync.
